### PR TITLE
feat: rename github repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3156 +2,3156 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.2.29](https://github.com/webex/react-ciscospark/compare/v0.2.28...v0.2.29) (2019-07-23)
+### [0.2.29](https://github.com/webex/react-widgets/compare/v0.2.28...v0.2.29) (2019-07-23)
 
 
 
-### [0.2.28](https://github.com/webex/react-ciscospark/compare/v0.2.27...v0.2.28) (2019-07-11)
+### [0.2.28](https://github.com/webex/react-widgets/compare/v0.2.27...v0.2.28) (2019-07-11)
 
 
 ### Features
 
-* **webpack:** update csp for s3 uploads ([bc36bb1](https://github.com/webex/react-ciscospark/commit/bc36bb1))
+* **webpack:** update csp for s3 uploads ([bc36bb1](https://github.com/webex/react-widgets/commit/bc36bb1))
 
 
 
-### [0.2.27](https://github.com/webex/react-ciscospark/compare/v0.2.26...v0.2.27) (2019-07-11)
+### [0.2.27](https://github.com/webex/react-widgets/compare/v0.2.26...v0.2.27) (2019-07-11)
 
 
 ### Bug Fixes
 
-* **scripts:** fix handler logic for transpiling all components ([4cd7706](https://github.com/webex/react-ciscospark/commit/4cd7706))
+* **scripts:** fix handler logic for transpiling all components ([4cd7706](https://github.com/webex/react-widgets/commit/4cd7706))
 
 
 
-### [0.2.26](https://github.com/webex/react-ciscospark/compare/v0.2.25...v0.2.26) (2019-07-11)
+### [0.2.26](https://github.com/webex/react-widgets/compare/v0.2.25...v0.2.26) (2019-07-11)
 
 
 
-### [0.2.25](https://github.com/webex/react-ciscospark/compare/v0.2.24...v0.2.25) (2019-07-03)
+### [0.2.25](https://github.com/webex/react-widgets/compare/v0.2.24...v0.2.25) (2019-07-03)
 
 
 ### Bug Fixes
 
-* **Jenkinsfile:** add CISCOSPARK_SCOPES to Jenkinsfile ([82f1a71](https://github.com/webex/react-ciscospark/commit/82f1a71))
+* **Jenkinsfile:** add CISCOSPARK_SCOPES to Jenkinsfile ([82f1a71](https://github.com/webex/react-widgets/commit/82f1a71))
 
 
 
-### [0.2.24](https://github.com/webex/react-ciscospark/compare/v0.2.23...v0.2.24) (2019-06-18)
+### [0.2.24](https://github.com/webex/react-widgets/compare/v0.2.23...v0.2.24) (2019-06-18)
 
 
 
-### [0.2.23](https://github.com/webex/react-ciscospark/compare/v0.2.22...v0.2.23) (2019-06-17)
+### [0.2.23](https://github.com/webex/react-widgets/compare/v0.2.22...v0.2.23) (2019-06-17)
 
 
 
-### [0.2.22](https://github.com/webex/react-ciscospark/compare/v0.2.21...v0.2.22) (2019-06-14)
-
-
-### Features
-
-* **package:** Webex internal flag dependency set to fixed version ([47a287d](https://github.com/webex/react-ciscospark/commit/47a287d))
-
-
-
-### [0.2.21](https://github.com/webex/react-ciscospark/compare/v0.2.20...v0.2.21) (2019-06-07)
+### [0.2.22](https://github.com/webex/react-widgets/compare/v0.2.21...v0.2.22) (2019-06-14)
 
 
 ### Features
 
-* **Spark:** Replaced static methods with class internal methods ([b3ae58c](https://github.com/webex/react-ciscospark/commit/b3ae58c))
-* **sparkComponent:** Verify spark instance plugins had been injected properly ([590bac6](https://github.com/webex/react-ciscospark/commit/590bac6))
+* **package:** Webex internal flag dependency set to fixed version ([47a287d](https://github.com/webex/react-widgets/commit/47a287d))
 
 
 
-### [0.2.20](https://github.com/webex/react-ciscospark/compare/v0.2.19...v0.2.20) (2019-06-06)
+### [0.2.21](https://github.com/webex/react-widgets/compare/v0.2.20...v0.2.21) (2019-06-07)
+
+
+### Features
+
+* **Spark:** Replaced static methods with class internal methods ([b3ae58c](https://github.com/webex/react-widgets/commit/b3ae58c))
+* **sparkComponent:** Verify spark instance plugins had been injected properly ([590bac6](https://github.com/webex/react-widgets/commit/590bac6))
+
+
+
+### [0.2.20](https://github.com/webex/react-widgets/compare/v0.2.19...v0.2.20) (2019-06-06)
 
 
 ### Tests
 
-* **activity:** update tests due to markdown update ([bfcbd31](https://github.com/webex/react-ciscospark/commit/bfcbd31))
+* **activity:** update tests due to markdown update ([bfcbd31](https://github.com/webex/react-widgets/commit/bfcbd31))
 
 
 
 <a name="0.2.19"></a>
-## [0.2.19](https://github.com/webex/react-ciscospark/compare/v0.2.18...v0.2.19) (2019-05-31)
+## [0.2.19](https://github.com/webex/react-widgets/compare/v0.2.18...v0.2.19) (2019-05-31)
 
 
 ### Features
 
-* **widget-demo:** Added a validator to the load space count input ([fb367d3](https://github.com/webex/react-ciscospark/commit/fb367d3))
+* **widget-demo:** Added a validator to the load space count input ([fb367d3](https://github.com/webex/react-widgets/commit/fb367d3))
 
 
 
 <a name="0.2.18"></a>
-## [0.2.18](https://github.com/webex/react-ciscospark/compare/v0.2.17...v0.2.18) (2019-05-30)
+## [0.2.18](https://github.com/webex/react-widgets/compare/v0.2.17...v0.2.18) (2019-05-30)
 
 
 ### Features
 
-* **Jenkinsfile:** Implemented es-check into the pipeline ([e5afa7d](https://github.com/webex/react-ciscospark/commit/e5afa7d))
-* **package:** Added es-check dependency ([66c5e42](https://github.com/webex/react-ciscospark/commit/66c5e42))
-* **SCRIPTS:** Updated the SCRIPTS file with es-check scripts accordingly ([1e25b8f](https://github.com/webex/react-ciscospark/commit/1e25b8f))
+* **Jenkinsfile:** Implemented es-check into the pipeline ([e5afa7d](https://github.com/webex/react-widgets/commit/e5afa7d))
+* **package:** Added es-check dependency ([66c5e42](https://github.com/webex/react-widgets/commit/66c5e42))
+* **SCRIPTS:** Updated the SCRIPTS file with es-check scripts accordingly ([1e25b8f](https://github.com/webex/react-widgets/commit/1e25b8f))
 
 
 
 <a name="0.2.17"></a>
-## [0.2.17](https://github.com/webex/react-ciscospark/compare/v0.2.16...v0.2.17) (2019-05-30)
+## [0.2.17](https://github.com/webex/react-widgets/compare/v0.2.16...v0.2.17) (2019-05-30)
 
 
 
 <a name="0.2.16"></a>
-## [0.2.16](https://github.com/webex/react-ciscospark/compare/v0.2.15...v0.2.16) (2019-05-30)
+## [0.2.16](https://github.com/webex/react-widgets/compare/v0.2.15...v0.2.16) (2019-05-30)
 
 
 
 <a name="0.2.15"></a>
-## [0.2.15](https://github.com/webex/react-ciscospark/compare/v0.2.14...v0.2.15) (2019-05-23)
+## [0.2.15](https://github.com/webex/react-widgets/compare/v0.2.14...v0.2.15) (2019-05-23)
 
 
 
 <a name="0.2.14"></a>
-## [0.2.14](https://github.com/webex/react-ciscospark/compare/v0.2.13...v0.2.14) (2019-05-23)
+## [0.2.14](https://github.com/webex/react-widgets/compare/v0.2.13...v0.2.14) (2019-05-23)
 
 
 
 <a name="0.2.13"></a>
-## [0.2.13](https://github.com/webex/react-ciscospark/compare/v0.2.12...v0.2.13) (2019-05-22)
+## [0.2.13](https://github.com/webex/react-widgets/compare/v0.2.12...v0.2.13) (2019-05-22)
 
 
 ### Bug Fixes
 
-* **widget-demo:** spaceLoadCount empty value is now converted to default value ([4e8edff](https://github.com/webex/react-ciscospark/commit/4e8edff))
+* **widget-demo:** spaceLoadCount empty value is now converted to default value ([4e8edff](https://github.com/webex/react-widgets/commit/4e8edff))
 
 
 ### Features
 
-* **widget-recent:** Setting spaceLoadcount to total number of the rooms ([1184335](https://github.com/webex/react-ciscospark/commit/1184335))
+* **widget-recent:** Setting spaceLoadcount to total number of the rooms ([1184335](https://github.com/webex/react-widgets/commit/1184335))
 
 
 
 <a name="0.2.12"></a>
-## [0.2.12](https://github.com/webex/react-ciscospark/compare/v0.2.11...v0.2.12) (2019-05-22)
+## [0.2.12](https://github.com/webex/react-widgets/compare/v0.2.11...v0.2.12) (2019-05-22)
 
 
 
 <a name="0.2.11"></a>
-## [0.2.11](https://github.com/webex/react-ciscospark/compare/v0.2.10...v0.2.11) (2019-05-21)
+## [0.2.11](https://github.com/webex/react-widgets/compare/v0.2.10...v0.2.11) (2019-05-21)
 
 
 ### Features
 
-* **widget-meet:** update start call aria label ([d0041f6](https://github.com/webex/react-ciscospark/commit/d0041f6))
+* **widget-meet:** update start call aria label ([d0041f6](https://github.com/webex/react-widgets/commit/d0041f6))
 
 
 
 <a name="0.2.10"></a>
-## [0.2.10](https://github.com/webex/react-ciscospark/compare/v0.2.9...v0.2.10) (2019-05-21)
+## [0.2.10](https://github.com/webex/react-widgets/compare/v0.2.9...v0.2.10) (2019-05-21)
 
 
 ### Features
 
-* **r-c-activity-item-base:** upgrade to momentum-ui ([fd8490b](https://github.com/webex/react-ciscospark/commit/fd8490b))
-* **r-c-activity-list:** upgrade to momentum-ui ([28eb673](https://github.com/webex/react-ciscospark/commit/28eb673))
-* **r-c-activity-menu:** upgrade to momentum-ui ([8b191b3](https://github.com/webex/react-ciscospark/commit/8b191b3))
-* **r-c-activity-menu-header:** upgrade to momentum-ui ([e409abe](https://github.com/webex/react-ciscospark/commit/e409abe))
-* **r-c-activity-share-file:** upgrade to momentum-ui ([0926a1c](https://github.com/webex/react-ciscospark/commit/0926a1c))
-* **r-c-activity-share-thumbnail:** upgrade to momentum-ui ([d9f453b](https://github.com/webex/react-ciscospark/commit/d9f453b))
-* **r-c-button:** upgrade to momentum-ui ([2a95294](https://github.com/webex/react-ciscospark/commit/2a95294))
-* **r-c-button-controls:** upgrade to momentum-ui ([2fb6671](https://github.com/webex/react-ciscospark/commit/2fb6671))
-* **r-c-chip-base:** upgrade to momentum-ui ([0c28c30](https://github.com/webex/react-ciscospark/commit/0c28c30))
-* **r-c-chip-file:** upgrade to momentum-ui ([baee61e](https://github.com/webex/react-ciscospark/commit/baee61e))
-* **r-c-loading-screen:** upgrade to momentum-ui ([2ff74d8](https://github.com/webex/react-ciscospark/commit/2ff74d8))
-* **r-c-message-composer:** upgrade to momentum-ui ([a6ef2ee](https://github.com/webex/react-ciscospark/commit/a6ef2ee))
-* **r-c-people-list:** upgrade to momentum-ui ([d4b6493](https://github.com/webex/react-ciscospark/commit/d4b6493))
-* **r-c-presence-avatar:** upgrade to momentum-ui ([a3a5113](https://github.com/webex/react-ciscospark/commit/a3a5113))
-* **r-c-scrolling-activity:** upgrade to momentum-ui ([5e671df](https://github.com/webex/react-ciscospark/commit/5e671df))
-* **r-c-space-item:** upgrade to momentum-ui ([b001cc8](https://github.com/webex/react-ciscospark/commit/b001cc8))
-* **r-c-space-item:** upgrade to momentum-ui ([11dbabc](https://github.com/webex/react-ciscospark/commit/11dbabc))
-* **r-c-spaces-list:** upgrade to momentum-ui ([bd148f8](https://github.com/webex/react-ciscospark/commit/bd148f8))
-* **r-c-spark-fonts:** upgrade to momentum-ui ([d3a5e1f](https://github.com/webex/react-ciscospark/commit/d3a5e1f))
-* **samples:** added momentum style changes ([7e9afbc](https://github.com/webex/react-ciscospark/commit/7e9afbc))
-* **widget-demo:** upgrade to momentum-ui ([d7f059a](https://github.com/webex/react-ciscospark/commit/d7f059a))
-* **widget-demo:** use babel-polyfill directly ([f751750](https://github.com/webex/react-ciscospark/commit/f751750))
-* **widget-meet:** upgrade to momentum-ui ([2f6d451](https://github.com/webex/react-ciscospark/commit/2f6d451))
-* **widget-message:** upgrade to momentum-ui ([34e390e](https://github.com/webex/react-ciscospark/commit/34e390e))
-* **widget-recents:** upgrade to momentum-ui ([9419110](https://github.com/webex/react-ciscospark/commit/9419110))
-* **widget-recents-demo:** upgrade to momentum-ui ([064b19d](https://github.com/webex/react-ciscospark/commit/064b19d))
-* **widget-roster:** upgrade to momentum-ui ([c204521](https://github.com/webex/react-ciscospark/commit/c204521))
-* **widget-space:** upgrade to momentum-ui ([ba89fba](https://github.com/webex/react-ciscospark/commit/ba89fba))
-* **widget-space-demo:** upgrade to momentum-ui ([baa2cac](https://github.com/webex/react-ciscospark/commit/baa2cac))
+* **r-c-activity-item-base:** upgrade to momentum-ui ([fd8490b](https://github.com/webex/react-widgets/commit/fd8490b))
+* **r-c-activity-list:** upgrade to momentum-ui ([28eb673](https://github.com/webex/react-widgets/commit/28eb673))
+* **r-c-activity-menu:** upgrade to momentum-ui ([8b191b3](https://github.com/webex/react-widgets/commit/8b191b3))
+* **r-c-activity-menu-header:** upgrade to momentum-ui ([e409abe](https://github.com/webex/react-widgets/commit/e409abe))
+* **r-c-activity-share-file:** upgrade to momentum-ui ([0926a1c](https://github.com/webex/react-widgets/commit/0926a1c))
+* **r-c-activity-share-thumbnail:** upgrade to momentum-ui ([d9f453b](https://github.com/webex/react-widgets/commit/d9f453b))
+* **r-c-button:** upgrade to momentum-ui ([2a95294](https://github.com/webex/react-widgets/commit/2a95294))
+* **r-c-button-controls:** upgrade to momentum-ui ([2fb6671](https://github.com/webex/react-widgets/commit/2fb6671))
+* **r-c-chip-base:** upgrade to momentum-ui ([0c28c30](https://github.com/webex/react-widgets/commit/0c28c30))
+* **r-c-chip-file:** upgrade to momentum-ui ([baee61e](https://github.com/webex/react-widgets/commit/baee61e))
+* **r-c-loading-screen:** upgrade to momentum-ui ([2ff74d8](https://github.com/webex/react-widgets/commit/2ff74d8))
+* **r-c-message-composer:** upgrade to momentum-ui ([a6ef2ee](https://github.com/webex/react-widgets/commit/a6ef2ee))
+* **r-c-people-list:** upgrade to momentum-ui ([d4b6493](https://github.com/webex/react-widgets/commit/d4b6493))
+* **r-c-presence-avatar:** upgrade to momentum-ui ([a3a5113](https://github.com/webex/react-widgets/commit/a3a5113))
+* **r-c-scrolling-activity:** upgrade to momentum-ui ([5e671df](https://github.com/webex/react-widgets/commit/5e671df))
+* **r-c-space-item:** upgrade to momentum-ui ([b001cc8](https://github.com/webex/react-widgets/commit/b001cc8))
+* **r-c-space-item:** upgrade to momentum-ui ([11dbabc](https://github.com/webex/react-widgets/commit/11dbabc))
+* **r-c-spaces-list:** upgrade to momentum-ui ([bd148f8](https://github.com/webex/react-widgets/commit/bd148f8))
+* **r-c-spark-fonts:** upgrade to momentum-ui ([d3a5e1f](https://github.com/webex/react-widgets/commit/d3a5e1f))
+* **samples:** added momentum style changes ([7e9afbc](https://github.com/webex/react-widgets/commit/7e9afbc))
+* **widget-demo:** upgrade to momentum-ui ([d7f059a](https://github.com/webex/react-widgets/commit/d7f059a))
+* **widget-demo:** use babel-polyfill directly ([f751750](https://github.com/webex/react-widgets/commit/f751750))
+* **widget-meet:** upgrade to momentum-ui ([2f6d451](https://github.com/webex/react-widgets/commit/2f6d451))
+* **widget-message:** upgrade to momentum-ui ([34e390e](https://github.com/webex/react-widgets/commit/34e390e))
+* **widget-recents:** upgrade to momentum-ui ([9419110](https://github.com/webex/react-widgets/commit/9419110))
+* **widget-recents-demo:** upgrade to momentum-ui ([064b19d](https://github.com/webex/react-widgets/commit/064b19d))
+* **widget-roster:** upgrade to momentum-ui ([c204521](https://github.com/webex/react-widgets/commit/c204521))
+* **widget-space:** upgrade to momentum-ui ([ba89fba](https://github.com/webex/react-widgets/commit/ba89fba))
+* **widget-space-demo:** upgrade to momentum-ui ([baa2cac](https://github.com/webex/react-widgets/commit/baa2cac))
 
 
 
 <a name="0.2.9"></a>
-## [0.2.9](https://github.com/webex/react-ciscospark/compare/v0.2.8...v0.2.9) (2019-05-20)
+## [0.2.9](https://github.com/webex/react-widgets/compare/v0.2.8...v0.2.9) (2019-05-20)
 
 
 
 <a name="0.2.8"></a>
-## [0.2.8](https://github.com/webex/react-ciscospark/compare/v0.2.7...v0.2.8) (2019-05-16)
+## [0.2.8](https://github.com/webex/react-widgets/compare/v0.2.7...v0.2.8) (2019-05-16)
 
 
 ### Features
 
-* **widget-recents:** remove extendedLoad ([6593ed5](https://github.com/webex/react-ciscospark/commit/6593ed5))
+* **widget-recents:** remove extendedLoad ([6593ed5](https://github.com/webex/react-widgets/commit/6593ed5))
 
 
 
 <a name="0.2.7"></a>
-## [0.2.7](https://github.com/webex/react-ciscospark/compare/v0.2.6...v0.2.7) (2019-05-08)
+## [0.2.7](https://github.com/webex/react-widgets/compare/v0.2.6...v0.2.7) (2019-05-08)
 
 
 ### Features
 
-* **r-m-spaces:** add error when service fails ([22afc46](https://github.com/webex/react-ciscospark/commit/22afc46))
+* **r-m-spaces:** add error when service fails ([22afc46](https://github.com/webex/react-widgets/commit/22afc46))
 
 
 
 <a name="0.2.6"></a>
-## [0.2.6](https://github.com/webex/react-ciscospark/compare/v0.2.5...v0.2.6) (2019-05-07)
+## [0.2.6](https://github.com/webex/react-widgets/compare/v0.2.5...v0.2.6) (2019-05-07)
 
 
 ### Bug Fixes
 
-* **widget-recents:** load space avatars properly ([b12db01](https://github.com/webex/react-ciscospark/commit/b12db01))
+* **widget-recents:** load space avatars properly ([b12db01](https://github.com/webex/react-widgets/commit/b12db01))
 
 
 
 <a name="0.2.5"></a>
-## [0.2.5](https://github.com/webex/react-ciscospark/compare/v0.2.4...v0.2.5) (2019-05-03)
+## [0.2.5](https://github.com/webex/react-widgets/compare/v0.2.4...v0.2.5) (2019-05-03)
 
 
 ### Bug Fixes
 
-* **widget-recents:** proper hasFetchedAllSpaces calcs ([7e5706a](https://github.com/webex/react-ciscospark/commit/7e5706a))
+* **widget-recents:** proper hasFetchedAllSpaces calcs ([7e5706a](https://github.com/webex/react-widgets/commit/7e5706a))
 
 
 
 <a name="0.2.4"></a>
-## [0.2.4](https://github.com/webex/react-ciscospark/compare/v0.2.3...v0.2.4) (2019-04-25)
+## [0.2.4](https://github.com/webex/react-widgets/compare/v0.2.3...v0.2.4) (2019-04-25)
 
 
 
 <a name="0.2.3"></a>
-## [0.2.3](https://github.com/webex/react-ciscospark/compare/v0.2.2...v0.2.3) (2019-04-24)
+## [0.2.3](https://github.com/webex/react-widgets/compare/v0.2.2...v0.2.3) (2019-04-24)
 
 
 ### Features
 
-* **widget-recents:** update scroll status as needed ([f80a17b](https://github.com/webex/react-ciscospark/commit/f80a17b))
+* **widget-recents:** update scroll status as needed ([f80a17b](https://github.com/webex/react-widgets/commit/f80a17b))
 
 
 
 <a name="0.2.2"></a>
-## [0.2.2](https://github.com/webex/react-ciscospark/compare/v0.2.1...v0.2.2) (2019-04-24)
+## [0.2.2](https://github.com/webex/react-widgets/compare/v0.2.1...v0.2.2) (2019-04-24)
 
 
 ### Features
 
-* **r-m-spaces:** add fetchSpacesHydra action ([2b237a9](https://github.com/webex/react-ciscospark/commit/2b237a9))
-* **widget-demo:** add recents basicMode prop ([2828af8](https://github.com/webex/react-ciscospark/commit/2828af8))
-* **widget-recents:** add basicMode property ([1171611](https://github.com/webex/react-ciscospark/commit/1171611))
-* **widget-recents:** show spaces as read in basicMode ([f5b7e82](https://github.com/webex/react-ciscospark/commit/f5b7e82))
+* **r-m-spaces:** add fetchSpacesHydra action ([2b237a9](https://github.com/webex/react-widgets/commit/2b237a9))
+* **widget-demo:** add recents basicMode prop ([2828af8](https://github.com/webex/react-widgets/commit/2828af8))
+* **widget-recents:** add basicMode property ([1171611](https://github.com/webex/react-widgets/commit/1171611))
+* **widget-recents:** show spaces as read in basicMode ([f5b7e82](https://github.com/webex/react-widgets/commit/f5b7e82))
 
 
 
 <a name="0.2.1"></a>
-## [0.2.1](https://github.com/webex/react-ciscospark/compare/v0.1.448...v0.2.1) (2019-04-23)
+## [0.2.1](https://github.com/webex/react-widgets/compare/v0.1.448...v0.2.1) (2019-04-23)
 
 
 
 <a name="0.1.448"></a>
-## [0.1.448](https://github.com/webex/react-ciscospark/compare/v0.1.447...v0.1.448) (2019-04-09)
+## [0.1.448](https://github.com/webex/react-widgets/compare/v0.1.447...v0.1.448) (2019-04-09)
 
 
 ### Bug Fixes
 
-* **journeys:** fix firefox messaging journey test ([8c977e7](https://github.com/webex/react-ciscospark/commit/8c977e7))
+* **journeys:** fix firefox messaging journey test ([8c977e7](https://github.com/webex/react-widgets/commit/8c977e7))
 
 
 
 <a name="0.1.447"></a>
-## [0.1.447](https://github.com/webex/react-ciscospark/compare/v0.1.446...v0.1.447) (2019-04-09)
+## [0.1.447](https://github.com/webex/react-widgets/compare/v0.1.446...v0.1.447) (2019-04-09)
 
 
 ### Features
 
-* **loading-screen:** use Img component to display images ([2bc4fcf](https://github.com/webex/react-ciscospark/commit/2bc4fcf))
+* **loading-screen:** use Img component to display images ([2bc4fcf](https://github.com/webex/react-widgets/commit/2bc4fcf))
 
 
 
 <a name="0.1.446"></a>
-## [0.1.446](https://github.com/webex/react-ciscospark/compare/v0.1.445...v0.1.446) (2019-04-09)
+## [0.1.446](https://github.com/webex/react-widgets/compare/v0.1.445...v0.1.446) (2019-04-09)
 
 
 ### Features
 
-* **widget-meet:** remove old spark logo ([c94f865](https://github.com/webex/react-ciscospark/commit/c94f865))
+* **widget-meet:** remove old spark logo ([c94f865](https://github.com/webex/react-widgets/commit/c94f865))
 
 
 
 <a name="0.1.445"></a>
-## [0.1.445](https://github.com/webex/react-ciscospark/compare/v0.1.444...v0.1.445) (2019-04-08)
+## [0.1.445](https://github.com/webex/react-widgets/compare/v0.1.444...v0.1.445) (2019-04-08)
 
 
 
 <a name="0.1.444"></a>
-## [0.1.444](https://github.com/webex/react-ciscospark/compare/v0.1.443...v0.1.444) (2019-04-05)
+## [0.1.444](https://github.com/webex/react-widgets/compare/v0.1.443...v0.1.444) (2019-04-05)
 
 
 ### Features
 
-* **package:** update to [@ciscospark](https://github.com/ciscospark) sdk 1.50.18 ([6201642](https://github.com/webex/react-ciscospark/commit/6201642))
+* **package:** update to [@ciscospark](https://github.com/ciscospark) sdk 1.50.18 ([6201642](https://github.com/webex/react-widgets/commit/6201642))
 
 
 
 <a name="0.1.443"></a>
-## [0.1.443](https://github.com/webex/react-ciscospark/compare/v0.1.442...v0.1.443) (2019-04-01)
+## [0.1.443](https://github.com/webex/react-widgets/compare/v0.1.442...v0.1.443) (2019-04-01)
 
 
 ### Features
 
-* **react-redux-spark:** enable federation by default ([a10e8bf](https://github.com/webex/react-ciscospark/commit/a10e8bf))
+* **react-redux-spark:** enable federation by default ([a10e8bf](https://github.com/webex/react-widgets/commit/a10e8bf))
 
 
 
 <a name="0.1.442"></a>
-## [0.1.442](https://github.com/webex/react-ciscospark/compare/v0.1.441...v0.1.442) (2019-03-26)
+## [0.1.442](https://github.com/webex/react-widgets/compare/v0.1.441...v0.1.442) (2019-03-26)
 
 
 
 <a name="0.1.441"></a>
-## [0.1.441](https://github.com/webex/react-ciscospark/compare/v0.1.440...v0.1.441) (2019-03-26)
+## [0.1.441](https://github.com/webex/react-widgets/compare/v0.1.440...v0.1.441) (2019-03-26)
 
 
 ### Bug Fixes
 
-* **widget-recents:** recents widget does not load for user with no spaces ([06ccc66](https://github.com/webex/react-ciscospark/commit/06ccc66))
+* **widget-recents:** recents widget does not load for user with no spaces ([06ccc66](https://github.com/webex/react-widgets/commit/06ccc66))
 
 
 
 <a name="0.1.440"></a>
-## [0.1.440](https://github.com/webex/react-ciscospark/compare/v0.1.439...v0.1.440) (2019-03-26)
+## [0.1.440](https://github.com/webex/react-widgets/compare/v0.1.439...v0.1.440) (2019-03-26)
 
 
 
 <a name="0.1.439"></a>
-## [0.1.439](https://github.com/webex/react-ciscospark/compare/v0.1.438...v0.1.439) (2019-03-25)
+## [0.1.439](https://github.com/webex/react-widgets/compare/v0.1.438...v0.1.439) (2019-03-25)
 
 
 ### Features
 
-* **widget-base:** Aligned our scrollbar styling with web client ([cd29a3e](https://github.com/webex/react-ciscospark/commit/cd29a3e))
-* **widget-recents:** Semi-customized the scrollbar on IE11 to match with web client ([9d72602](https://github.com/webex/react-ciscospark/commit/9d72602))
-* **widget-space:** Semi-customized the scrollbar on IE11 to match with web client ([62c3bfc](https://github.com/webex/react-ciscospark/commit/62c3bfc))
+* **widget-base:** Aligned our scrollbar styling with web client ([cd29a3e](https://github.com/webex/react-widgets/commit/cd29a3e))
+* **widget-recents:** Semi-customized the scrollbar on IE11 to match with web client ([9d72602](https://github.com/webex/react-widgets/commit/9d72602))
+* **widget-space:** Semi-customized the scrollbar on IE11 to match with web client ([62c3bfc](https://github.com/webex/react-widgets/commit/62c3bfc))
 
 
 
 <a name="0.1.438"></a>
-## [0.1.438](https://github.com/webex/react-ciscospark/compare/v0.1.437...v0.1.438) (2019-03-25)
+## [0.1.438](https://github.com/webex/react-widgets/compare/v0.1.437...v0.1.438) (2019-03-25)
 
 
 
 <a name="0.1.437"></a>
-## [0.1.437](https://github.com/webex/react-ciscospark/compare/v0.1.436...v0.1.437) (2019-03-21)
+## [0.1.437](https://github.com/webex/react-widgets/compare/v0.1.436...v0.1.437) (2019-03-21)
 
 
 
 <a name="0.1.436"></a>
-## [0.1.436](https://github.com/webex/react-ciscospark/compare/v0.1.435...v0.1.436) (2019-03-20)
+## [0.1.436](https://github.com/webex/react-widgets/compare/v0.1.435...v0.1.436) (2019-03-20)
 
 
 ### Features
 
-* **react-redux-spark:** make federation configurable ([e56d557](https://github.com/webex/react-ciscospark/commit/e56d557))
-* **spark:** add federation support ([efc8996](https://github.com/webex/react-ciscospark/commit/efc8996))
+* **react-redux-spark:** make federation configurable ([e56d557](https://github.com/webex/react-widgets/commit/e56d557))
+* **spark:** add federation support ([efc8996](https://github.com/webex/react-widgets/commit/efc8996))
 
 
 
 <a name="0.1.435"></a>
-## [0.1.435](https://github.com/webex/react-ciscospark/compare/v0.1.434...v0.1.435) (2019-03-19)
+## [0.1.435](https://github.com/webex/react-widgets/compare/v0.1.434...v0.1.435) (2019-03-19)
 
 
 
 <a name="0.1.434"></a>
-## [0.1.434](https://github.com/webex/react-ciscospark/compare/v0.1.433...v0.1.434) (2019-03-15)
+## [0.1.434](https://github.com/webex/react-widgets/compare/v0.1.433...v0.1.434) (2019-03-15)
 
 
 
 <a name="0.1.433"></a>
-## [0.1.433](https://github.com/webex/react-ciscospark/compare/v0.1.432...v0.1.433) (2019-03-13)
+## [0.1.433](https://github.com/webex/react-widgets/compare/v0.1.432...v0.1.433) (2019-03-13)
 
 
 ### Bug Fixes
 
-* **webdriver:** fix firefox automation problems ([fc26110](https://github.com/webex/react-ciscospark/commit/fc26110))
+* **webdriver:** fix firefox automation problems ([fc26110](https://github.com/webex/react-widgets/commit/fc26110))
 
 
 
 <a name="0.1.432"></a>
-## [0.1.432](https://github.com/webex/react-ciscospark/compare/v0.1.431...v0.1.432) (2019-03-13)
+## [0.1.432](https://github.com/webex/react-widgets/compare/v0.1.431...v0.1.432) (2019-03-13)
 
 
 ### Features
 
-* **presence-avatar:** replaced "default" with empty string type from avatar props ([131b5dd](https://github.com/webex/react-ciscospark/commit/131b5dd))
-* **widget-demo:** Added an additional checkbox to enable the user signout menu ([41b0aa0](https://github.com/webex/react-ciscospark/commit/41b0aa0))
-* **widget-recents:** Added  User profile sign out menu ([9ec73e3](https://github.com/webex/react-ciscospark/commit/9ec73e3))
+* **presence-avatar:** replaced "default" with empty string type from avatar props ([131b5dd](https://github.com/webex/react-widgets/commit/131b5dd))
+* **widget-demo:** Added an additional checkbox to enable the user signout menu ([41b0aa0](https://github.com/webex/react-widgets/commit/41b0aa0))
+* **widget-recents:** Added  User profile sign out menu ([9ec73e3](https://github.com/webex/react-widgets/commit/9ec73e3))
 
 
 
 <a name="0.1.431"></a>
-## [0.1.431](https://github.com/webex/react-ciscospark/compare/v0.1.430...v0.1.431) (2019-03-11)
+## [0.1.431](https://github.com/webex/react-widgets/compare/v0.1.430...v0.1.431) (2019-03-11)
 
 
 
 <a name="0.1.430"></a>
-## [0.1.430](https://github.com/webex/react-ciscospark/compare/v0.1.429...v0.1.430) (2019-03-08)
+## [0.1.430](https://github.com/webex/react-widgets/compare/v0.1.429...v0.1.430) (2019-03-08)
 
 
 ### Features
 
-* **hoc-conversation-mercury:** ignore reply activities ([f0c0328](https://github.com/webex/react-ciscospark/commit/f0c0328))
-* **r-m-conversation:** filter out reply activities ([e7cec51](https://github.com/webex/react-ciscospark/commit/e7cec51))
-* **utils:** add activity type constants ([feae011](https://github.com/webex/react-ciscospark/commit/feae011))
-* **widget-message:** ignore reply activities ([d01d339](https://github.com/webex/react-ciscospark/commit/d01d339))
-* **widget-recents:** ignore reply activities ([660d763](https://github.com/webex/react-ciscospark/commit/660d763))
+* **hoc-conversation-mercury:** ignore reply activities ([f0c0328](https://github.com/webex/react-widgets/commit/f0c0328))
+* **r-m-conversation:** filter out reply activities ([e7cec51](https://github.com/webex/react-widgets/commit/e7cec51))
+* **utils:** add activity type constants ([feae011](https://github.com/webex/react-widgets/commit/feae011))
+* **widget-message:** ignore reply activities ([d01d339](https://github.com/webex/react-widgets/commit/d01d339))
+* **widget-recents:** ignore reply activities ([660d763](https://github.com/webex/react-widgets/commit/660d763))
 
 
 
 <a name="0.1.429"></a>
-## [0.1.429](https://github.com/webex/react-ciscospark/compare/v0.1.428...v0.1.429) (2019-03-06)
+## [0.1.429](https://github.com/webex/react-widgets/compare/v0.1.428...v0.1.429) (2019-03-06)
 
 
 
 <a name="0.1.428"></a>
-## [0.1.428](https://github.com/webex/react-ciscospark/compare/v0.1.427...v0.1.428) (2019-02-28)
+## [0.1.428](https://github.com/webex/react-widgets/compare/v0.1.427...v0.1.428) (2019-02-28)
 
 
 ### Bug Fixes
 
-* **r-m-users:** check correct avatar property ([6f7e128](https://github.com/webex/react-ciscospark/commit/6f7e128))
+* **r-m-users:** check correct avatar property ([6f7e128](https://github.com/webex/react-widgets/commit/6f7e128))
 
 
 ### Features
 
-* **r-component-presence-avatar:** add onclick ([4fa7c3d](https://github.com/webex/react-ciscospark/commit/4fa7c3d))
-* **r-component-presence-avatar:** add onclick ([fee6f87](https://github.com/webex/react-ciscospark/commit/fee6f87))
-* **r-m-users:** subscribe to current user presence ([69cb037](https://github.com/webex/react-ciscospark/commit/69cb037))
-* **spaces-list:** add prop for onScoll event ([2441a01](https://github.com/webex/react-ciscospark/commit/2441a01))
-* **widget-demo:** add recents header options ([1585197](https://github.com/webex/react-ciscospark/commit/1585197))
-* **widget-recents:** add user profile and add button to header ([504365e](https://github.com/webex/react-ciscospark/commit/504365e))
-* **widget-recents:** hide bottom border based on scroll position ([dae8db2](https://github.com/webex/react-ciscospark/commit/dae8db2))
+* **r-component-presence-avatar:** add onclick ([4fa7c3d](https://github.com/webex/react-widgets/commit/4fa7c3d))
+* **r-component-presence-avatar:** add onclick ([fee6f87](https://github.com/webex/react-widgets/commit/fee6f87))
+* **r-m-users:** subscribe to current user presence ([69cb037](https://github.com/webex/react-widgets/commit/69cb037))
+* **spaces-list:** add prop for onScoll event ([2441a01](https://github.com/webex/react-widgets/commit/2441a01))
+* **widget-demo:** add recents header options ([1585197](https://github.com/webex/react-widgets/commit/1585197))
+* **widget-recents:** add user profile and add button to header ([504365e](https://github.com/webex/react-widgets/commit/504365e))
+* **widget-recents:** hide bottom border based on scroll position ([dae8db2](https://github.com/webex/react-widgets/commit/dae8db2))
 
 
 
 <a name="0.1.427"></a>
-## [0.1.427](https://github.com/webex/react-ciscospark/compare/v0.1.426...v0.1.427) (2019-02-22)
+## [0.1.427](https://github.com/webex/react-widgets/compare/v0.1.426...v0.1.427) (2019-02-22)
 
 
 ### Bug Fixes
 
-* **r-m-users:** add support for users with no nicknames ([89c88e4](https://github.com/webex/react-ciscospark/commit/89c88e4))
+* **r-m-users:** add support for users with no nicknames ([89c88e4](https://github.com/webex/react-widgets/commit/89c88e4))
 
 
 
 <a name="0.1.426"></a>
-## [0.1.426](https://github.com/webex/react-ciscospark/compare/v0.1.425...v0.1.426) (2019-02-22)
+## [0.1.426](https://github.com/webex/react-widgets/compare/v0.1.425...v0.1.426) (2019-02-22)
 
 
 ### Bug Fixes
 
-* **widget-message:** use proper toUser object in activity event ([a8f3393](https://github.com/webex/react-ciscospark/commit/a8f3393))
+* **widget-message:** use proper toUser object in activity event ([a8f3393](https://github.com/webex/react-widgets/commit/a8f3393))
 
 
 ### Features
 
-* **r-m-spaces:** add fetchSpacesEncrypted action ([dad2bcf](https://github.com/webex/react-ciscospark/commit/dad2bcf))
-* **widget-recents:** add get avatar and user for new space to listeners ([b775d6a](https://github.com/webex/react-ciscospark/commit/b775d6a))
-* **widget-recents:** add helpers ([52fa1af](https://github.com/webex/react-ciscospark/commit/52fa1af))
-* **widget-recents:** add support for empty 1:1 in selector ([6c48c4d](https://github.com/webex/react-ciscospark/commit/6c48c4d))
-* **widget-recents:** use fetchSpacesEncrypted in setup ([7b49601](https://github.com/webex/react-ciscospark/commit/7b49601))
+* **r-m-spaces:** add fetchSpacesEncrypted action ([dad2bcf](https://github.com/webex/react-widgets/commit/dad2bcf))
+* **widget-recents:** add get avatar and user for new space to listeners ([b775d6a](https://github.com/webex/react-widgets/commit/b775d6a))
+* **widget-recents:** add helpers ([52fa1af](https://github.com/webex/react-widgets/commit/52fa1af))
+* **widget-recents:** add support for empty 1:1 in selector ([6c48c4d](https://github.com/webex/react-widgets/commit/6c48c4d))
+* **widget-recents:** use fetchSpacesEncrypted in setup ([7b49601](https://github.com/webex/react-widgets/commit/7b49601))
 
 
 
 <a name="0.1.425"></a>
-## [0.1.425](https://github.com/webex/react-ciscospark/compare/v0.1.424...v0.1.425) (2019-02-21)
+## [0.1.425](https://github.com/webex/react-widgets/compare/v0.1.424...v0.1.425) (2019-02-21)
 
 
 
 <a name="0.1.424"></a>
-## [0.1.424](https://github.com/webex/react-ciscospark/compare/v0.1.423...v0.1.424) (2019-02-20)
+## [0.1.424](https://github.com/webex/react-widgets/compare/v0.1.423...v0.1.424) (2019-02-20)
 
 
 
 <a name="0.1.423"></a>
-## [0.1.423](https://github.com/webex/react-ciscospark/compare/v0.1.422...v0.1.423) (2019-02-20)
+## [0.1.423](https://github.com/webex/react-widgets/compare/v0.1.422...v0.1.423) (2019-02-20)
 
 
 
 <a name="0.1.422"></a>
-## [0.1.422](https://github.com/webex/react-ciscospark/compare/v0.1.421...v0.1.422) (2019-02-19)
+## [0.1.422](https://github.com/webex/react-widgets/compare/v0.1.421...v0.1.422) (2019-02-19)
 
 
 ### Bug Fixes
 
-* **space:** ECM files are displayed as links now ([cc65e8d](https://github.com/webex/react-ciscospark/commit/cc65e8d))
+* **space:** ECM files are displayed as links now ([cc65e8d](https://github.com/webex/react-widgets/commit/cc65e8d))
 
 
 ### Features
 
-* **space:** Upgraded Cisco Spark SDK to 1.47.3 ([14e304f](https://github.com/webex/react-ciscospark/commit/14e304f))
+* **space:** Upgraded Cisco Spark SDK to 1.47.3 ([14e304f](https://github.com/webex/react-widgets/commit/14e304f))
 
 
 
 <a name="0.1.421"></a>
-## [0.1.421](https://github.com/webex/react-ciscospark/compare/v0.1.420...v0.1.421) (2019-02-19)
+## [0.1.421](https://github.com/webex/react-widgets/compare/v0.1.420...v0.1.421) (2019-02-19)
 
 
 ### Features
 
-* **widget-demo:** remove spaceTypeFilter option ([864afbc](https://github.com/webex/react-ciscospark/commit/864afbc))
-* **widget-recents:** remove spaceTypeFilter ([1bd514a](https://github.com/webex/react-ciscospark/commit/1bd514a))
+* **widget-demo:** remove spaceTypeFilter option ([864afbc](https://github.com/webex/react-widgets/commit/864afbc))
+* **widget-recents:** remove spaceTypeFilter ([1bd514a](https://github.com/webex/react-widgets/commit/1bd514a))
 
 
 
 <a name="0.1.420"></a>
-## [0.1.420](https://github.com/webex/react-ciscospark/compare/v0.1.419...v0.1.420) (2019-02-18)
+## [0.1.420](https://github.com/webex/react-widgets/compare/v0.1.419...v0.1.420) (2019-02-18)
 
 
 
 <a name="0.1.419"></a>
-## [0.1.419](https://github.com/webex/react-ciscospark/compare/v0.1.418...v0.1.419) (2019-02-13)
+## [0.1.419](https://github.com/webex/react-widgets/compare/v0.1.418...v0.1.419) (2019-02-13)
 
 
 ### Bug Fixes
 
-* **circleci:** pin firefox version to 64 ([6f990a0](https://github.com/webex/react-ciscospark/commit/6f990a0))
+* **circleci:** pin firefox version to 64 ([6f990a0](https://github.com/webex/react-widgets/commit/6f990a0))
 
 
 
 <a name="0.1.418"></a>
-## [0.1.418](https://github.com/webex/react-ciscospark/compare/v0.1.417...v0.1.418) (2019-02-12)
+## [0.1.418](https://github.com/webex/react-widgets/compare/v0.1.417...v0.1.418) (2019-02-12)
 
 
 ### Bug Fixes
 
-* **recents:** use proper selector method in setup ([ffddab2](https://github.com/webex/react-ciscospark/commit/ffddab2))
+* **recents:** use proper selector method in setup ([ffddab2](https://github.com/webex/react-widgets/commit/ffddab2))
 
 
 ### Features
 
-* **r-m-spaces:** add add/remove tags actions ([9faf95b](https://github.com/webex/react-ciscospark/commit/9faf95b))
-* **react-component-utils:** add api activity verb constants ([c555b16](https://github.com/webex/react-ciscospark/commit/c555b16))
-* **recents:** move activity listener to enhancer ([c794323](https://github.com/webex/react-ciscospark/commit/c794323))
-* **utils:** update getBadgeState to ignore "MUTED" tag ([0427503](https://github.com/webex/react-ciscospark/commit/0427503))
-* **widget-recents:** add support for TAG and UNTAG activities ([6f16f07](https://github.com/webex/react-ciscospark/commit/6f16f07))
+* **r-m-spaces:** add add/remove tags actions ([9faf95b](https://github.com/webex/react-widgets/commit/9faf95b))
+* **react-component-utils:** add api activity verb constants ([c555b16](https://github.com/webex/react-widgets/commit/c555b16))
+* **recents:** move activity listener to enhancer ([c794323](https://github.com/webex/react-widgets/commit/c794323))
+* **utils:** update getBadgeState to ignore "MUTED" tag ([0427503](https://github.com/webex/react-widgets/commit/0427503))
+* **widget-recents:** add support for TAG and UNTAG activities ([6f16f07](https://github.com/webex/react-widgets/commit/6f16f07))
 
 
 
 <a name="0.1.417"></a>
-## [0.1.417](https://github.com/webex/react-ciscospark/compare/v0.1.416...v0.1.417) (2019-02-11)
+## [0.1.417](https://github.com/webex/react-widgets/compare/v0.1.416...v0.1.417) (2019-02-11)
 
 
 ### Bug Fixes
 
-* **widget-recents:** fetch proper to user avatar in direct spaces ([bb5cb6e](https://github.com/webex/react-ciscospark/commit/bb5cb6e))
-* **widget-recents:** use proper selector method in setup ([8435ae8](https://github.com/webex/react-ciscospark/commit/8435ae8))
+* **widget-recents:** fetch proper to user avatar in direct spaces ([bb5cb6e](https://github.com/webex/react-widgets/commit/bb5cb6e))
+* **widget-recents:** use proper selector method in setup ([8435ae8](https://github.com/webex/react-widgets/commit/8435ae8))
 
 
 
 <a name="0.1.416"></a>
-## [0.1.416](https://github.com/webex/react-ciscospark/compare/v0.1.415...v0.1.416) (2019-02-04)
+## [0.1.416](https://github.com/webex/react-widgets/compare/v0.1.415...v0.1.416) (2019-02-04)
 
 
 
 <a name="0.1.415"></a>
-## [0.1.415](https://github.com/webex/react-ciscospark/compare/v0.1.414...v0.1.415) (2019-01-31)
+## [0.1.415](https://github.com/webex/react-widgets/compare/v0.1.414...v0.1.415) (2019-01-31)
 
 
 
 <a name="0.1.414"></a>
-## [0.1.414](https://github.com/webex/react-ciscospark/compare/v0.1.413...v0.1.414) (2019-01-25)
+## [0.1.414](https://github.com/webex/react-widgets/compare/v0.1.413...v0.1.414) (2019-01-25)
 
 
 ### Features
 
-* **recents:** add extendedLoad property ([3be5cd3](https://github.com/webex/react-ciscospark/commit/3be5cd3))
-* **recents:** add spaceLoadCount property ([150e405](https://github.com/webex/react-ciscospark/commit/150e405))
-* **widget-demo:** add extendedLoad config to recents ([6aece07](https://github.com/webex/react-ciscospark/commit/6aece07))
-* **widget-demo:** add support for recents spaceLoadCount prop ([5bffd7c](https://github.com/webex/react-ciscospark/commit/5bffd7c))
+* **recents:** add extendedLoad property ([3be5cd3](https://github.com/webex/react-widgets/commit/3be5cd3))
+* **recents:** add spaceLoadCount property ([150e405](https://github.com/webex/react-widgets/commit/150e405))
+* **widget-demo:** add extendedLoad config to recents ([6aece07](https://github.com/webex/react-widgets/commit/6aece07))
+* **widget-demo:** add support for recents spaceLoadCount prop ([5bffd7c](https://github.com/webex/react-widgets/commit/5bffd7c))
 
 
 
 <a name="0.1.413"></a>
-## [0.1.413](https://github.com/webex/react-ciscospark/compare/v0.1.412...v0.1.413) (2019-01-24)
+## [0.1.413](https://github.com/webex/react-widgets/compare/v0.1.412...v0.1.413) (2019-01-24)
 
 
 ### Bug Fixes
 
-* **widget-demo:** correct spaceActivities prop ([2f938e3](https://github.com/webex/react-ciscospark/commit/2f938e3))
+* **widget-demo:** correct spaceActivities prop ([2f938e3](https://github.com/webex/react-widgets/commit/2f938e3))
 
 
 
 <a name="0.1.412"></a>
-## [0.1.412](https://github.com/webex/react-ciscospark/compare/v0.1.411...v0.1.412) (2019-01-22)
+## [0.1.412](https://github.com/webex/react-widgets/compare/v0.1.411...v0.1.412) (2019-01-22)
 
 
 ### Bug Fixes
 
-* **space-item:** fix call start time display ([f46b5d2](https://github.com/webex/react-ciscospark/commit/f46b5d2))
+* **space-item:** fix call start time display ([f46b5d2](https://github.com/webex/react-widgets/commit/f46b5d2))
 
 
 ### Features
 
-* **r-m-spaces:** add decrypt promise to space item ([a3abdeb](https://github.com/webex/react-ciscospark/commit/a3abdeb))
-* **r-m-spaces:** optimize convo request and storage ([aa0cc26](https://github.com/webex/react-ciscospark/commit/aa0cc26))
-* **recents:** add avatars to initial fetch before continuing ([f3b170d](https://github.com/webex/react-ciscospark/commit/f3b170d))
-* **recents:** optimize initial space loading via enhancers ([e34956d](https://github.com/webex/react-ciscospark/commit/e34956d))
+* **r-m-spaces:** add decrypt promise to space item ([a3abdeb](https://github.com/webex/react-widgets/commit/a3abdeb))
+* **r-m-spaces:** optimize convo request and storage ([aa0cc26](https://github.com/webex/react-widgets/commit/aa0cc26))
+* **recents:** add avatars to initial fetch before continuing ([f3b170d](https://github.com/webex/react-widgets/commit/f3b170d))
+* **recents:** optimize initial space loading via enhancers ([e34956d](https://github.com/webex/react-widgets/commit/e34956d))
 
 
 
 <a name="0.1.411"></a>
-## [0.1.411](https://github.com/webex/react-ciscospark/compare/v0.1.410...v0.1.411) (2019-01-18)
+## [0.1.411](https://github.com/webex/react-widgets/compare/v0.1.410...v0.1.411) (2019-01-18)
 
 
 
 <a name="0.1.410"></a>
-## [0.1.410](https://github.com/webex/react-ciscospark/compare/v0.1.409...v0.1.410) (2019-01-18)
+## [0.1.410](https://github.com/webex/react-widgets/compare/v0.1.409...v0.1.410) (2019-01-18)
 
 
 
 <a name="0.1.409"></a>
-## [0.1.409](https://github.com/webex/react-ciscospark/compare/v0.1.408...v0.1.409) (2019-01-15)
+## [0.1.409](https://github.com/webex/react-widgets/compare/v0.1.408...v0.1.409) (2019-01-15)
 
 
 ### Bug Fixes
 
-* **widget-recents:** padding for search input box for lower resolutions ([4376a02](https://github.com/webex/react-ciscospark/commit/4376a02))
+* **widget-recents:** padding for search input box for lower resolutions ([4376a02](https://github.com/webex/react-widgets/commit/4376a02))
 
 
 
 <a name="0.1.408"></a>
-## [0.1.408](https://github.com/webex/react-ciscospark/compare/v0.1.407...v0.1.408) (2019-01-15)
+## [0.1.408](https://github.com/webex/react-widgets/compare/v0.1.407...v0.1.408) (2019-01-15)
 
 
 
 <a name="0.1.407"></a>
-## [0.1.407](https://github.com/webex/react-ciscospark/compare/v0.1.406...v0.1.407) (2019-01-11)
+## [0.1.407](https://github.com/webex/react-widgets/compare/v0.1.406...v0.1.407) (2019-01-11)
 
 
 
 <a name="0.1.406"></a>
-## [0.1.406](https://github.com/webex/react-ciscospark/compare/v0.1.405...v0.1.406) (2019-01-11)
+## [0.1.406](https://github.com/webex/react-widgets/compare/v0.1.405...v0.1.406) (2019-01-11)
 
 
 ### Bug Fixes
 
-* **presence-avatar:** remove empty div causing layout issues ([c11aaa7](https://github.com/webex/react-ciscospark/commit/c11aaa7))
+* **presence-avatar:** remove empty div causing layout issues ([c11aaa7](https://github.com/webex/react-widgets/commit/c11aaa7))
 
 
 
 <a name="0.1.405"></a>
-## [0.1.405](https://github.com/webex/react-ciscospark/compare/v0.1.404...v0.1.405) (2019-01-10)
+## [0.1.405](https://github.com/webex/react-widgets/compare/v0.1.404...v0.1.405) (2019-01-10)
 
 
 
 <a name="0.1.404"></a>
-## [0.1.404](https://github.com/webex/react-ciscospark/compare/v0.1.403...v0.1.404) (2019-01-10)
+## [0.1.404](https://github.com/webex/react-widgets/compare/v0.1.403...v0.1.404) (2019-01-10)
 
 
 ### Features
 
-* **spark:** add client id and scope ([ea9432e](https://github.com/webex/react-ciscospark/commit/ea9432e))
+* **spark:** add client id and scope ([ea9432e](https://github.com/webex/react-widgets/commit/ea9432e))
 
 
 
 <a name="0.1.403"></a>
-## [0.1.403](https://github.com/webex/react-ciscospark/compare/v0.1.402...v0.1.403) (2019-01-09)
+## [0.1.403](https://github.com/webex/react-widgets/compare/v0.1.402...v0.1.403) (2019-01-09)
 
 
 
 <a name="0.1.402"></a>
-## [0.1.402](https://github.com/webex/react-ciscospark/compare/v0.1.401...v0.1.402) (2019-01-08)
+## [0.1.402](https://github.com/webex/react-widgets/compare/v0.1.401...v0.1.402) (2019-01-08)
 
 
 
 <a name="0.1.401"></a>
-## [0.1.401](https://github.com/webex/react-ciscospark/compare/v0.1.400...v0.1.401) (2019-01-08)
+## [0.1.401](https://github.com/webex/react-widgets/compare/v0.1.400...v0.1.401) (2019-01-08)
 
 
 
 <a name="0.1.400"></a>
-## [0.1.400](https://github.com/webex/react-ciscospark/compare/v0.1.399...v0.1.400) (2019-01-08)
+## [0.1.400](https://github.com/webex/react-widgets/compare/v0.1.399...v0.1.400) (2019-01-08)
 
 
 
 <a name="0.1.399"></a>
-## [0.1.399](https://github.com/webex/react-ciscospark/compare/v0.1.398...v0.1.399) (2019-01-02)
+## [0.1.399](https://github.com/webex/react-widgets/compare/v0.1.398...v0.1.399) (2019-01-02)
 
 
 ### Features
 
-* **react-component-utils:** space type filter ([6335aa4](https://github.com/webex/react-ciscospark/commit/6335aa4))
-* **widget-demo:** space type filter ([ddb57d6](https://github.com/webex/react-ciscospark/commit/ddb57d6))
-* **widget-recents:** space type filter ([d071e5e](https://github.com/webex/react-ciscospark/commit/d071e5e))
+* **react-component-utils:** space type filter ([6335aa4](https://github.com/webex/react-widgets/commit/6335aa4))
+* **widget-demo:** space type filter ([ddb57d6](https://github.com/webex/react-widgets/commit/ddb57d6))
+* **widget-recents:** space type filter ([d071e5e](https://github.com/webex/react-widgets/commit/d071e5e))
 
 
 
 <a name="0.1.398"></a>
-## [0.1.398](https://github.com/webex/react-ciscospark/compare/v0.1.397...v0.1.398) (2018-12-21)
+## [0.1.398](https://github.com/webex/react-widgets/compare/v0.1.397...v0.1.398) (2018-12-21)
 
 
 
 <a name="0.1.397"></a>
-## [0.1.397](https://github.com/webex/react-ciscospark/compare/v0.1.396...v0.1.397) (2018-12-17)
+## [0.1.397](https://github.com/webex/react-widgets/compare/v0.1.396...v0.1.397) (2018-12-17)
 
 
 ### Features
 
-* **demo-widget:** recents widget space filter ([bb06907](https://github.com/webex/react-ciscospark/commit/bb06907))
-* **react-component-space-item:** recents widget space filter ([6eb4da5](https://github.com/webex/react-ciscospark/commit/6eb4da5))
-* **react-component-spaces-list:** recents widget space filter ([1fbe6cf](https://github.com/webex/react-ciscospark/commit/1fbe6cf))
-* **react-component-utils:** recents widget space filter ([1affe3d](https://github.com/webex/react-ciscospark/commit/1affe3d))
-* **redux-module-spaces:** recents widget space filter ([1dde27d](https://github.com/webex/react-ciscospark/commit/1dde27d))
-* **widget-recents:** recents widget space filter ([e45b887](https://github.com/webex/react-ciscospark/commit/e45b887))
+* **demo-widget:** recents widget space filter ([bb06907](https://github.com/webex/react-widgets/commit/bb06907))
+* **react-component-space-item:** recents widget space filter ([6eb4da5](https://github.com/webex/react-widgets/commit/6eb4da5))
+* **react-component-spaces-list:** recents widget space filter ([1fbe6cf](https://github.com/webex/react-widgets/commit/1fbe6cf))
+* **react-component-utils:** recents widget space filter ([1affe3d](https://github.com/webex/react-widgets/commit/1affe3d))
+* **redux-module-spaces:** recents widget space filter ([1dde27d](https://github.com/webex/react-widgets/commit/1dde27d))
+* **widget-recents:** recents widget space filter ([e45b887](https://github.com/webex/react-widgets/commit/e45b887))
 
 
 
 <a name="0.1.396"></a>
-## [0.1.396](https://github.com/webex/react-ciscospark/compare/v0.1.395...v0.1.396) (2018-12-15)
+## [0.1.396](https://github.com/webex/react-widgets/compare/v0.1.395...v0.1.396) (2018-12-15)
 
 
 
 <a name="0.1.395"></a>
-## [0.1.395](https://github.com/webex/react-ciscospark/compare/v0.1.394...v0.1.395) (2018-12-15)
+## [0.1.395](https://github.com/webex/react-widgets/compare/v0.1.394...v0.1.395) (2018-12-15)
 
 
 
 <a name="0.1.394"></a>
-## [0.1.394](https://github.com/webex/react-ciscospark/compare/v0.1.393...v0.1.394) (2018-12-15)
+## [0.1.394](https://github.com/webex/react-widgets/compare/v0.1.393...v0.1.394) (2018-12-15)
 
 
 
 <a name="0.1.393"></a>
-## [0.1.393](https://github.com/webex/react-ciscospark/compare/v0.1.392...v0.1.393) (2018-12-14)
+## [0.1.393](https://github.com/webex/react-widgets/compare/v0.1.392...v0.1.393) (2018-12-14)
 
 
 
 <a name="0.1.392"></a>
-## [0.1.392](https://github.com/webex/react-ciscospark/compare/v0.1.391...v0.1.392) (2018-12-14)
+## [0.1.392](https://github.com/webex/react-widgets/compare/v0.1.391...v0.1.392) (2018-12-14)
 
 
 ### Features
 
-* **widget-demos:** add support for secondaryActivitiesFullWidth ([23c8954](https://github.com/webex/react-ciscospark/commit/23c8954))
-* **widget-space:** add secondaryActivitiesFullWidth param ([8b8940e](https://github.com/webex/react-ciscospark/commit/8b8940e))
+* **widget-demos:** add support for secondaryActivitiesFullWidth ([23c8954](https://github.com/webex/react-widgets/commit/23c8954))
+* **widget-space:** add secondaryActivitiesFullWidth param ([8b8940e](https://github.com/webex/react-widgets/commit/8b8940e))
 
 
 
 <a name="0.1.391"></a>
-## [0.1.391](https://github.com/webex/react-ciscospark/compare/v0.1.390...v0.1.391) (2018-12-14)
+## [0.1.391](https://github.com/webex/react-widgets/compare/v0.1.390...v0.1.391) (2018-12-14)
 
 
 ### Bug Fixes
 
-* **button-controls:** use accessibility labels prop ([523fff9](https://github.com/webex/react-ciscospark/commit/523fff9))
-* **r-c-share-file:** fix css to add ie 11 compatibility ([382ab59](https://github.com/webex/react-ciscospark/commit/382ab59))
-* **title-bar:** remove hard coded font style ([3e22dd0](https://github.com/webex/react-ciscospark/commit/3e22dd0))
-* **widget-meet:** call control state doesn't update before call is connected ([5ac658a](https://github.com/webex/react-ciscospark/commit/5ac658a))
-* **widget-message:** support for empty lastActivity ([ebfb053](https://github.com/webex/react-ciscospark/commit/ebfb053))
-* **widget-space:** fetch space details ([fccc91b](https://github.com/webex/react-ciscospark/commit/fccc91b))
+* **button-controls:** use accessibility labels prop ([523fff9](https://github.com/webex/react-widgets/commit/523fff9))
+* **r-c-share-file:** fix css to add ie 11 compatibility ([382ab59](https://github.com/webex/react-widgets/commit/382ab59))
+* **title-bar:** remove hard coded font style ([3e22dd0](https://github.com/webex/react-widgets/commit/3e22dd0))
+* **widget-meet:** call control state doesn't update before call is connected ([5ac658a](https://github.com/webex/react-widgets/commit/5ac658a))
+* **widget-message:** support for empty lastActivity ([ebfb053](https://github.com/webex/react-widgets/commit/ebfb053))
+* **widget-space:** fetch space details ([fccc91b](https://github.com/webex/react-widgets/commit/fccc91b))
 
 
 ### Features
 
-* **activity-item:** add support for isAdditional style ([6d54624](https://github.com/webex/react-ciscospark/commit/6d54624))
-* **activity-item-base:** use collab-ui icons and styling ([7036fc2](https://github.com/webex/react-ciscospark/commit/7036fc2))
-* **activity-list:** add padding at bottom of list ([e3324f9](https://github.com/webex/react-ciscospark/commit/e3324f9))
-* **activity-menu-header:** update to collab-ui components ([e2f3919](https://github.com/webex/react-ciscospark/commit/e2f3919))
-* **activity-share-thumbnail:** use collab-ui spinner ([4e78d50](https://github.com/webex/react-ciscospark/commit/4e78d50))
-* **demo-widget-space:** add ability to toggle composer buttons ([986042b](https://github.com/webex/react-ciscospark/commit/986042b))
-* **file-uploads:** update styles and use collab-ui components ([1e3cbf2](https://github.com/webex/react-ciscospark/commit/1e3cbf2))
-* **incoming-call:** add accessibility labels ([ed08e97](https://github.com/webex/react-ciscospark/commit/ed08e97))
-* **loading-screen:** use collab-ui spinner ([4c48614](https://github.com/webex/react-ciscospark/commit/4c48614))
-* **message-composer:** create message activities area ([5b94161](https://github.com/webex/react-ciscospark/commit/5b94161))
-* **message-composer:** update styles for existing input ([766208a](https://github.com/webex/react-ciscospark/commit/766208a))
-* **people-list:** use popover menu for moderator actions ([d2ad8b4](https://github.com/webex/react-ciscospark/commit/d2ad8b4))
-* **private-r-c-space-destination:** add ability to toggle composer buttons ([8841a82](https://github.com/webex/react-ciscospark/commit/8841a82))
-* **r-c-activity-item:** add actor and timestamp props ([53c02e7](https://github.com/webex/react-ciscospark/commit/53c02e7))
-* **r-c-activity-menu:** use collab-ui exit button in activity menu ([5b7b9d5](https://github.com/webex/react-ciscospark/commit/5b7b9d5))
-* **r-c-activity-menu-header:** add support for menu toggle ([bdd2282](https://github.com/webex/react-ciscospark/commit/bdd2282))
-* **r-c-activity-share-file:** new IA design ([18d10cf](https://github.com/webex/react-ciscospark/commit/18d10cf))
-* **r-c-activity-share-files:** add additional props for new design ([d21b644](https://github.com/webex/react-ciscospark/commit/d21b644))
-* **r-c-activity-share-thumbnail:** use collab-ui ContentItem component ([25bf9ba](https://github.com/webex/react-ciscospark/commit/25bf9ba))
-* **r-c-button-controls:** use collab-ui ActivityButtons ([83e3d8f](https://github.com/webex/react-ciscospark/commit/83e3d8f))
-* **r-c-button-controls:** use collab-ui call controls ([70513cb](https://github.com/webex/react-ciscospark/commit/70513cb))
-* **r-c-file-share-display:** use thumbnail component ([e6505bf](https://github.com/webex/react-ciscospark/commit/e6505bf))
-* **r-c-incoming-call:** use collab-ui call controls ([9c4225a](https://github.com/webex/react-ciscospark/commit/9c4225a))
-* **r-c-message-composer:** add ability to toggle composer buttons ([5297740](https://github.com/webex/react-ciscospark/commit/5297740))
-* **react-component-utils:** add helper function for file icons ([f47a4cd](https://github.com/webex/react-ciscospark/commit/f47a4cd))
-* **scrolling-activity:** use collab-ui loader ([6298708](https://github.com/webex/react-ciscospark/commit/6298708))
-* **title-bar:** create new webex title bar component ([2c6c5b4](https://github.com/webex/react-ciscospark/commit/2c6c5b4))
-* **widget-demo:** add ability to toggle composer buttons ([0f32b1c](https://github.com/webex/react-ciscospark/commit/0f32b1c))
-* **widget-demo:** add polyfill support for ie11 ([ceea47e](https://github.com/webex/react-ciscospark/commit/ceea47e))
-* **widget-files:** add props for actor, type, and timestamp ([63cc275](https://github.com/webex/react-ciscospark/commit/63cc275))
-* **widget-files:** add support for menu toggle ([63ae507](https://github.com/webex/react-ciscospark/commit/63ae507))
-* **widget-files:** add timestamp prop ([569c08e](https://github.com/webex/react-ciscospark/commit/569c08e))
-* **widget-message:** use collab-ui for scroll to bottom button ([0fd4b67](https://github.com/webex/react-ciscospark/commit/0fd4b67))
-* **widget-roster:** add support for menu toggle ([7fcfe34](https://github.com/webex/react-ciscospark/commit/7fcfe34))
-* **widget-roster:** remove participant editing screen ([9e1f28b](https://github.com/webex/react-ciscospark/commit/9e1f28b))
-* **widget-roster:** use collab-ui spinner ([a7a1b5c](https://github.com/webex/react-ciscospark/commit/a7a1b5c))
-* **widget-roster:** use collab-ui styles ([1d43510](https://github.com/webex/react-ciscospark/commit/1d43510))
-* **widget-space:** add ability to toggle composer buttons ([3046b6e](https://github.com/webex/react-ciscospark/commit/3046b6e))
-* **widget-space:** add ability to toggle composer buttons ([23bee04](https://github.com/webex/react-ciscospark/commit/23bee04))
-* **widget-space:** add collab-ui css stylesheet ([87fd05f](https://github.com/webex/react-ciscospark/commit/87fd05f))
-* **widget-space:** add support for menu toggle ([910ab8f](https://github.com/webex/react-ciscospark/commit/910ab8f))
-* **widget-space:** use webex title bar component and collab ui ([99b4be0](https://github.com/webex/react-ciscospark/commit/99b4be0))
+* **activity-item:** add support for isAdditional style ([6d54624](https://github.com/webex/react-widgets/commit/6d54624))
+* **activity-item-base:** use collab-ui icons and styling ([7036fc2](https://github.com/webex/react-widgets/commit/7036fc2))
+* **activity-list:** add padding at bottom of list ([e3324f9](https://github.com/webex/react-widgets/commit/e3324f9))
+* **activity-menu-header:** update to collab-ui components ([e2f3919](https://github.com/webex/react-widgets/commit/e2f3919))
+* **activity-share-thumbnail:** use collab-ui spinner ([4e78d50](https://github.com/webex/react-widgets/commit/4e78d50))
+* **demo-widget-space:** add ability to toggle composer buttons ([986042b](https://github.com/webex/react-widgets/commit/986042b))
+* **file-uploads:** update styles and use collab-ui components ([1e3cbf2](https://github.com/webex/react-widgets/commit/1e3cbf2))
+* **incoming-call:** add accessibility labels ([ed08e97](https://github.com/webex/react-widgets/commit/ed08e97))
+* **loading-screen:** use collab-ui spinner ([4c48614](https://github.com/webex/react-widgets/commit/4c48614))
+* **message-composer:** create message activities area ([5b94161](https://github.com/webex/react-widgets/commit/5b94161))
+* **message-composer:** update styles for existing input ([766208a](https://github.com/webex/react-widgets/commit/766208a))
+* **people-list:** use popover menu for moderator actions ([d2ad8b4](https://github.com/webex/react-widgets/commit/d2ad8b4))
+* **private-r-c-space-destination:** add ability to toggle composer buttons ([8841a82](https://github.com/webex/react-widgets/commit/8841a82))
+* **r-c-activity-item:** add actor and timestamp props ([53c02e7](https://github.com/webex/react-widgets/commit/53c02e7))
+* **r-c-activity-menu:** use collab-ui exit button in activity menu ([5b7b9d5](https://github.com/webex/react-widgets/commit/5b7b9d5))
+* **r-c-activity-menu-header:** add support for menu toggle ([bdd2282](https://github.com/webex/react-widgets/commit/bdd2282))
+* **r-c-activity-share-file:** new IA design ([18d10cf](https://github.com/webex/react-widgets/commit/18d10cf))
+* **r-c-activity-share-files:** add additional props for new design ([d21b644](https://github.com/webex/react-widgets/commit/d21b644))
+* **r-c-activity-share-thumbnail:** use collab-ui ContentItem component ([25bf9ba](https://github.com/webex/react-widgets/commit/25bf9ba))
+* **r-c-button-controls:** use collab-ui ActivityButtons ([83e3d8f](https://github.com/webex/react-widgets/commit/83e3d8f))
+* **r-c-button-controls:** use collab-ui call controls ([70513cb](https://github.com/webex/react-widgets/commit/70513cb))
+* **r-c-file-share-display:** use thumbnail component ([e6505bf](https://github.com/webex/react-widgets/commit/e6505bf))
+* **r-c-incoming-call:** use collab-ui call controls ([9c4225a](https://github.com/webex/react-widgets/commit/9c4225a))
+* **r-c-message-composer:** add ability to toggle composer buttons ([5297740](https://github.com/webex/react-widgets/commit/5297740))
+* **react-component-utils:** add helper function for file icons ([f47a4cd](https://github.com/webex/react-widgets/commit/f47a4cd))
+* **scrolling-activity:** use collab-ui loader ([6298708](https://github.com/webex/react-widgets/commit/6298708))
+* **title-bar:** create new webex title bar component ([2c6c5b4](https://github.com/webex/react-widgets/commit/2c6c5b4))
+* **widget-demo:** add ability to toggle composer buttons ([0f32b1c](https://github.com/webex/react-widgets/commit/0f32b1c))
+* **widget-demo:** add polyfill support for ie11 ([ceea47e](https://github.com/webex/react-widgets/commit/ceea47e))
+* **widget-files:** add props for actor, type, and timestamp ([63cc275](https://github.com/webex/react-widgets/commit/63cc275))
+* **widget-files:** add support for menu toggle ([63ae507](https://github.com/webex/react-widgets/commit/63ae507))
+* **widget-files:** add timestamp prop ([569c08e](https://github.com/webex/react-widgets/commit/569c08e))
+* **widget-message:** use collab-ui for scroll to bottom button ([0fd4b67](https://github.com/webex/react-widgets/commit/0fd4b67))
+* **widget-roster:** add support for menu toggle ([7fcfe34](https://github.com/webex/react-widgets/commit/7fcfe34))
+* **widget-roster:** remove participant editing screen ([9e1f28b](https://github.com/webex/react-widgets/commit/9e1f28b))
+* **widget-roster:** use collab-ui spinner ([a7a1b5c](https://github.com/webex/react-widgets/commit/a7a1b5c))
+* **widget-roster:** use collab-ui styles ([1d43510](https://github.com/webex/react-widgets/commit/1d43510))
+* **widget-space:** add ability to toggle composer buttons ([3046b6e](https://github.com/webex/react-widgets/commit/3046b6e))
+* **widget-space:** add ability to toggle composer buttons ([23bee04](https://github.com/webex/react-widgets/commit/23bee04))
+* **widget-space:** add collab-ui css stylesheet ([87fd05f](https://github.com/webex/react-widgets/commit/87fd05f))
+* **widget-space:** add support for menu toggle ([910ab8f](https://github.com/webex/react-widgets/commit/910ab8f))
+* **widget-space:** use webex title bar component and collab ui ([99b4be0](https://github.com/webex/react-widgets/commit/99b4be0))
 
 
 
 <a name="0.1.390"></a>
-## [0.1.390](https://github.com/webex/react-ciscospark/compare/v0.1.389...v0.1.390) (2018-12-13)
+## [0.1.390](https://github.com/webex/react-widgets/compare/v0.1.389...v0.1.390) (2018-12-13)
 
 
 ### Bug Fixes
 
-* **r-m-users:** add support for a user with no display name ([ba2d2d3](https://github.com/webex/react-ciscospark/commit/ba2d2d3))
-* **widget-space:** load user data and connect to mercury ([05bb9c5](https://github.com/webex/react-ciscospark/commit/05bb9c5))
+* **r-m-users:** add support for a user with no display name ([ba2d2d3](https://github.com/webex/react-widgets/commit/ba2d2d3))
+* **widget-space:** load user data and connect to mercury ([05bb9c5](https://github.com/webex/react-widgets/commit/05bb9c5))
 
 
 
 <a name="0.1.389"></a>
-## [0.1.389](https://github.com/webex/react-ciscospark/compare/v0.1.388...v0.1.389) (2018-12-12)
+## [0.1.389](https://github.com/webex/react-widgets/compare/v0.1.388...v0.1.389) (2018-12-12)
 
 
 ### Features
 
-* **react-component-space-item:** Add notification level icon support (SPARK-38152) ([b87474c](https://github.com/webex/react-ciscospark/commit/b87474c))
-* **react-component-utils:** Add notification level icon support (SPARK-38152) ([1a7b44d](https://github.com/webex/react-ciscospark/commit/1a7b44d))
-* **redux-module-spaces:** Add notification level icon support (SPARK-38152) ([0c423b2](https://github.com/webex/react-ciscospark/commit/0c423b2))
-* **widget-recents:** Add notification level icon support (SPARK-38152) ([ad95142](https://github.com/webex/react-ciscospark/commit/ad95142))
+* **react-component-space-item:** Add notification level icon support (SPARK-38152) ([b87474c](https://github.com/webex/react-widgets/commit/b87474c))
+* **react-component-utils:** Add notification level icon support (SPARK-38152) ([1a7b44d](https://github.com/webex/react-widgets/commit/1a7b44d))
+* **redux-module-spaces:** Add notification level icon support (SPARK-38152) ([0c423b2](https://github.com/webex/react-widgets/commit/0c423b2))
+* **widget-recents:** Add notification level icon support (SPARK-38152) ([ad95142](https://github.com/webex/react-widgets/commit/ad95142))
 
 
 
 <a name="0.1.388"></a>
-## [0.1.388](https://github.com/webex/react-ciscospark/compare/v0.1.387...v0.1.388) (2018-12-12)
+## [0.1.388](https://github.com/webex/react-widgets/compare/v0.1.387...v0.1.388) (2018-12-12)
 
 
 ### Features
 
-* **widget-recents:** load collab-ui styles at head ([c0598e6](https://github.com/webex/react-ciscospark/commit/c0598e6))
+* **widget-recents:** load collab-ui styles at head ([c0598e6](https://github.com/webex/react-widgets/commit/c0598e6))
 
 
 
 <a name="0.1.387"></a>
-## [0.1.387](https://github.com/webex/react-ciscospark/compare/v0.1.386...v0.1.387) (2018-12-11)
+## [0.1.387](https://github.com/webex/react-widgets/compare/v0.1.386...v0.1.387) (2018-12-11)
 
 
 
 <a name="0.1.386"></a>
-## [0.1.386](https://github.com/webex/react-ciscospark/compare/v0.1.385...v0.1.386) (2018-11-21)
+## [0.1.386](https://github.com/webex/react-widgets/compare/v0.1.385...v0.1.386) (2018-11-21)
 
 
 
 <a name="0.1.385"></a>
-## [0.1.385](https://github.com/webex/react-ciscospark/compare/v0.1.384...v0.1.385) (2018-11-20)
+## [0.1.385](https://github.com/webex/react-widgets/compare/v0.1.384...v0.1.385) (2018-11-20)
 
 
 
 <a name="0.1.384"></a>
-## [0.1.384](https://github.com/webex/react-ciscospark/compare/v0.1.383...v0.1.384) (2018-11-19)
+## [0.1.384](https://github.com/webex/react-widgets/compare/v0.1.383...v0.1.384) (2018-11-19)
 
 
 ### Features
 
-* **widget-demo:** add external control options ([3e46fbd](https://github.com/webex/react-ciscospark/commit/3e46fbd))
-* **widget-space:** add setCurrentActivity prop to control ([29f11d1](https://github.com/webex/react-ciscospark/commit/29f11d1))
-* **widget-space:** send event when activity changes ([cf0f738](https://github.com/webex/react-ciscospark/commit/cf0f738))
+* **widget-demo:** add external control options ([3e46fbd](https://github.com/webex/react-widgets/commit/3e46fbd))
+* **widget-space:** add setCurrentActivity prop to control ([29f11d1](https://github.com/webex/react-widgets/commit/29f11d1))
+* **widget-space:** send event when activity changes ([cf0f738](https://github.com/webex/react-widgets/commit/cf0f738))
 
 
 
 <a name="0.1.383"></a>
-## [0.1.383](https://github.com/webex/react-ciscospark/compare/v0.1.382...v0.1.383) (2018-11-19)
+## [0.1.383](https://github.com/webex/react-widgets/compare/v0.1.382...v0.1.383) (2018-11-19)
 
 
 ### Features
 
-* **widget-demo:** add sticky mode support ([58189e1](https://github.com/webex/react-ciscospark/commit/58189e1))
+* **widget-demo:** add sticky mode support ([58189e1](https://github.com/webex/react-widgets/commit/58189e1))
 
 
 
 <a name="0.1.382"></a>
-## [0.1.382](https://github.com/webex/react-ciscospark/compare/v0.1.381...v0.1.382) (2018-11-16)
+## [0.1.382](https://github.com/webex/react-widgets/compare/v0.1.381...v0.1.382) (2018-11-16)
 
 
 
 <a name="0.1.381"></a>
-## [0.1.381](https://github.com/webex/react-ciscospark/compare/v0.1.380...v0.1.381) (2018-11-15)
+## [0.1.381](https://github.com/webex/react-widgets/compare/v0.1.380...v0.1.381) (2018-11-15)
 
 
 ### Bug Fixes
 
-* **journeys:** remove extended debugging option ([99e8aa6](https://github.com/webex/react-ciscospark/commit/99e8aa6))
+* **journeys:** remove extended debugging option ([99e8aa6](https://github.com/webex/react-widgets/commit/99e8aa6))
 
 
 ### Features
 
-* **r-c-presence-avatar:** use collab-ui component for presence avatar ([4a53cd5](https://github.com/webex/react-ciscospark/commit/4a53cd5))
+* **r-c-presence-avatar:** use collab-ui component for presence avatar ([4a53cd5](https://github.com/webex/react-widgets/commit/4a53cd5))
 
 
 
 <a name="0.1.380"></a>
-## [0.1.380](https://github.com/webex/react-ciscospark/compare/v0.1.379...v0.1.380) (2018-11-02)
+## [0.1.380](https://github.com/webex/react-widgets/compare/v0.1.379...v0.1.380) (2018-11-02)
 
 
 
 <a name="0.1.379"></a>
-## [0.1.379](https://github.com/webex/react-ciscospark/compare/v0.1.378...v0.1.379) (2018-10-26)
+## [0.1.379](https://github.com/webex/react-widgets/compare/v0.1.378...v0.1.379) (2018-10-26)
 
 
 
 <a name="0.1.378"></a>
-## [0.1.378](https://github.com/webex/react-ciscospark/compare/v0.1.377...v0.1.378) (2018-10-25)
+## [0.1.378](https://github.com/webex/react-widgets/compare/v0.1.377...v0.1.378) (2018-10-25)
 
 
 
 <a name="0.1.377"></a>
-## [0.1.377](https://github.com/webex/react-ciscospark/compare/v0.1.376...v0.1.377) (2018-10-23)
+## [0.1.377](https://github.com/webex/react-widgets/compare/v0.1.376...v0.1.377) (2018-10-23)
 
 
 ### Features
 
-* **example-code:** create example code component ([bf116d1](https://github.com/webex/react-ciscospark/commit/bf116d1))
-* **Jenkinsfile:** build and archive the widget-demo ([6d23883](https://github.com/webex/react-ciscospark/commit/6d23883))
-* **package:** remove material-ui ([00ddf27](https://github.com/webex/react-ciscospark/commit/00ddf27))
-* **recents-demo:** remove material-ui ([89cbcd8](https://github.com/webex/react-ciscospark/commit/89cbcd8))
-* **recents-demo:** use example code component ([513e42f](https://github.com/webex/react-ciscospark/commit/513e42f))
-* **space-demo:** remove material-ui ([8577088](https://github.com/webex/react-ciscospark/commit/8577088))
-* **token-input:** remove material design components ([1bc879e](https://github.com/webex/react-ciscospark/commit/1bc879e))
-* **widget-demo:** add example code sections ([2ca5af1](https://github.com/webex/react-ciscospark/commit/2ca5af1))
-* **widget-demo:** remove material design ([618e155](https://github.com/webex/react-ciscospark/commit/618e155))
-* **widget-demo:** use react version of recents widget ([69d3253](https://github.com/webex/react-ciscospark/commit/69d3253))
+* **example-code:** create example code component ([bf116d1](https://github.com/webex/react-widgets/commit/bf116d1))
+* **Jenkinsfile:** build and archive the widget-demo ([6d23883](https://github.com/webex/react-widgets/commit/6d23883))
+* **package:** remove material-ui ([00ddf27](https://github.com/webex/react-widgets/commit/00ddf27))
+* **recents-demo:** remove material-ui ([89cbcd8](https://github.com/webex/react-widgets/commit/89cbcd8))
+* **recents-demo:** use example code component ([513e42f](https://github.com/webex/react-widgets/commit/513e42f))
+* **space-demo:** remove material-ui ([8577088](https://github.com/webex/react-widgets/commit/8577088))
+* **token-input:** remove material design components ([1bc879e](https://github.com/webex/react-widgets/commit/1bc879e))
+* **widget-demo:** add example code sections ([2ca5af1](https://github.com/webex/react-widgets/commit/2ca5af1))
+* **widget-demo:** remove material design ([618e155](https://github.com/webex/react-widgets/commit/618e155))
+* **widget-demo:** use react version of recents widget ([69d3253](https://github.com/webex/react-widgets/commit/69d3253))
 
 
 
 <a name="0.1.376"></a>
-## [0.1.376](https://github.com/webex/react-ciscospark/compare/v0.1.375...v0.1.376) (2018-10-22)
+## [0.1.376](https://github.com/webex/react-widgets/compare/v0.1.375...v0.1.376) (2018-10-22)
 
 
 ### Bug Fixes
 
-* **space-demo:** handle mode change ([f3aebf8](https://github.com/webex/react-ciscospark/commit/f3aebf8))
+* **space-demo:** handle mode change ([f3aebf8](https://github.com/webex/react-widgets/commit/f3aebf8))
 
 
 
 <a name="0.1.375"></a>
-## [0.1.375](https://github.com/webex/react-ciscospark/compare/v0.1.374...v0.1.375) (2018-10-19)
+## [0.1.375](https://github.com/webex/react-widgets/compare/v0.1.374...v0.1.375) (2018-10-19)
 
 
 ### Features
 
-* **react-component-spark-fonts:** use collab-ui fonts ([6229364](https://github.com/webex/react-ciscospark/commit/6229364))
-* **widget-recents:** implement new IA for spaces list ([e925960](https://github.com/webex/react-ciscospark/commit/e925960))
-* **widget-recents:** use collab-ui fonts ([36924f7](https://github.com/webex/react-ciscospark/commit/36924f7))
+* **react-component-spark-fonts:** use collab-ui fonts ([6229364](https://github.com/webex/react-widgets/commit/6229364))
+* **widget-recents:** implement new IA for spaces list ([e925960](https://github.com/webex/react-widgets/commit/e925960))
+* **widget-recents:** use collab-ui fonts ([36924f7](https://github.com/webex/react-widgets/commit/36924f7))
 
 
 
 <a name="0.1.374"></a>
-## [0.1.374](https://github.com/webex/react-ciscospark/compare/v0.1.373...v0.1.374) (2018-10-18)
+## [0.1.374](https://github.com/webex/react-widgets/compare/v0.1.373...v0.1.374) (2018-10-18)
 
 
 ### Features
 
-* **r-m-media:** add ability to pass constraints to call answer ([63b606a](https://github.com/webex/react-ciscospark/commit/63b606a))
-* **webpack:** add source map to transpile ([6214bde](https://github.com/webex/react-ciscospark/commit/6214bde))
-* **widget-meet:** removes video constraint from audio only calls ([2445333](https://github.com/webex/react-ciscospark/commit/2445333))
+* **r-m-media:** add ability to pass constraints to call answer ([63b606a](https://github.com/webex/react-widgets/commit/63b606a))
+* **webpack:** add source map to transpile ([6214bde](https://github.com/webex/react-widgets/commit/6214bde))
+* **widget-meet:** removes video constraint from audio only calls ([2445333](https://github.com/webex/react-widgets/commit/2445333))
 
 
 
 <a name="0.1.373"></a>
-## [0.1.373](https://github.com/webex/react-ciscospark/compare/v0.1.372...v0.1.373) (2018-10-16)
+## [0.1.373](https://github.com/webex/react-widgets/compare/v0.1.372...v0.1.373) (2018-10-16)
 
 
 
 <a name="0.1.372"></a>
-## [0.1.372](https://github.com/webex/react-ciscospark/compare/v0.1.371...v0.1.372) (2018-10-15)
+## [0.1.372](https://github.com/webex/react-widgets/compare/v0.1.371...v0.1.372) (2018-10-15)
 
 
 
 <a name="0.1.371"></a>
-## [0.1.371](https://github.com/webex/react-ciscospark/compare/v0.1.370...v0.1.371) (2018-10-15)
+## [0.1.371](https://github.com/webex/react-widgets/compare/v0.1.370...v0.1.371) (2018-10-15)
 
 
 
 <a name="0.1.370"></a>
-## [0.1.370](https://github.com/webex/react-ciscospark/compare/v0.1.369...v0.1.370) (2018-10-11)
+## [0.1.370](https://github.com/webex/react-widgets/compare/v0.1.369...v0.1.370) (2018-10-11)
 
 
 ### Bug Fixes
 
-* **ciscospark:** Do not display device joins/leaves in message widget 1:1 ([1e87dc5](https://github.com/webex/react-ciscospark/commit/1e87dc5))
+* **ciscospark:** Do not display device joins/leaves in message widget 1:1 ([1e87dc5](https://github.com/webex/react-widgets/commit/1e87dc5))
 
 
 
 <a name="0.1.369"></a>
-## [0.1.369](https://github.com/webex/react-ciscospark/compare/v0.1.368...v0.1.369) (2018-10-11)
+## [0.1.369](https://github.com/webex/react-widgets/compare/v0.1.368...v0.1.369) (2018-10-11)
 
 
 ### Bug Fixes
 
-* **ciscospark:** fix widget call controls container CSS issue ([8097c46](https://github.com/webex/react-ciscospark/commit/8097c46))
+* **ciscospark:** fix widget call controls container CSS issue ([8097c46](https://github.com/webex/react-widgets/commit/8097c46))
 
 
 
 <a name="0.1.368"></a>
-## [0.1.368](https://github.com/webex/react-ciscospark/compare/v0.1.367...v0.1.368) (2018-10-10)
+## [0.1.368](https://github.com/webex/react-widgets/compare/v0.1.367...v0.1.368) (2018-10-10)
 
 
 ### Bug Fixes
 
-* **journeys:** remove extra tests for message widget visibility ([665e4d2](https://github.com/webex/react-ciscospark/commit/665e4d2))
-* **react-component-chip-base:** Add aria-label ([1dca83e](https://github.com/webex/react-ciscospark/commit/1dca83e))
+* **journeys:** remove extra tests for message widget visibility ([665e4d2](https://github.com/webex/react-widgets/commit/665e4d2))
+* **react-component-chip-base:** Add aria-label ([1dca83e](https://github.com/webex/react-widgets/commit/1dca83e))
 
 
 
 <a name="0.1.367"></a>
-## [0.1.367](https://github.com/webex/react-ciscospark/compare/v0.1.366...v0.1.367) (2018-10-08)
+## [0.1.367](https://github.com/webex/react-widgets/compare/v0.1.366...v0.1.367) (2018-10-08)
 
 
 
 <a name="0.1.366"></a>
-## [0.1.366](https://github.com/webex/react-ciscospark/compare/v0.1.365...v0.1.366) (2018-10-03)
+## [0.1.366](https://github.com/webex/react-widgets/compare/v0.1.365...v0.1.366) (2018-10-03)
 
 
 ### Features
 
-* **package:** update to latest [@collab-ui](https://github.com/collab-ui) version ([77478ca](https://github.com/webex/react-ciscospark/commit/77478ca))
-* **space-destination:** use input components from collab-ui ([0e6114d](https://github.com/webex/react-ciscospark/commit/0e6114d))
-* **token-input:** use input components from collab-ui ([17a1107](https://github.com/webex/react-ciscospark/commit/17a1107))
-* **widget-demo:** add Button component from collab-ui ([4c75b28](https://github.com/webex/react-ciscospark/commit/4c75b28))
-* **widget-demo:** add Topbar component from collab-ui ([dcbc96d](https://github.com/webex/react-ciscospark/commit/dcbc96d))
-* **widget-demos:** use updated onChange results from destination ([e792cff](https://github.com/webex/react-ciscospark/commit/e792cff))
+* **package:** update to latest [@collab-ui](https://github.com/collab-ui) version ([77478ca](https://github.com/webex/react-widgets/commit/77478ca))
+* **space-destination:** use input components from collab-ui ([0e6114d](https://github.com/webex/react-widgets/commit/0e6114d))
+* **token-input:** use input components from collab-ui ([17a1107](https://github.com/webex/react-widgets/commit/17a1107))
+* **widget-demo:** add Button component from collab-ui ([4c75b28](https://github.com/webex/react-widgets/commit/4c75b28))
+* **widget-demo:** add Topbar component from collab-ui ([dcbc96d](https://github.com/webex/react-widgets/commit/dcbc96d))
+* **widget-demos:** use updated onChange results from destination ([e792cff](https://github.com/webex/react-widgets/commit/e792cff))
 
 
 
 <a name="0.1.365"></a>
-## [0.1.365](https://github.com/webex/react-ciscospark/compare/v0.1.364...v0.1.365) (2018-10-02)
+## [0.1.365](https://github.com/webex/react-widgets/compare/v0.1.364...v0.1.365) (2018-10-02)
 
 
 
 <a name="0.1.364"></a>
-## [0.1.364](https://github.com/webex/react-ciscospark/compare/v0.1.363...v0.1.364) (2018-10-01)
+## [0.1.364](https://github.com/webex/react-widgets/compare/v0.1.363...v0.1.364) (2018-10-01)
 
 
 ### Bug Fixes
 
-* **message-composer:** export missing string constant ([98be811](https://github.com/webex/react-ciscospark/commit/98be811))
-* **r-m-activities:** add files directories to package.json ([eecfe9f](https://github.com/webex/react-ciscospark/commit/eecfe9f))
-* **spark-widget-base:** remove unused enhancers option ([dabfe19](https://github.com/webex/react-ciscospark/commit/dabfe19))
-* **widget-space:** export eventNames object ([4e3fa0d](https://github.com/webex/react-ciscospark/commit/4e3fa0d))
+* **message-composer:** export missing string constant ([98be811](https://github.com/webex/react-widgets/commit/98be811))
+* **r-m-activities:** add files directories to package.json ([eecfe9f](https://github.com/webex/react-widgets/commit/eecfe9f))
+* **spark-widget-base:** remove unused enhancers option ([dabfe19](https://github.com/webex/react-widgets/commit/dabfe19))
+* **widget-space:** export eventNames object ([4e3fa0d](https://github.com/webex/react-widgets/commit/4e3fa0d))
 
 
 ### Features
 
-* **scripts:** transpile widgets using webpack ([ee6a45c](https://github.com/webex/react-ciscospark/commit/ee6a45c))
+* **scripts:** transpile widgets using webpack ([ee6a45c](https://github.com/webex/react-widgets/commit/ee6a45c))
 
 
 
 <a name="0.1.363"></a>
-## [0.1.363](https://github.com/webex/react-ciscospark/compare/v0.1.362...v0.1.363) (2018-09-19)
+## [0.1.363](https://github.com/webex/react-widgets/compare/v0.1.362...v0.1.363) (2018-09-19)
 
 
 ### Features
 
-* **scripts:** publish all widgets except for demos ([391ed1d](https://github.com/webex/react-ciscospark/commit/391ed1d))
+* **scripts:** publish all widgets except for demos ([391ed1d](https://github.com/webex/react-widgets/commit/391ed1d))
 
 
 
 <a name="0.1.362"></a>
-## [0.1.362](https://github.com/webex/react-ciscospark/compare/v0.1.361...v0.1.362) (2018-09-18)
+## [0.1.362](https://github.com/webex/react-widgets/compare/v0.1.361...v0.1.362) (2018-09-18)
 
 
 ### Bug Fixes
 
-* **circleci:** error on multiline command doesn't fail build ([20e7346](https://github.com/webex/react-ciscospark/commit/20e7346))
+* **circleci:** error on multiline command doesn't fail build ([20e7346](https://github.com/webex/react-widgets/commit/20e7346))
 
 
 
 <a name="0.1.361"></a>
-## [0.1.361](https://github.com/webex/react-ciscospark/compare/v0.1.360...v0.1.361) (2018-09-18)
+## [0.1.361](https://github.com/webex/react-widgets/compare/v0.1.360...v0.1.361) (2018-09-18)
 
 
 
 <a name="0.1.360"></a>
-## [0.1.360](https://github.com/webex/react-ciscospark/compare/v0.1.359...v0.1.360) (2018-09-17)
+## [0.1.360](https://github.com/webex/react-widgets/compare/v0.1.359...v0.1.360) (2018-09-17)
 
 
 ### Features
 
-* **widget-meet:** use [@webex](https://github.com/webex) loading screen ([e314af1](https://github.com/webex/react-ciscospark/commit/e314af1))
-* **widget-message:** use [@webex](https://github.com/webex) loading screen ([289a24b](https://github.com/webex/react-ciscospark/commit/289a24b))
-* **widget-roster:** use [@webex](https://github.com/webex) loading screen ([72859e2](https://github.com/webex/react-ciscospark/commit/72859e2))
+* **widget-meet:** use [@webex](https://github.com/webex) loading screen ([e314af1](https://github.com/webex/react-widgets/commit/e314af1))
+* **widget-message:** use [@webex](https://github.com/webex) loading screen ([289a24b](https://github.com/webex/react-widgets/commit/289a24b))
+* **widget-roster:** use [@webex](https://github.com/webex) loading screen ([72859e2](https://github.com/webex/react-widgets/commit/72859e2))
 
 
 
 <a name="0.1.359"></a>
-## [0.1.359](https://github.com/webex/react-ciscospark/compare/v0.1.358...v0.1.359) (2018-09-17)
+## [0.1.359](https://github.com/webex/react-widgets/compare/v0.1.358...v0.1.359) (2018-09-17)
 
 
 
 <a name="0.1.358"></a>
-## [0.1.358](https://github.com/webex/react-ciscospark/compare/v0.1.357...v0.1.358) (2018-09-14)
+## [0.1.358](https://github.com/webex/react-widgets/compare/v0.1.357...v0.1.358) (2018-09-14)
 
 
 ### Bug Fixes
 
-* **r-m-media:** fix call error handling for call id ([ce3eb4f](https://github.com/webex/react-ciscospark/commit/ce3eb4f))
-* **r-m-media:** fix return type of processCall ([7c80a28](https://github.com/webex/react-ciscospark/commit/7c80a28))
-* **widget-meet:** fix call error handling ([81ec636](https://github.com/webex/react-ciscospark/commit/81ec636))
+* **r-m-media:** fix call error handling for call id ([ce3eb4f](https://github.com/webex/react-widgets/commit/ce3eb4f))
+* **r-m-media:** fix return type of processCall ([7c80a28](https://github.com/webex/react-widgets/commit/7c80a28))
+* **widget-meet:** fix call error handling ([81ec636](https://github.com/webex/react-widgets/commit/81ec636))
 
 
 
 <a name="0.1.357"></a>
-## [0.1.357](https://github.com/webex/react-ciscospark/compare/v0.1.356...v0.1.357) (2018-09-13)
+## [0.1.357](https://github.com/webex/react-widgets/compare/v0.1.356...v0.1.357) (2018-09-13)
 
 
 ### Bug Fixes
 
-* **r-m-media:** add declined flag ([da5bfa3](https://github.com/webex/react-ciscospark/commit/da5bfa3))
-* **r-m-media:** clarify call storage, correctly remove all call data ([04b4778](https://github.com/webex/react-ciscospark/commit/04b4778))
-* **r-m-media:** correct call instance mappings ([07fc4de](https://github.com/webex/react-ciscospark/commit/07fc4de))
-* **r-m-media:** incoming call states ([35df60a](https://github.com/webex/react-ciscospark/commit/35df60a))
-* **r-m-media:** media event listeners ([5fede34](https://github.com/webex/react-ciscospark/commit/5fede34))
-* **r-m-media:** remove extraneous event listeners ([c59f465](https://github.com/webex/react-ciscospark/commit/c59f465))
-* **tooling:** update circle ci config for forked branch fix ([ee20750](https://github.com/webex/react-ciscospark/commit/ee20750))
-* **widget-meet:** filter extra meeting_bridge participant ([c5ce1c4](https://github.com/webex/react-ciscospark/commit/c5ce1c4))
-* **widget-meet:** prevent infinite look with avatar fetching ([1a0e6a5](https://github.com/webex/react-ciscospark/commit/1a0e6a5))
-* **widget-message:** add last message check ([e68e820](https://github.com/webex/react-ciscospark/commit/e68e820))
-* **widget-message:** reorder call state renderers ([232e790](https://github.com/webex/react-ciscospark/commit/232e790))
-* **widget-recents:** add support for call events without roomId ([9cd595e](https://github.com/webex/react-ciscospark/commit/9cd595e))
-* **widget-recents:** check fo locus before getting space ([f076ece](https://github.com/webex/react-ciscospark/commit/f076ece))
-* **widget-recents:** clean up call events ([b42ca6c](https://github.com/webex/react-ciscospark/commit/b42ca6c))
-* **widget-recents:** in progress call indicator ([29bbf8e](https://github.com/webex/react-ciscospark/commit/29bbf8e))
-* **widget-space:** error message logic ([b47af25](https://github.com/webex/react-ciscospark/commit/b47af25))
+* **r-m-media:** add declined flag ([da5bfa3](https://github.com/webex/react-widgets/commit/da5bfa3))
+* **r-m-media:** clarify call storage, correctly remove all call data ([04b4778](https://github.com/webex/react-widgets/commit/04b4778))
+* **r-m-media:** correct call instance mappings ([07fc4de](https://github.com/webex/react-widgets/commit/07fc4de))
+* **r-m-media:** incoming call states ([35df60a](https://github.com/webex/react-widgets/commit/35df60a))
+* **r-m-media:** media event listeners ([5fede34](https://github.com/webex/react-widgets/commit/5fede34))
+* **r-m-media:** remove extraneous event listeners ([c59f465](https://github.com/webex/react-widgets/commit/c59f465))
+* **tooling:** update circle ci config for forked branch fix ([ee20750](https://github.com/webex/react-widgets/commit/ee20750))
+* **widget-meet:** filter extra meeting_bridge participant ([c5ce1c4](https://github.com/webex/react-widgets/commit/c5ce1c4))
+* **widget-meet:** prevent infinite look with avatar fetching ([1a0e6a5](https://github.com/webex/react-widgets/commit/1a0e6a5))
+* **widget-message:** add last message check ([e68e820](https://github.com/webex/react-widgets/commit/e68e820))
+* **widget-message:** reorder call state renderers ([232e790](https://github.com/webex/react-widgets/commit/232e790))
+* **widget-recents:** add support for call events without roomId ([9cd595e](https://github.com/webex/react-widgets/commit/9cd595e))
+* **widget-recents:** check fo locus before getting space ([f076ece](https://github.com/webex/react-widgets/commit/f076ece))
+* **widget-recents:** clean up call events ([b42ca6c](https://github.com/webex/react-widgets/commit/b42ca6c))
+* **widget-recents:** in progress call indicator ([29bbf8e](https://github.com/webex/react-widgets/commit/29bbf8e))
+* **widget-space:** error message logic ([b47af25](https://github.com/webex/react-widgets/commit/b47af25))
 
 
 ### Features
 
-* **widget-demo:** add pstn to demos ([672067f](https://github.com/webex/react-ciscospark/commit/672067f))
-* **widget-meet:** enable pstn calling ([87228fd](https://github.com/webex/react-ciscospark/commit/87228fd))
-* **widget-space:** default to first available initialActivity ([8045a49](https://github.com/webex/react-ciscospark/commit/8045a49))
-* **widget-space:** enable pstn calling ([f30e40c](https://github.com/webex/react-ciscospark/commit/f30e40c))
+* **widget-demo:** add pstn to demos ([672067f](https://github.com/webex/react-widgets/commit/672067f))
+* **widget-meet:** enable pstn calling ([87228fd](https://github.com/webex/react-widgets/commit/87228fd))
+* **widget-space:** default to first available initialActivity ([8045a49](https://github.com/webex/react-widgets/commit/8045a49))
+* **widget-space:** enable pstn calling ([f30e40c](https://github.com/webex/react-widgets/commit/f30e40c))
 
 
 
 <a name="0.1.356"></a>
-## [0.1.356](https://github.com/webex/react-ciscospark/compare/v0.1.355...v0.1.356) (2018-09-13)
+## [0.1.356](https://github.com/webex/react-widgets/compare/v0.1.355...v0.1.356) (2018-09-13)
 
 
 ### Bug Fixes
 
-* **tap:** cannot use nvm with prefix error ([3843fb6](https://github.com/webex/react-ciscospark/commit/3843fb6))
+* **tap:** cannot use nvm with prefix error ([3843fb6](https://github.com/webex/react-widgets/commit/3843fb6))
 
 
 
 <a name="0.1.355"></a>
-## [0.1.355](https://github.com/webex/react-ciscospark/compare/v0.1.354...v0.1.355) (2018-09-12)
+## [0.1.355](https://github.com/webex/react-widgets/compare/v0.1.354...v0.1.355) (2018-09-12)
 
 
 
 <a name="0.1.354"></a>
-## [0.1.354](https://github.com/webex/react-ciscospark/compare/v0.1.353...v0.1.354) (2018-09-11)
+## [0.1.354](https://github.com/webex/react-widgets/compare/v0.1.353...v0.1.354) (2018-09-11)
 
 
 ### Bug Fixes
 
-* **wdio:** remove incorrect destructuring ([f729813](https://github.com/webex/react-ciscospark/commit/f729813))
+* **wdio:** remove incorrect destructuring ([f729813](https://github.com/webex/react-widgets/commit/f729813))
 
 
 
 <a name="0.1.353"></a>
-## [0.1.353](https://github.com/webex/react-ciscospark/compare/v0.1.352...v0.1.353) (2018-09-11)
+## [0.1.353](https://github.com/webex/react-widgets/compare/v0.1.352...v0.1.353) (2018-09-11)
 
 
 
 <a name="0.1.352"></a>
-## [0.1.352](https://github.com/webex/react-ciscospark/compare/v0.1.351...v0.1.352) (2018-09-10)
+## [0.1.352](https://github.com/webex/react-widgets/compare/v0.1.351...v0.1.352) (2018-09-10)
 
 
 
 <a name="0.1.351"></a>
-## [0.1.351](https://github.com/webex/react-ciscospark/compare/v0.1.350...v0.1.351) (2018-09-07)
+## [0.1.351](https://github.com/webex/react-widgets/compare/v0.1.350...v0.1.351) (2018-09-07)
 
 
 ### Features
 
-* **r-m-conversation:** add support for giphy activities ([6a59951](https://github.com/webex/react-ciscospark/commit/6a59951))
+* **r-m-conversation:** add support for giphy activities ([6a59951](https://github.com/webex/react-widgets/commit/6a59951))
 
 
 
 <a name="0.1.350"></a>
-## [0.1.350](https://github.com/webex/react-ciscospark/compare/v0.1.349...v0.1.350) (2018-09-05)
+## [0.1.350](https://github.com/webex/react-widgets/compare/v0.1.349...v0.1.350) (2018-09-05)
 
 
 ### Bug Fixes
 
-* **demo:** use correct activities property name ([d411231](https://github.com/webex/react-ciscospark/commit/d411231))
-* **r-m-conversation:** apply proper update content filter ([b0996d2](https://github.com/webex/react-ciscospark/commit/b0996d2))
+* **demo:** use correct activities property name ([d411231](https://github.com/webex/react-widgets/commit/d411231))
+* **r-m-conversation:** apply proper update content filter ([b0996d2](https://github.com/webex/react-widgets/commit/b0996d2))
 
 
 
 <a name="0.1.349"></a>
-## [0.1.349](https://github.com/webex/react-ciscospark/compare/v0.1.348...v0.1.349) (2018-09-04)
+## [0.1.349](https://github.com/webex/react-widgets/compare/v0.1.348...v0.1.349) (2018-09-04)
 
 
 
 <a name="0.1.348"></a>
-## [0.1.348](https://github.com/webex/react-ciscospark/compare/v0.1.347...v0.1.348) (2018-08-31)
+## [0.1.348](https://github.com/webex/react-widgets/compare/v0.1.347...v0.1.348) (2018-08-31)
 
 
 
 <a name="0.1.347"></a>
-## [0.1.347](https://github.com/webex/react-ciscospark/compare/v0.1.346...v0.1.347) (2018-08-27)
+## [0.1.347](https://github.com/webex/react-widgets/compare/v0.1.346...v0.1.347) (2018-08-27)
 
 
 ### Bug Fixes
 
-* **widget-space:** cannot place call with direct room id ([98d66aa](https://github.com/webex/react-ciscospark/commit/98d66aa))
+* **widget-space:** cannot place call with direct room id ([98d66aa](https://github.com/webex/react-widgets/commit/98d66aa))
 
 
 
 <a name="0.1.346"></a>
-## [0.1.346](https://github.com/webex/react-ciscospark/compare/v0.1.345...v0.1.346) (2018-08-23)
+## [0.1.346](https://github.com/webex/react-widgets/compare/v0.1.345...v0.1.346) (2018-08-23)
 
 
 ### Bug Fixes
 
-* **tap:** fix config prefix error ([d9ad41f](https://github.com/webex/react-ciscospark/commit/d9ad41f))
+* **tap:** fix config prefix error ([d9ad41f](https://github.com/webex/react-widgets/commit/d9ad41f))
 
 
 
 <a name="0.1.345"></a>
-## [0.1.345](https://github.com/webex/react-ciscospark/compare/v0.1.344...v0.1.345) (2018-08-23)
+## [0.1.345](https://github.com/webex/react-widgets/compare/v0.1.344...v0.1.345) (2018-08-23)
 
 
 ### Bug Fixes
 
-* **tap:** clear cookies after tests ([0097c7b](https://github.com/webex/react-ciscospark/commit/0097c7b))
+* **tap:** clear cookies after tests ([0097c7b](https://github.com/webex/react-widgets/commit/0097c7b))
 
 
 
 <a name="0.1.344"></a>
-## [0.1.344](https://github.com/webex/react-ciscospark/compare/v0.1.343...v0.1.344) (2018-08-23)
+## [0.1.344](https://github.com/webex/react-widgets/compare/v0.1.343...v0.1.344) (2018-08-23)
 
 
 ### Bug Fixes
 
-* **tap:** update aria label to fix tap test ([c982bb5](https://github.com/webex/react-ciscospark/commit/c982bb5))
+* **tap:** update aria label to fix tap test ([c982bb5](https://github.com/webex/react-widgets/commit/c982bb5))
 
 
 
 <a name="0.1.343"></a>
-## [0.1.343](https://github.com/webex/react-ciscospark/compare/v0.1.342...v0.1.343) (2018-08-22)
+## [0.1.343](https://github.com/webex/react-widgets/compare/v0.1.342...v0.1.343) (2018-08-22)
 
 
 ### Bug Fixes
 
-* **jest:** remove nonexistent root path ([4abcde5](https://github.com/webex/react-ciscospark/commit/4abcde5))
+* **jest:** remove nonexistent root path ([4abcde5](https://github.com/webex/react-widgets/commit/4abcde5))
 
 
 ### Features
 
-* **activity-list:** remove new line stripping ([c39a56d](https://github.com/webex/react-ciscospark/commit/c39a56d))
-* **r-m-activity:** add smart newline handling ([80b26d7](https://github.com/webex/react-ciscospark/commit/80b26d7))
+* **activity-list:** remove new line stripping ([c39a56d](https://github.com/webex/react-widgets/commit/c39a56d))
+* **r-m-activity:** add smart newline handling ([80b26d7](https://github.com/webex/react-widgets/commit/80b26d7))
 
 
 
 <a name="0.1.342"></a>
-## [0.1.342](https://github.com/webex/react-ciscospark/compare/v0.1.341...v0.1.342) (2018-08-15)
+## [0.1.342](https://github.com/webex/react-widgets/compare/v0.1.341...v0.1.342) (2018-08-15)
 
 
 ### Features
 
-* **widget-demo:** add sip calling ([d599d80](https://github.com/webex/react-ciscospark/commit/d599d80))
+* **widget-demo:** add sip calling ([d599d80](https://github.com/webex/react-widgets/commit/d599d80))
 
 
 
 <a name="0.1.341"></a>
-## [0.1.341](https://github.com/webex/react-ciscospark/compare/v0.1.340...v0.1.341) (2018-08-15)
+## [0.1.341](https://github.com/webex/react-widgets/compare/v0.1.340...v0.1.341) (2018-08-15)
 
 
 ### Bug Fixes
 
-* **r-m-activities:** add check for actor field ([2bcbeb0](https://github.com/webex/react-ciscospark/commit/2bcbeb0))
+* **r-m-activities:** add check for actor field ([2bcbeb0](https://github.com/webex/react-widgets/commit/2bcbeb0))
 
 
 ### Features
 
-* **widget-meet:** enable sip calling ([ff6061a](https://github.com/webex/react-ciscospark/commit/ff6061a))
-* **widget-space:** enable sip calling ([ff540c6](https://github.com/webex/react-ciscospark/commit/ff540c6))
+* **widget-meet:** enable sip calling ([ff6061a](https://github.com/webex/react-widgets/commit/ff6061a))
+* **widget-space:** enable sip calling ([ff540c6](https://github.com/webex/react-widgets/commit/ff540c6))
 
 
 
 <a name="0.1.340"></a>
-## [0.1.340](https://github.com/webex/react-ciscospark/compare/v0.1.339...v0.1.340) (2018-08-15)
+## [0.1.340](https://github.com/webex/react-widgets/compare/v0.1.339...v0.1.340) (2018-08-15)
 
 
 ### Bug Fixes
 
-* **token-input:** update aria labels to match previous use ([170e066](https://github.com/webex/react-ciscospark/commit/170e066))
+* **token-input:** update aria labels to match previous use ([170e066](https://github.com/webex/react-widgets/commit/170e066))
 
 
 
 <a name="0.1.339"></a>
-## [0.1.339](https://github.com/webex/react-ciscospark/compare/v0.1.338...v0.1.339) (2018-08-14)
+## [0.1.339](https://github.com/webex/react-widgets/compare/v0.1.338...v0.1.339) (2018-08-14)
 
 
 ### Bug Fixes
 
-* **activity-system-message:** remove incorrect required prop ([32c7831](https://github.com/webex/react-ciscospark/commit/32c7831))
+* **activity-system-message:** remove incorrect required prop ([32c7831](https://github.com/webex/react-widgets/commit/32c7831))
 
 
 ### Features
 
-* **message:** use convo loading status ([ee1b811](https://github.com/webex/react-ciscospark/commit/ee1b811))
-* **r-m-conversation:** filter update content activities from store ([7a5ae62](https://github.com/webex/react-ciscospark/commit/7a5ae62))
+* **message:** use convo loading status ([ee1b811](https://github.com/webex/react-widgets/commit/ee1b811))
+* **r-m-conversation:** filter update content activities from store ([7a5ae62](https://github.com/webex/react-widgets/commit/7a5ae62))
 
 
 
 <a name="0.1.338"></a>
-## [0.1.338](https://github.com/webex/react-ciscospark/compare/v0.1.337...v0.1.338) (2018-08-14)
+## [0.1.338](https://github.com/webex/react-widgets/compare/v0.1.337...v0.1.338) (2018-08-14)
 
 
 ### Bug Fixes
 
-* **react-component-activity-share-file:** missing file download button ([88cc125](https://github.com/webex/react-ciscospark/commit/88cc125))
+* **react-component-activity-share-file:** missing file download button ([88cc125](https://github.com/webex/react-widgets/commit/88cc125))
 
 
 
 <a name="0.1.337"></a>
-## [0.1.337](https://github.com/webex/react-ciscospark/compare/v0.1.336...v0.1.337) (2018-08-13)
+## [0.1.337](https://github.com/webex/react-widgets/compare/v0.1.336...v0.1.337) (2018-08-13)
 
 
 ### Features
 
-* **recents-demo:** use TokenInput component ([ef806e1](https://github.com/webex/react-ciscospark/commit/ef806e1))
-* **space-demo:** use TokenInput and SpaceDestination components ([05abd3f](https://github.com/webex/react-ciscospark/commit/05abd3f))
-* **space-destination:** add space destination component for demos ([7247dd0](https://github.com/webex/react-ciscospark/commit/7247dd0))
-* **token-input:** add token input component for demos ([a8f6ce0](https://github.com/webex/react-ciscospark/commit/a8f6ce0))
-* **widget-demo:** use new shared token input component ([bb951ee](https://github.com/webex/react-ciscospark/commit/bb951ee))
-* **widget-demo:** use space destination component ([cf946f1](https://github.com/webex/react-ciscospark/commit/cf946f1))
+* **recents-demo:** use TokenInput component ([ef806e1](https://github.com/webex/react-widgets/commit/ef806e1))
+* **space-demo:** use TokenInput and SpaceDestination components ([05abd3f](https://github.com/webex/react-widgets/commit/05abd3f))
+* **space-destination:** add space destination component for demos ([7247dd0](https://github.com/webex/react-widgets/commit/7247dd0))
+* **token-input:** add token input component for demos ([a8f6ce0](https://github.com/webex/react-widgets/commit/a8f6ce0))
+* **widget-demo:** use new shared token input component ([bb951ee](https://github.com/webex/react-widgets/commit/bb951ee))
+* **widget-demo:** use space destination component ([cf946f1](https://github.com/webex/react-widgets/commit/cf946f1))
 
 
 
 <a name="0.1.336"></a>
-## [0.1.336](https://github.com/webex/react-ciscospark/compare/v0.1.335...v0.1.336) (2018-08-13)
+## [0.1.336](https://github.com/webex/react-widgets/compare/v0.1.335...v0.1.336) (2018-08-13)
 
 
 ### Bug Fixes
 
-* **widget-meet:** prevent portrait video from hiding controls ([959e082](https://github.com/webex/react-ciscospark/commit/959e082))
-* **widget-recents:** re-add missing event fields ([3d314a9](https://github.com/webex/react-ciscospark/commit/3d314a9))
+* **widget-meet:** prevent portrait video from hiding controls ([959e082](https://github.com/webex/react-widgets/commit/959e082))
+* **widget-recents:** re-add missing event fields ([3d314a9](https://github.com/webex/react-widgets/commit/3d314a9))
 
 
 
 <a name="0.1.335"></a>
-## [0.1.335](https://github.com/webex/react-ciscospark/compare/v0.1.334...v0.1.335) (2018-08-10)
+## [0.1.335](https://github.com/webex/react-widgets/compare/v0.1.334...v0.1.335) (2018-08-10)
 
 
 ### Bug Fixes
 
-* **widget-meet:** Render error page when webrtc isn't supported ([c5728cb](https://github.com/webex/react-ciscospark/commit/c5728cb))
+* **widget-meet:** Render error page when webrtc isn't supported ([c5728cb](https://github.com/webex/react-widgets/commit/c5728cb))
 
 
 ### Features
 
-* **redux-module-activities:** Add delete/tombstone action ([d45abc5](https://github.com/webex/react-ciscospark/commit/d45abc5))
+* **redux-module-activities:** Add delete/tombstone action ([d45abc5](https://github.com/webex/react-widgets/commit/d45abc5))
 
 
 
 <a name="0.1.334"></a>
-## [0.1.334](https://github.com/webex/react-ciscospark/compare/v0.1.333...v0.1.334) (2018-08-07)
+## [0.1.334](https://github.com/webex/react-widgets/compare/v0.1.333...v0.1.334) (2018-08-07)
 
 
 
 <a name="0.1.333"></a>
-## [0.1.333](https://github.com/webex/react-ciscospark/compare/v0.1.332...v0.1.333) (2018-08-07)
+## [0.1.333](https://github.com/webex/react-widgets/compare/v0.1.332...v0.1.333) (2018-08-07)
 
 
 ### Bug Fixes
 
-* **widget-recents:** order of loading enhancers ([b47df2b](https://github.com/webex/react-ciscospark/commit/b47df2b))
+* **widget-recents:** order of loading enhancers ([b47df2b](https://github.com/webex/react-widgets/commit/b47df2b))
 
 
 
 <a name="0.1.332"></a>
-## [0.1.332](https://github.com/webex/react-ciscospark/compare/v0.1.331...v0.1.332) (2018-08-07)
+## [0.1.332](https://github.com/webex/react-widgets/compare/v0.1.331...v0.1.332) (2018-08-07)
 
 
 
 <a name="0.1.331"></a>
-## [0.1.331](https://github.com/webex/react-ciscospark/compare/v0.1.330...v0.1.331) (2018-08-06)
+## [0.1.331](https://github.com/webex/react-widgets/compare/v0.1.330...v0.1.331) (2018-08-06)
 
 
 ### Features
 
-* **redux-module-media:** ignore inactive created calls ([2b35ae3](https://github.com/webex/react-ciscospark/commit/2b35ae3))
+* **redux-module-media:** ignore inactive created calls ([2b35ae3](https://github.com/webex/react-widgets/commit/2b35ae3))
 
 
 
 <a name="0.1.330"></a>
-## [0.1.330](https://github.com/webex/react-ciscospark/compare/v0.1.329...v0.1.330) (2018-08-06)
+## [0.1.330](https://github.com/webex/react-widgets/compare/v0.1.329...v0.1.330) (2018-08-06)
 
 
 
 <a name="0.1.329"></a>
-## [0.1.329](https://github.com/webex/react-ciscospark/compare/v0.1.328...v0.1.329) (2018-08-03)
+## [0.1.329](https://github.com/webex/react-widgets/compare/v0.1.328...v0.1.329) (2018-08-03)
 
 
 ### Bug Fixes
 
-* **widget-space:** only auto switch to message/meet when available ([e7eb805](https://github.com/webex/react-ciscospark/commit/e7eb805))
-* **widget-space:** use call start time from call object ([fa6e9ed](https://github.com/webex/react-ciscospark/commit/fa6e9ed))
+* **widget-space:** only auto switch to message/meet when available ([e7eb805](https://github.com/webex/react-widgets/commit/e7eb805))
+* **widget-space:** use call start time from call object ([fa6e9ed](https://github.com/webex/react-widgets/commit/fa6e9ed))
 
 
 ### Features
 
-* **r-m-media:** store locus id for destination when known ([33940d7](https://github.com/webex/react-ciscospark/commit/33940d7))
-* **widget-space:** fetch call by destination if convo not available ([3ed6af3](https://github.com/webex/react-ciscospark/commit/3ed6af3))
-* **widget-space:** generate spaceDetails prop without conversation ([38401dc](https://github.com/webex/react-ciscospark/commit/38401dc))
+* **r-m-media:** store locus id for destination when known ([33940d7](https://github.com/webex/react-widgets/commit/33940d7))
+* **widget-space:** fetch call by destination if convo not available ([3ed6af3](https://github.com/webex/react-widgets/commit/3ed6af3))
+* **widget-space:** generate spaceDetails prop without conversation ([38401dc](https://github.com/webex/react-widgets/commit/38401dc))
 
 
 
 <a name="0.1.328"></a>
-## [0.1.328](https://github.com/webex/react-ciscospark/compare/v0.1.327...v0.1.328) (2018-08-01)
+## [0.1.328](https://github.com/webex/react-widgets/compare/v0.1.327...v0.1.328) (2018-08-01)
 
 
 ### Bug Fixes
 
-* **README:** update circle build status link ([8665781](https://github.com/webex/react-ciscospark/commit/8665781))
+* **README:** update circle build status link ([8665781](https://github.com/webex/react-widgets/commit/8665781))
 
 
 
 <a name="0.1.327"></a>
-## [0.1.327](https://github.com/webex/react-ciscospark/compare/v0.1.326...v0.1.327) (2018-08-01)
+## [0.1.327](https://github.com/webex/react-widgets/compare/v0.1.326...v0.1.327) (2018-08-01)
 
 
 ### Bug Fixes
 
-* **tooling:** use proper shell result for git commands ([6e2cdbd](https://github.com/webex/react-ciscospark/commit/6e2cdbd))
+* **tooling:** use proper shell result for git commands ([6e2cdbd](https://github.com/webex/react-widgets/commit/6e2cdbd))
 
 
 
 <a name="0.1.326"></a>
-## [0.1.326](https://github.com/webex/react-ciscospark/compare/v0.1.325...v0.1.326) (2018-08-01)
+## [0.1.326](https://github.com/webex/react-widgets/compare/v0.1.325...v0.1.326) (2018-08-01)
 
 
 
 <a name="0.1.325"></a>
-## [0.1.325](https://github.com/webex/react-ciscospark/compare/v0.1.324...v0.1.325) (2018-08-01)
+## [0.1.325](https://github.com/webex/react-widgets/compare/v0.1.324...v0.1.325) (2018-08-01)
 
 
 ### Features
 
-* **widget-demo:** add initial activity setting ([497aacb](https://github.com/webex/react-ciscospark/commit/497aacb))
-* **widget-demo:** save activities and initialActivity in cookies ([d038863](https://github.com/webex/react-ciscospark/commit/d038863))
-* **widget-space-demo:** add initial activity setting ([3106a7f](https://github.com/webex/react-ciscospark/commit/3106a7f))
-* **widget-space-demo:** save activities and initialActivity in cookies ([78730fa](https://github.com/webex/react-ciscospark/commit/78730fa))
+* **widget-demo:** add initial activity setting ([497aacb](https://github.com/webex/react-widgets/commit/497aacb))
+* **widget-demo:** save activities and initialActivity in cookies ([d038863](https://github.com/webex/react-widgets/commit/d038863))
+* **widget-space-demo:** add initial activity setting ([3106a7f](https://github.com/webex/react-widgets/commit/3106a7f))
+* **widget-space-demo:** save activities and initialActivity in cookies ([78730fa](https://github.com/webex/react-widgets/commit/78730fa))
 
 
 
 <a name="0.1.324"></a>
-## [0.1.324](https://github.com/webex/react-ciscospark/compare/v0.1.323...v0.1.324) (2018-07-31)
+## [0.1.324](https://github.com/webex/react-widgets/compare/v0.1.323...v0.1.324) (2018-07-31)
 
 
 ### Features
 
-* **widget-recents:** use new avatar design ([f9a5ba4](https://github.com/webex/react-ciscospark/commit/f9a5ba4))
+* **widget-recents:** use new avatar design ([f9a5ba4](https://github.com/webex/react-widgets/commit/f9a5ba4))
 
 
 
 <a name="0.1.323"></a>
-## [0.1.323](https://github.com/webex/react-ciscospark/compare/v0.1.322...v0.1.323) (2018-07-31)
+## [0.1.323](https://github.com/webex/react-widgets/compare/v0.1.322...v0.1.323) (2018-07-31)
 
 
 ### Bug Fixes
 
-* **tooling:** remove node_modules folder before installing ([e39337d](https://github.com/webex/react-ciscospark/commit/e39337d))
+* **tooling:** remove node_modules folder before installing ([e39337d](https://github.com/webex/react-widgets/commit/e39337d))
 
 
 
 <a name="0.1.322"></a>
-## [0.1.322](https://github.com/webex/react-ciscospark/compare/v0.1.321...v0.1.322) (2018-07-31)
+## [0.1.322](https://github.com/webex/react-widgets/compare/v0.1.321...v0.1.322) (2018-07-31)
 
 
 
 <a name="0.1.321"></a>
-## [0.1.321](https://github.com/webex/react-ciscospark/compare/v0.1.320...v0.1.321) (2018-07-16)
+## [0.1.321](https://github.com/webex/react-widgets/compare/v0.1.320...v0.1.321) (2018-07-16)
 
 
 ### Features
 
-* **widget-space:** use new webex teams loading screen ([f294ba3](https://github.com/webex/react-ciscospark/commit/f294ba3))
+* **widget-space:** use new webex teams loading screen ([f294ba3](https://github.com/webex/react-widgets/commit/f294ba3))
 
 
 
 <a name="0.1.320"></a>
-## [0.1.320](https://github.com/webex/react-ciscospark/compare/v0.1.319...v0.1.320) (2018-07-16)
+## [0.1.320](https://github.com/webex/react-widgets/compare/v0.1.319...v0.1.320) (2018-07-16)
 
 
 ### Features
 
-* **widget-recents:** use new webex teams loading screen ([4dc52e3](https://github.com/webex/react-ciscospark/commit/4dc52e3))
+* **widget-recents:** use new webex teams loading screen ([4dc52e3](https://github.com/webex/react-widgets/commit/4dc52e3))
 
 
 
 <a name="0.1.319"></a>
-## [0.1.319](https://github.com/webex/react-ciscospark/compare/v0.1.318...v0.1.319) (2018-07-12)
+## [0.1.319](https://github.com/webex/react-widgets/compare/v0.1.318...v0.1.319) (2018-07-12)
 
 
 
 <a name="0.1.318"></a>
-## [0.1.318](https://github.com/webex/react-ciscospark/compare/v0.1.317...v0.1.318) (2018-07-11)
+## [0.1.318](https://github.com/webex/react-widgets/compare/v0.1.317...v0.1.318) (2018-07-11)
 
 
 
 <a name="0.1.317"></a>
-## [0.1.317](https://github.com/webex/react-ciscospark/compare/v0.1.316...v0.1.317) (2018-07-10)
+## [0.1.317](https://github.com/webex/react-widgets/compare/v0.1.316...v0.1.317) (2018-07-10)
 
 
 ### Features
 
-* **webex-loading:** create new loading screen component ([1363c97](https://github.com/webex/react-ciscospark/commit/1363c97))
+* **webex-loading:** create new loading screen component ([1363c97](https://github.com/webex/react-widgets/commit/1363c97))
 
 
 
 <a name="0.1.316"></a>
-## [0.1.316](https://github.com/webex/react-ciscospark/compare/v0.1.315...v0.1.316) (2018-07-09)
+## [0.1.316](https://github.com/webex/react-widgets/compare/v0.1.315...v0.1.316) (2018-07-09)
 
 
 ### Bug Fixes
 
-* **widget-space:** update sdk version, fix firefox calling ([cde50e4](https://github.com/webex/react-ciscospark/commit/cde50e4))
+* **widget-space:** update sdk version, fix firefox calling ([cde50e4](https://github.com/webex/react-widgets/commit/cde50e4))
 
 
 
 <a name="0.1.315"></a>
-## [0.1.315](https://github.com/webex/react-ciscospark/compare/v0.1.314...v0.1.315) (2018-07-09)
+## [0.1.315](https://github.com/webex/react-widgets/compare/v0.1.314...v0.1.315) (2018-07-09)
 
 
 ### Features
 
-* **module-conversation:** add reset conversation action ([e1ab8b9](https://github.com/webex/react-ciscospark/commit/e1ab8b9))
-* **module-errors:** add reset errors action ([09d3bfb](https://github.com/webex/react-ciscospark/commit/09d3bfb))
-* **redux-module-users:** export immutable records for testing ([2421332](https://github.com/webex/react-ciscospark/commit/2421332))
-* **widget-demo:** use react component for space widget ([cb10fc2](https://github.com/webex/react-ciscospark/commit/cb10fc2))
-* **widget-message:** reset widget on destination change ([78e26bc](https://github.com/webex/react-ciscospark/commit/78e26bc))
-* **widget-space:** reload widget on destination change ([188d6f6](https://github.com/webex/react-ciscospark/commit/188d6f6))
+* **module-conversation:** add reset conversation action ([e1ab8b9](https://github.com/webex/react-widgets/commit/e1ab8b9))
+* **module-errors:** add reset errors action ([09d3bfb](https://github.com/webex/react-widgets/commit/09d3bfb))
+* **redux-module-users:** export immutable records for testing ([2421332](https://github.com/webex/react-widgets/commit/2421332))
+* **widget-demo:** use react component for space widget ([cb10fc2](https://github.com/webex/react-widgets/commit/cb10fc2))
+* **widget-message:** reset widget on destination change ([78e26bc](https://github.com/webex/react-widgets/commit/78e26bc))
+* **widget-space:** reload widget on destination change ([188d6f6](https://github.com/webex/react-widgets/commit/188d6f6))
 
 
 
 <a name="0.1.314"></a>
-## [0.1.314](https://github.com/webex/react-ciscospark/compare/v0.1.313...v0.1.314) (2018-07-05)
+## [0.1.314](https://github.com/webex/react-widgets/compare/v0.1.313...v0.1.314) (2018-07-05)
 
 
 ### Bug Fixes
 
-* **activity-system-message:** remove incorrect isRequired from props ([d9250c9](https://github.com/webex/react-ciscospark/commit/d9250c9))
-* **day-separator:** add correct prop type ([58285ee](https://github.com/webex/react-ciscospark/commit/58285ee))
+* **activity-system-message:** remove incorrect isRequired from props ([d9250c9](https://github.com/webex/react-widgets/commit/d9250c9))
+* **day-separator:** add correct prop type ([58285ee](https://github.com/webex/react-widgets/commit/58285ee))
 
 
 
 <a name="0.1.313"></a>
-## [0.1.313](https://github.com/webex/react-ciscospark/compare/v0.1.312...v0.1.313) (2018-06-29)
+## [0.1.313](https://github.com/webex/react-widgets/compare/v0.1.312...v0.1.313) (2018-06-29)
 
 
 ### Bug Fixes
 
-* **tooling:** cannot run journey tests locally ([2263166](https://github.com/webex/react-ciscospark/commit/2263166))
+* **tooling:** cannot run journey tests locally ([2263166](https://github.com/webex/react-widgets/commit/2263166))
 
 
 ### Features
 
-* **module-users:** use uuid for all user ids ([a450c54](https://github.com/webex/react-ciscospark/commit/a450c54))
-* **widget-demo:** add destination support ([c3a6857](https://github.com/webex/react-ciscospark/commit/c3a6857))
-* **widget-meet:** add destination support ([b0f3ffe](https://github.com/webex/react-ciscospark/commit/b0f3ffe))
-* **widget-message:** add destination prop support ([5d44ac3](https://github.com/webex/react-ciscospark/commit/5d44ac3))
-* **widget-space:** add destination prop ([67a4a0b](https://github.com/webex/react-ciscospark/commit/67a4a0b))
-* **widget-space-demo:** update props to destination ([9912b71](https://github.com/webex/react-ciscospark/commit/9912b71))
+* **module-users:** use uuid for all user ids ([a450c54](https://github.com/webex/react-widgets/commit/a450c54))
+* **widget-demo:** add destination support ([c3a6857](https://github.com/webex/react-widgets/commit/c3a6857))
+* **widget-meet:** add destination support ([b0f3ffe](https://github.com/webex/react-widgets/commit/b0f3ffe))
+* **widget-message:** add destination prop support ([5d44ac3](https://github.com/webex/react-widgets/commit/5d44ac3))
+* **widget-space:** add destination prop ([67a4a0b](https://github.com/webex/react-widgets/commit/67a4a0b))
+* **widget-space-demo:** update props to destination ([9912b71](https://github.com/webex/react-widgets/commit/9912b71))
 
 
 
 <a name="0.1.312"></a>
-## [0.1.312](https://github.com/webex/react-ciscospark/compare/v0.1.311...v0.1.312) (2018-06-21)
+## [0.1.312](https://github.com/webex/react-widgets/compare/v0.1.311...v0.1.312) (2018-06-21)
 
 
 ### Bug Fixes
 
-* **tooling:** featureFlag.js is in suite definitions ([1e536b1](https://github.com/webex/react-ciscospark/commit/1e536b1))
-* **widget-space:** does not verify default activity is not disabled if initial activity is not set ([eeb05e3](https://github.com/webex/react-ciscospark/commit/eeb05e3))
+* **tooling:** featureFlag.js is in suite definitions ([1e536b1](https://github.com/webex/react-widgets/commit/1e536b1))
+* **widget-space:** does not verify default activity is not disabled if initial activity is not set ([eeb05e3](https://github.com/webex/react-widgets/commit/eeb05e3))
 
 
 ### Features
 
-* **widget-space-demo:** add option to disable default activities ([abd1b39](https://github.com/webex/react-ciscospark/commit/abd1b39))
+* **widget-space-demo:** add option to disable default activities ([abd1b39](https://github.com/webex/react-widgets/commit/abd1b39))
 
 
 
 <a name="0.1.311"></a>
-## [0.1.311](https://github.com/webex/react-ciscospark/compare/v0.1.310...v0.1.311) (2018-06-20)
+## [0.1.311](https://github.com/webex/react-widgets/compare/v0.1.310...v0.1.311) (2018-06-20)
 
 
 ### Features
 
-* **widget-space:** allow default overrides in activity menu ([e34377b](https://github.com/webex/react-ciscospark/commit/e34377b))
+* **widget-space:** allow default overrides in activity menu ([e34377b](https://github.com/webex/react-widgets/commit/e34377b))
 
 
 
 <a name="0.1.310"></a>
-## [0.1.310](https://github.com/webex/react-ciscospark/compare/v0.1.309...v0.1.310) (2018-06-14)
+## [0.1.310](https://github.com/webex/react-widgets/compare/v0.1.309...v0.1.310) (2018-06-14)
 
 
 ### Features
 
-* **all:** remove group calling feature flag ([dc3d285](https://github.com/webex/react-ciscospark/commit/dc3d285))
-* **all:** remove roster feature flag ([aff906d](https://github.com/webex/react-ciscospark/commit/aff906d))
-* **widget-message:** remove mentions feature flag ([46a8e81](https://github.com/webex/react-ciscospark/commit/46a8e81))
+* **all:** remove group calling feature flag ([dc3d285](https://github.com/webex/react-widgets/commit/dc3d285))
+* **all:** remove roster feature flag ([aff906d](https://github.com/webex/react-widgets/commit/aff906d))
+* **widget-message:** remove mentions feature flag ([46a8e81](https://github.com/webex/react-widgets/commit/46a8e81))
 
 
 
 <a name="0.1.309"></a>
-## [0.1.309](https://github.com/webex/react-ciscospark/compare/v0.1.308...v0.1.309) (2018-06-13)
+## [0.1.309](https://github.com/webex/react-widgets/compare/v0.1.308...v0.1.309) (2018-06-13)
 
 
 ### Bug Fixes
 
-* **r-c-activity-item-base:** delete message button not displayed for long messages ([caed5eb](https://github.com/webex/react-ciscospark/commit/caed5eb))
+* **r-c-activity-item-base:** delete message button not displayed for long messages ([caed5eb](https://github.com/webex/react-widgets/commit/caed5eb))
 
 
 
 <a name="0.1.308"></a>
-## [0.1.308](https://github.com/webex/react-ciscospark/compare/v0.1.307...v0.1.308) (2018-06-12)
+## [0.1.308](https://github.com/webex/react-widgets/compare/v0.1.307...v0.1.308) (2018-06-12)
 
 
 
 <a name="0.1.307"></a>
-## [0.1.307](https://github.com/webex/react-ciscospark/compare/v0.1.306...v0.1.307) (2018-06-11)
+## [0.1.307](https://github.com/webex/react-widgets/compare/v0.1.306...v0.1.307) (2018-06-11)
 
 
 ### Bug Fixes
 
-* **icon:** add missing download icon ([3f11f7f](https://github.com/webex/react-ciscospark/commit/3f11f7f))
+* **icon:** add missing download icon ([3f11f7f](https://github.com/webex/react-widgets/commit/3f11f7f))
 
 
 ### Features
 
-* **samples:** add download icon ([2d49de7](https://github.com/webex/react-ciscospark/commit/2d49de7))
+* **samples:** add download icon ([2d49de7](https://github.com/webex/react-widgets/commit/2d49de7))
 
 
 
 <a name="0.1.306"></a>
-## [0.1.306](https://github.com/webex/react-ciscospark/compare/v0.1.305...v0.1.306) (2018-06-11)
+## [0.1.306](https://github.com/webex/react-widgets/compare/v0.1.305...v0.1.306) (2018-06-11)
 
 
 
 <a name="0.1.305"></a>
-## [0.1.305](https://github.com/webex/react-ciscospark/compare/v0.1.304...v0.1.305) (2018-06-05)
+## [0.1.305](https://github.com/webex/react-widgets/compare/v0.1.304...v0.1.305) (2018-06-05)
 
 
 ### Bug Fixes
 
-* **widget-roster:** external participant message height and width are not specified ([da54601](https://github.com/webex/react-ciscospark/commit/da54601))
-* **widget-roster:** get proper loading state of search ([7e6cb97](https://github.com/webex/react-ciscospark/commit/7e6cb97))
+* **widget-roster:** external participant message height and width are not specified ([da54601](https://github.com/webex/react-widgets/commit/da54601))
+* **widget-roster:** get proper loading state of search ([7e6cb97](https://github.com/webex/react-widgets/commit/7e6cb97))
 
 
 ### Features
 
-* **react-component-people-list:** use react-virtualized for rendering people list ([e60c566](https://github.com/webex/react-ciscospark/commit/e60c566))
-* **widget-message:** load avatars from activities list ([befaf9e](https://github.com/webex/react-ciscospark/commit/befaf9e))
+* **react-component-people-list:** use react-virtualized for rendering people list ([e60c566](https://github.com/webex/react-widgets/commit/e60c566))
+* **widget-message:** load avatars from activities list ([befaf9e](https://github.com/webex/react-widgets/commit/befaf9e))
 
 
 
 <a name="0.1.304"></a>
-## [0.1.304](https://github.com/webex/react-ciscospark/compare/v0.1.303...v0.1.304) (2018-06-01)
+## [0.1.304](https://github.com/webex/react-widgets/compare/v0.1.303...v0.1.304) (2018-06-01)
 
 
 
 <a name="0.1.303"></a>
-## [0.1.303](https://github.com/webex/react-ciscospark/compare/v0.1.302...v0.1.303) (2018-05-24)
+## [0.1.303](https://github.com/webex/react-widgets/compare/v0.1.302...v0.1.303) (2018-05-24)
 
 
 ### Bug Fixes
 
-* **r-c-read-receipts:** add support for empty activities ([e9b16bc](https://github.com/webex/react-ciscospark/commit/e9b16bc))
+* **r-c-read-receipts:** add support for empty activities ([e9b16bc](https://github.com/webex/react-widgets/commit/e9b16bc))
 
 
 
 <a name="0.1.302"></a>
-## [0.1.302](https://github.com/webex/react-ciscospark/compare/v0.1.301...v0.1.302) (2018-05-23)
+## [0.1.302](https://github.com/webex/react-widgets/compare/v0.1.301...v0.1.302) (2018-05-23)
 
 
 ### Features
 
-* **react-container-notifications:** filter notifications with alertType none ([708cf7e](https://github.com/webex/react-ciscospark/commit/708cf7e))
+* **react-container-notifications:** filter notifications with alertType none ([708cf7e](https://github.com/webex/react-widgets/commit/708cf7e))
 
 
 
 <a name="0.1.301"></a>
-## [0.1.301](https://github.com/webex/react-ciscospark/compare/v0.1.300...v0.1.301) (2018-05-17)
+## [0.1.301](https://github.com/webex/react-widgets/compare/v0.1.300...v0.1.301) (2018-05-17)
 
 
 ### Bug Fixes
 
-* **call-data-activity:** add support for empty actor field ([0637eb0](https://github.com/webex/react-ciscospark/commit/0637eb0))
-* **call-data-activity:** add support for missing actor ([6661a2f](https://github.com/webex/react-ciscospark/commit/6661a2f))
+* **call-data-activity:** add support for empty actor field ([0637eb0](https://github.com/webex/react-widgets/commit/0637eb0))
+* **call-data-activity:** add support for missing actor ([6661a2f](https://github.com/webex/react-widgets/commit/6661a2f))
 
 
 ### Features
 
-* **spaces-list:** remove unused currentUser prop ([c95e2a1](https://github.com/webex/react-ciscospark/commit/c95e2a1))
-* **spaces-list:** use react-virtualized for rendering list ([c50840d](https://github.com/webex/react-ciscospark/commit/c50840d))
-* **widget-recents:** use updated spaces list ([a672ef8](https://github.com/webex/react-ciscospark/commit/a672ef8))
+* **spaces-list:** remove unused currentUser prop ([c95e2a1](https://github.com/webex/react-widgets/commit/c95e2a1))
+* **spaces-list:** use react-virtualized for rendering list ([c50840d](https://github.com/webex/react-widgets/commit/c50840d))
+* **widget-recents:** use updated spaces list ([a672ef8](https://github.com/webex/react-widgets/commit/a672ef8))
 
 
 
 <a name="0.1.300"></a>
-## [0.1.300](https://github.com/webex/react-ciscospark/compare/v0.1.299...v0.1.300) (2018-05-16)
+## [0.1.300](https://github.com/webex/react-widgets/compare/v0.1.299...v0.1.300) (2018-05-16)
 
 
 ### Features
 
-* **activity-item-base:** update to new icons component ([b9d1360](https://github.com/webex/react-ciscospark/commit/b9d1360))
-* **activity-menu:** update to new icons component ([72fdc8f](https://github.com/webex/react-ciscospark/commit/72fdc8f))
-* **activity-menu-header:** update to new icons component ([32e0a1e](https://github.com/webex/react-ciscospark/commit/32e0a1e))
-* **activity-post-action:** update to new icons component ([4b7da58](https://github.com/webex/react-ciscospark/commit/4b7da58))
-* **activity-share-file:** update to new icons component ([15356bd](https://github.com/webex/react-ciscospark/commit/15356bd))
-* **activity-share-thumbnail:** update to new icons component ([b62dedf](https://github.com/webex/react-ciscospark/commit/b62dedf))
-* **add-file-button:** update to new icons component ([1eeb2c7](https://github.com/webex/react-ciscospark/commit/1eeb2c7))
-* **avatar:** update to new icons component ([d8fb535](https://github.com/webex/react-ciscospark/commit/d8fb535))
-* **button:** update to new icons component ([ed9349a](https://github.com/webex/react-ciscospark/commit/ed9349a))
-* **button-controls:** update to new icons component ([9fa6668](https://github.com/webex/react-ciscospark/commit/9fa6668))
-* **chip-base:** update to new icons component ([0a45e0f](https://github.com/webex/react-ciscospark/commit/0a45e0f))
-* **chip-file:** update to new icons component ([c62179b](https://github.com/webex/react-ciscospark/commit/c62179b))
-* **container-activity-list:** update to new icons component ([7c8dabd](https://github.com/webex/react-ciscospark/commit/7c8dabd))
-* **container-file-uploader:** update to new icons component ([1951ae7](https://github.com/webex/react-ciscospark/commit/1951ae7))
-* **container-message-composer:** update to new icons component ([8ae0d64](https://github.com/webex/react-ciscospark/commit/8ae0d64))
-* **file-staging-area:** update to new icons component ([892adc5](https://github.com/webex/react-ciscospark/commit/892adc5))
-* **icon:** component now uses svg icons instead of fonts ([9fbf8ae](https://github.com/webex/react-ciscospark/commit/9fbf8ae))
-* **incoming-call:** update to new icons component ([cc3f914](https://github.com/webex/react-ciscospark/commit/cc3f914))
-* **presence-avatar:** update to new icons component ([b459d81](https://github.com/webex/react-ciscospark/commit/b459d81))
-* **samples:** add basic components ([d70aabd](https://github.com/webex/react-ciscospark/commit/d70aabd))
-* **scroll-to-bottom:** update to new icons component ([18b0f5c](https://github.com/webex/react-ciscospark/commit/18b0f5c))
-* **space-item:** update to new icons component ([6da071a](https://github.com/webex/react-ciscospark/commit/6da071a))
-* **widget-meet:** update to new icons component ([2ea26cf](https://github.com/webex/react-ciscospark/commit/2ea26cf))
-* **widget-roster:** update to new icons component ([2e1d815](https://github.com/webex/react-ciscospark/commit/2e1d815))
-* **widget-space:** update to new icons component ([21e8058](https://github.com/webex/react-ciscospark/commit/21e8058))
+* **activity-item-base:** update to new icons component ([b9d1360](https://github.com/webex/react-widgets/commit/b9d1360))
+* **activity-menu:** update to new icons component ([72fdc8f](https://github.com/webex/react-widgets/commit/72fdc8f))
+* **activity-menu-header:** update to new icons component ([32e0a1e](https://github.com/webex/react-widgets/commit/32e0a1e))
+* **activity-post-action:** update to new icons component ([4b7da58](https://github.com/webex/react-widgets/commit/4b7da58))
+* **activity-share-file:** update to new icons component ([15356bd](https://github.com/webex/react-widgets/commit/15356bd))
+* **activity-share-thumbnail:** update to new icons component ([b62dedf](https://github.com/webex/react-widgets/commit/b62dedf))
+* **add-file-button:** update to new icons component ([1eeb2c7](https://github.com/webex/react-widgets/commit/1eeb2c7))
+* **avatar:** update to new icons component ([d8fb535](https://github.com/webex/react-widgets/commit/d8fb535))
+* **button:** update to new icons component ([ed9349a](https://github.com/webex/react-widgets/commit/ed9349a))
+* **button-controls:** update to new icons component ([9fa6668](https://github.com/webex/react-widgets/commit/9fa6668))
+* **chip-base:** update to new icons component ([0a45e0f](https://github.com/webex/react-widgets/commit/0a45e0f))
+* **chip-file:** update to new icons component ([c62179b](https://github.com/webex/react-widgets/commit/c62179b))
+* **container-activity-list:** update to new icons component ([7c8dabd](https://github.com/webex/react-widgets/commit/7c8dabd))
+* **container-file-uploader:** update to new icons component ([1951ae7](https://github.com/webex/react-widgets/commit/1951ae7))
+* **container-message-composer:** update to new icons component ([8ae0d64](https://github.com/webex/react-widgets/commit/8ae0d64))
+* **file-staging-area:** update to new icons component ([892adc5](https://github.com/webex/react-widgets/commit/892adc5))
+* **icon:** component now uses svg icons instead of fonts ([9fbf8ae](https://github.com/webex/react-widgets/commit/9fbf8ae))
+* **incoming-call:** update to new icons component ([cc3f914](https://github.com/webex/react-widgets/commit/cc3f914))
+* **presence-avatar:** update to new icons component ([b459d81](https://github.com/webex/react-widgets/commit/b459d81))
+* **samples:** add basic components ([d70aabd](https://github.com/webex/react-widgets/commit/d70aabd))
+* **scroll-to-bottom:** update to new icons component ([18b0f5c](https://github.com/webex/react-widgets/commit/18b0f5c))
+* **space-item:** update to new icons component ([6da071a](https://github.com/webex/react-widgets/commit/6da071a))
+* **widget-meet:** update to new icons component ([2ea26cf](https://github.com/webex/react-widgets/commit/2ea26cf))
+* **widget-roster:** update to new icons component ([2e1d815](https://github.com/webex/react-widgets/commit/2e1d815))
+* **widget-space:** update to new icons component ([21e8058](https://github.com/webex/react-widgets/commit/21e8058))
 
 
 
 <a name="0.1.299"></a>
-## [0.1.299](https://github.com/webex/react-ciscospark/compare/v0.1.298...v0.1.299) (2018-05-14)
+## [0.1.299](https://github.com/webex/react-widgets/compare/v0.1.298...v0.1.299) (2018-05-14)
 
 
 
 <a name="0.1.298"></a>
-## [0.1.298](https://github.com/webex/react-ciscospark/compare/v0.1.297...v0.1.298) (2018-05-11)
+## [0.1.298](https://github.com/webex/react-widgets/compare/v0.1.297...v0.1.298) (2018-05-11)
 
 
 ### Bug Fixes
 
-* **widget-recents:** recent widget crash on undefined lastActivity ([c05b7bf](https://github.com/webex/react-ciscospark/commit/c05b7bf))
+* **widget-recents:** recent widget crash on undefined lastActivity ([c05b7bf](https://github.com/webex/react-widgets/commit/c05b7bf))
 
 
 
 <a name="0.1.297"></a>
-## [0.1.297](https://github.com/webex/react-ciscospark/compare/v0.1.296...v0.1.297) (2018-05-10)
+## [0.1.297](https://github.com/webex/react-widgets/compare/v0.1.296...v0.1.297) (2018-05-10)
 
 
 ### Bug Fixes
 
-* **react-component-activity-item-base:** avatar is not hidden for additional messages ([14cf216](https://github.com/webex/react-ciscospark/commit/14cf216))
+* **react-component-activity-item-base:** avatar is not hidden for additional messages ([14cf216](https://github.com/webex/react-widgets/commit/14cf216))
 
 
 
 <a name="0.1.296"></a>
-## [0.1.296](https://github.com/webex/react-ciscospark/compare/v0.1.295...v0.1.296) (2018-05-10)
+## [0.1.296](https://github.com/webex/react-widgets/compare/v0.1.295...v0.1.296) (2018-05-10)
 
 
 ### Bug Fixes
 
-* **react-container-notifications:** undefined browser notification for space widget messages ([c522f02](https://github.com/webex/react-ciscospark/commit/c522f02))
+* **react-container-notifications:** undefined browser notification for space widget messages ([c522f02](https://github.com/webex/react-widgets/commit/c522f02))
 
 
 ### Features
 
-* **react-container-notifications:** add support for muteNotifications parameter ([3e4ea6f](https://github.com/webex/react-ciscospark/commit/3e4ea6f))
+* **react-container-notifications:** add support for muteNotifications parameter ([3e4ea6f](https://github.com/webex/react-widgets/commit/3e4ea6f))
 
 
 
 <a name="0.1.295"></a>
-## [0.1.295](https://github.com/webex/react-ciscospark/compare/v0.1.294...v0.1.295) (2018-05-08)
+## [0.1.295](https://github.com/webex/react-widgets/compare/v0.1.294...v0.1.295) (2018-05-08)
 
 
 
 <a name="0.1.294"></a>
-## [0.1.294](https://github.com/webex/react-ciscospark/compare/v0.1.293...v0.1.294) (2018-05-08)
+## [0.1.294](https://github.com/webex/react-widgets/compare/v0.1.293...v0.1.294) (2018-05-08)
 
 
 ### Features
 
-* **space-item:** add active prop ([c64761a](https://github.com/webex/react-ciscospark/commit/c64761a))
+* **space-item:** add active prop ([c64761a](https://github.com/webex/react-widgets/commit/c64761a))
 
 
 
 <a name="0.1.293"></a>
-## [0.1.293](https://github.com/webex/react-ciscospark/compare/v0.1.292...v0.1.293) (2018-05-07)
+## [0.1.293](https://github.com/webex/react-widgets/compare/v0.1.292...v0.1.293) (2018-05-07)
 
 
 
 <a name="0.1.292"></a>
-## [0.1.292](https://github.com/webex/react-ciscospark/compare/v0.1.291...v0.1.292) (2018-05-03)
+## [0.1.292](https://github.com/webex/react-widgets/compare/v0.1.291...v0.1.292) (2018-05-03)
 
 
 
 <a name="0.1.291"></a>
-## [0.1.291](https://github.com/webex/react-ciscospark/compare/v0.1.290...v0.1.291) (2018-05-03)
+## [0.1.291](https://github.com/webex/react-widgets/compare/v0.1.290...v0.1.291) (2018-05-03)
 
 
 
 <a name="0.1.290"></a>
-## [0.1.290](https://github.com/webex/react-ciscospark/compare/v0.1.289...v0.1.290) (2018-05-02)
+## [0.1.290](https://github.com/webex/react-widgets/compare/v0.1.289...v0.1.290) (2018-05-02)
 
 
 
 <a name="0.1.289"></a>
-## [0.1.289](https://github.com/webex/react-ciscospark/compare/v0.1.288...v0.1.289) (2018-05-01)
+## [0.1.289](https://github.com/webex/react-widgets/compare/v0.1.288...v0.1.289) (2018-05-01)
 
 
 ### Features
 
-* **join-call-button:** moved to individual component ([4368e04](https://github.com/webex/react-ciscospark/commit/4368e04))
-* **samples:** add recents components to samples ([90c38ed](https://github.com/webex/react-ciscospark/commit/90c38ed))
-* **samples:** added samples section ([ab8a0de](https://github.com/webex/react-ciscospark/commit/ab8a0de))
-* **space-item:** moved to individual component ([3c32d6b](https://github.com/webex/react-ciscospark/commit/3c32d6b))
-* **spaces-list:** moved to individual component ([7c6c2de](https://github.com/webex/react-ciscospark/commit/7c6c2de))
+* **join-call-button:** moved to individual component ([4368e04](https://github.com/webex/react-widgets/commit/4368e04))
+* **samples:** add recents components to samples ([90c38ed](https://github.com/webex/react-widgets/commit/90c38ed))
+* **samples:** added samples section ([ab8a0de](https://github.com/webex/react-widgets/commit/ab8a0de))
+* **space-item:** moved to individual component ([3c32d6b](https://github.com/webex/react-widgets/commit/3c32d6b))
+* **spaces-list:** moved to individual component ([7c6c2de](https://github.com/webex/react-widgets/commit/7c6c2de))
 
 
 
 <a name="0.1.288"></a>
-## [0.1.288](https://github.com/webex/react-ciscospark/compare/v0.1.287...v0.1.288) (2018-04-30)
+## [0.1.288](https://github.com/webex/react-widgets/compare/v0.1.287...v0.1.288) (2018-04-30)
 
 
 ### Features
 
-* **widget-recents:** remove call.answer and call.reject events ([88e19d9](https://github.com/webex/react-ciscospark/commit/88e19d9))
-* **widget-recents:** remove incoming call screen ([7f2f0d2](https://github.com/webex/react-ciscospark/commit/7f2f0d2))
+* **widget-recents:** remove call.answer and call.reject events ([88e19d9](https://github.com/webex/react-widgets/commit/88e19d9))
+* **widget-recents:** remove incoming call screen ([7f2f0d2](https://github.com/webex/react-widgets/commit/7f2f0d2))
 
 
 
 <a name="0.1.287"></a>
-## [0.1.287](https://github.com/webex/react-ciscospark/compare/v0.1.286...v0.1.287) (2018-04-30)
+## [0.1.287](https://github.com/webex/react-widgets/compare/v0.1.286...v0.1.287) (2018-04-30)
 
 
 
 <a name="0.1.286"></a>
-## [0.1.286](https://github.com/webex/react-ciscospark/compare/v0.1.285...v0.1.286) (2018-04-30)
+## [0.1.286](https://github.com/webex/react-widgets/compare/v0.1.285...v0.1.286) (2018-04-30)
 
 
 
 <a name="0.1.285"></a>
-## [0.1.285](https://github.com/webex/react-ciscospark/compare/v0.1.284...v0.1.285) (2018-04-27)
+## [0.1.285](https://github.com/webex/react-widgets/compare/v0.1.284...v0.1.285) (2018-04-27)
 
 
 
 <a name="0.1.284"></a>
-## [0.1.284](https://github.com/webex/react-ciscospark/compare/v0.1.283...v0.1.284) (2018-04-27)
+## [0.1.284](https://github.com/webex/react-widgets/compare/v0.1.283...v0.1.284) (2018-04-27)
 
 
 
 <a name="0.1.283"></a>
-## [0.1.283](https://github.com/webex/react-ciscospark/compare/v0.1.282...v0.1.283) (2018-04-26)
+## [0.1.283](https://github.com/webex/react-widgets/compare/v0.1.282...v0.1.283) (2018-04-26)
 
 
 
 <a name="0.1.282"></a>
-## [0.1.282](https://github.com/webex/react-ciscospark/compare/v0.1.281...v0.1.282) (2018-04-26)
+## [0.1.282](https://github.com/webex/react-widgets/compare/v0.1.281...v0.1.282) (2018-04-26)
 
 
 
 <a name="0.1.281"></a>
-## [0.1.281](https://github.com/webex/react-ciscospark/compare/v0.1.280...v0.1.281) (2018-04-26)
+## [0.1.281](https://github.com/webex/react-widgets/compare/v0.1.280...v0.1.281) (2018-04-26)
 
 
 ### Features
 
-* **widget-space:** add selector for other user ([e84436a](https://github.com/webex/react-ciscospark/commit/e84436a))
+* **widget-space:** add selector for other user ([e84436a](https://github.com/webex/react-widgets/commit/e84436a))
 
 
 
 <a name="0.1.280"></a>
-## [0.1.280](https://github.com/webex/react-ciscospark/compare/v0.1.279...v0.1.280) (2018-04-25)
+## [0.1.280](https://github.com/webex/react-widgets/compare/v0.1.279...v0.1.280) (2018-04-25)
 
 
 
 <a name="0.1.279"></a>
-## [0.1.279](https://github.com/webex/react-ciscospark/compare/v0.1.278...v0.1.279) (2018-04-25)
+## [0.1.279](https://github.com/webex/react-widgets/compare/v0.1.278...v0.1.279) (2018-04-25)
 
 
 
 <a name="0.1.278"></a>
-## [0.1.278](https://github.com/webex/react-ciscospark/compare/v0.1.277...v0.1.278) (2018-04-23)
+## [0.1.278](https://github.com/webex/react-widgets/compare/v0.1.277...v0.1.278) (2018-04-23)
 
 
 
 <a name="0.1.277"></a>
-## [0.1.277](https://github.com/ciscospark/react-ciscospark/compare/v0.1.276...v0.1.277) (2018-04-20)
+## [0.1.277](https://github.com/ciscospark/react-widgets/compare/v0.1.276...v0.1.277) (2018-04-20)
 
 
 
 <a name="0.1.276"></a>
-## [0.1.276](https://github.com/webex/react-ciscospark/compare/v0.1.275...v0.1.276) (2018-04-17)
+## [0.1.276](https://github.com/webex/react-widgets/compare/v0.1.275...v0.1.276) (2018-04-17)
 
 
 
 <a name="0.1.275"></a>
-## [0.1.275](https://github.com/webex/react-ciscospark/compare/v0.1.273...v0.1.275) (2018-04-17)
+## [0.1.275](https://github.com/webex/react-widgets/compare/v0.1.273...v0.1.275) (2018-04-17)
 
 
 ### Bug Fixes
 
-* **journeys:** removing phone plugin from tests ([8271005](https://github.com/webex/react-ciscospark/commit/8271005))
+* **journeys:** removing phone plugin from tests ([8271005](https://github.com/webex/react-widgets/commit/8271005))
 
 
 
 <a name="0.1.273"></a>
-## [0.1.273](https://github.com/webex/react-ciscospark/compare/v0.1.272...v0.1.273) (2018-04-13)
+## [0.1.273](https://github.com/webex/react-widgets/compare/v0.1.272...v0.1.273) (2018-04-13)
 
 
 ### Bug Fixes
 
-* **changelog:** remove erroneous entries ([79083d6](https://github.com/webex/react-ciscospark/commit/79083d6))
+* **changelog:** remove erroneous entries ([79083d6](https://github.com/webex/react-widgets/commit/79083d6))
 
 
 
 <a name="0.1.272"></a>
-## [0.1.272](https://github.com/webex/react-ciscospark/compare/v0.1.271...v0.1.272) (2018-04-13)
+## [0.1.272](https://github.com/webex/react-widgets/compare/v0.1.271...v0.1.272) (2018-04-13)
 
 
 ### Bug Fixes
 
-* **journeys:** add a pause for call to establish ([4a41a60](https://github.com/webex/react-ciscospark/commit/4a41a60))
-* **journeys:** add a wait before moving mouse to call container ([b1b1c95](https://github.com/webex/react-ciscospark/commit/b1b1c95))
-* **journeys:** create conversation before start call test and add wait ([3852bcb](https://github.com/webex/react-ciscospark/commit/3852bcb))
-* **journeys:** open meet widget in remote browser for data api calling test ([a7d7814](https://github.com/webex/react-ciscospark/commit/a7d7814))
-* **journeys:** revert to nested elements where required ([88703ad](https://github.com/webex/react-ciscospark/commit/88703ad))
-* **journeys:** set spark events to a new array ([f05cc07](https://github.com/webex/react-ciscospark/commit/f05cc07))
+* **journeys:** add a pause for call to establish ([4a41a60](https://github.com/webex/react-widgets/commit/4a41a60))
+* **journeys:** add a wait before moving mouse to call container ([b1b1c95](https://github.com/webex/react-widgets/commit/b1b1c95))
+* **journeys:** create conversation before start call test and add wait ([3852bcb](https://github.com/webex/react-widgets/commit/3852bcb))
+* **journeys:** open meet widget in remote browser for data api calling test ([a7d7814](https://github.com/webex/react-widgets/commit/a7d7814))
+* **journeys:** revert to nested elements where required ([88703ad](https://github.com/webex/react-widgets/commit/88703ad))
+* **journeys:** set spark events to a new array ([f05cc07](https://github.com/webex/react-widgets/commit/f05cc07))
 
 
 
 <a name="0.1.271"></a>
-## [0.1.271](https://github.com/webex/react-ciscospark/compare/v0.1.270...v0.1.271) (2018-04-10)
+## [0.1.271](https://github.com/webex/react-widgets/compare/v0.1.270...v0.1.271) (2018-04-10)
 
 
 
 <a name="0.1.270"></a>
-## [0.1.270](https://github.com/webex/react-ciscospark/compare/v0.1.269...v0.1.270) (2018-03-23)
+## [0.1.270](https://github.com/webex/react-widgets/compare/v0.1.269...v0.1.270) (2018-03-23)
 
 
 ### Bug Fixes
 
-* **redux-module-media:** Prevent overwriting call record on connect ([8a3b7cc](https://github.com/webex/react-ciscospark/commit/8a3b7cc))
+* **redux-module-media:** Prevent overwriting call record on connect ([8a3b7cc](https://github.com/webex/react-widgets/commit/8a3b7cc))
 
 
 
 <a name="0.1.269"></a>
-## [0.1.269](https://github.com/webex/react-ciscospark/compare/v0.1.268...v0.1.269) (2018-03-20)
+## [0.1.269](https://github.com/webex/react-widgets/compare/v0.1.268...v0.1.269) (2018-03-20)
 
 
 
 <a name="0.1.268"></a>
-## [0.1.268](https://github.com/webex/react-ciscospark/compare/v0.1.267...v0.1.268) (2018-03-20)
+## [0.1.268](https://github.com/webex/react-widgets/compare/v0.1.267...v0.1.268) (2018-03-20)
 
 
 
 <a name="0.1.267"></a>
-## [0.1.267](https://github.com/webex/react-ciscospark/compare/v0.1.266...v0.1.267) (2018-03-19)
+## [0.1.267](https://github.com/webex/react-widgets/compare/v0.1.266...v0.1.267) (2018-03-19)
 
 
 ### Bug Fixes
 
-* **redux-module-conversation:** set conversation error message ([9afaa4c](https://github.com/webex/react-ciscospark/commit/9afaa4c))
-* **widget-meet:** remove duplicate incoming call handler ([2d04b7e](https://github.com/webex/react-ciscospark/commit/2d04b7e))
-* **widget-space:** handle uuids for toPersonId ([3c125ae](https://github.com/webex/react-ciscospark/commit/3c125ae))
+* **redux-module-conversation:** set conversation error message ([9afaa4c](https://github.com/webex/react-widgets/commit/9afaa4c))
+* **widget-meet:** remove duplicate incoming call handler ([2d04b7e](https://github.com/webex/react-widgets/commit/2d04b7e))
+* **widget-space:** handle uuids for toPersonId ([3c125ae](https://github.com/webex/react-widgets/commit/3c125ae))
 
 
 ### Features
 
-* **demo-widget:** add to user id support ([c7bc756](https://github.com/webex/react-ciscospark/commit/c7bc756))
-* **react-component-utils:** add hydraTypes object ([e1eeb24](https://github.com/webex/react-ciscospark/commit/e1eeb24))
-* **redux-module-conversation:** add hydra id support to create and get ([741b522](https://github.com/webex/react-ciscospark/commit/741b522))
+* **demo-widget:** add to user id support ([c7bc756](https://github.com/webex/react-widgets/commit/c7bc756))
+* **react-component-utils:** add hydraTypes object ([e1eeb24](https://github.com/webex/react-widgets/commit/e1eeb24))
+* **redux-module-conversation:** add hydra id support to create and get ([741b522](https://github.com/webex/react-widgets/commit/741b522))
 
 
 
 <a name="0.1.266"></a>
-## [0.1.266](https://github.com/webex/react-ciscospark/compare/v0.1.265...v0.1.266) (2018-03-16)
+## [0.1.266](https://github.com/webex/react-widgets/compare/v0.1.265...v0.1.266) (2018-03-16)
 
 
 
 <a name="0.1.265"></a>
-## [0.1.265](https://github.com/webex/react-ciscospark/compare/v0.1.264...v0.1.265) (2018-03-15)
+## [0.1.265](https://github.com/webex/react-widgets/compare/v0.1.264...v0.1.265) (2018-03-15)
 
 
 
 <a name="0.1.264"></a>
-## [0.1.264](https://github.com/webex/react-ciscospark/compare/v0.1.263...v0.1.264) (2018-03-15)
+## [0.1.264](https://github.com/webex/react-widgets/compare/v0.1.263...v0.1.264) (2018-03-15)
 
 
 ### Bug Fixes
 
-* **redux-module-media:** listen for declined incoming events ([a2fbba2](https://github.com/webex/react-ciscospark/commit/a2fbba2))
+* **redux-module-media:** listen for declined incoming events ([a2fbba2](https://github.com/webex/react-widgets/commit/a2fbba2))
 
 
 ### Features
 
-* **redux-module-media:** add #checkCurrentCalls method ([6a76fda](https://github.com/webex/react-ciscospark/commit/6a76fda))
-* **redux-module-media:** add support for call:created event ([83a14cc](https://github.com/webex/react-ciscospark/commit/83a14cc))
-* **redux-module-media:** get callStartTime on STORE_CALL ([2b9fac3](https://github.com/webex/react-ciscospark/commit/2b9fac3))
-* **redux-module-media:** listen for all calls in enhancer ([388216b](https://github.com/webex/react-ciscospark/commit/388216b))
-* **redux-module-spaces:** store locusUrl in space record ([b216068](https://github.com/webex/react-ciscospark/commit/b216068))
-* **widget-recents:** add associated call to space ([2e48842](https://github.com/webex/react-ciscospark/commit/2e48842))
-* **widget-recents:** check for current calls after spaces load ([86dc578](https://github.com/webex/react-ciscospark/commit/86dc578))
-* **widget-recents:** display join call button on space ([6bda887](https://github.com/webex/react-ciscospark/commit/6bda887))
-* **widget-recents:** use call.startTime prop ([88bb29d](https://github.com/webex/react-ciscospark/commit/88bb29d))
-* **widget-recents:** use media enhancer ([b188970](https://github.com/webex/react-ciscospark/commit/b188970))
-* **widget-recents:** use media's listenForCalls method ([5aa3e0b](https://github.com/webex/react-ciscospark/commit/5aa3e0b))
-* **widget-recents:** use space locusUrl to match to existing call ([a3db765](https://github.com/webex/react-ciscospark/commit/a3db765))
+* **redux-module-media:** add #checkCurrentCalls method ([6a76fda](https://github.com/webex/react-widgets/commit/6a76fda))
+* **redux-module-media:** add support for call:created event ([83a14cc](https://github.com/webex/react-widgets/commit/83a14cc))
+* **redux-module-media:** get callStartTime on STORE_CALL ([2b9fac3](https://github.com/webex/react-widgets/commit/2b9fac3))
+* **redux-module-media:** listen for all calls in enhancer ([388216b](https://github.com/webex/react-widgets/commit/388216b))
+* **redux-module-spaces:** store locusUrl in space record ([b216068](https://github.com/webex/react-widgets/commit/b216068))
+* **widget-recents:** add associated call to space ([2e48842](https://github.com/webex/react-widgets/commit/2e48842))
+* **widget-recents:** check for current calls after spaces load ([86dc578](https://github.com/webex/react-widgets/commit/86dc578))
+* **widget-recents:** display join call button on space ([6bda887](https://github.com/webex/react-widgets/commit/6bda887))
+* **widget-recents:** use call.startTime prop ([88bb29d](https://github.com/webex/react-widgets/commit/88bb29d))
+* **widget-recents:** use media enhancer ([b188970](https://github.com/webex/react-widgets/commit/b188970))
+* **widget-recents:** use media's listenForCalls method ([5aa3e0b](https://github.com/webex/react-widgets/commit/5aa3e0b))
+* **widget-recents:** use space locusUrl to match to existing call ([a3db765](https://github.com/webex/react-widgets/commit/a3db765))
 
 
 
 <a name="0.1.263"></a>
-## [0.1.263](https://github.com/webex/react-ciscospark/compare/v0.1.262...v0.1.263) (2018-03-15)
+## [0.1.263](https://github.com/webex/react-widgets/compare/v0.1.262...v0.1.263) (2018-03-15)
 
 
 ### Bug Fixes
 
-* **journeys:** remove check for in flight flag ([a380fe9](https://github.com/webex/react-ciscospark/commit/a380fe9))
-* **react-container-activity-list:** Add filter to remove extra new lines ([127f0be](https://github.com/webex/react-ciscospark/commit/127f0be))
-* **react-container-message-composer:** Proptypes error from mention lib ([6213369](https://github.com/webex/react-ciscospark/commit/6213369))
-* **redux-module-activity:** Add filter to remove extra new lines ([280a04c](https://github.com/webex/react-ciscospark/commit/280a04c))
-* **redux-module-activity:** raw url converts properly ([1b84205](https://github.com/webex/react-ciscospark/commit/1b84205))
-* **widget-meet:** Use userId when fetching avatar for direct space ([189319a](https://github.com/webex/react-ciscospark/commit/189319a))
-* **widget-message:** Fix unhandled exception when adding invalid files ([6da933f](https://github.com/webex/react-ciscospark/commit/6da933f))
-* **widget-message:** Incorrect events payload ([b5fafc4](https://github.com/webex/react-ciscospark/commit/b5fafc4))
-* **widget-module-flags:** Prevent multiple flagging calls ([c752e1b](https://github.com/webex/react-ciscospark/commit/c752e1b))
+* **journeys:** remove check for in flight flag ([a380fe9](https://github.com/webex/react-widgets/commit/a380fe9))
+* **react-container-activity-list:** Add filter to remove extra new lines ([127f0be](https://github.com/webex/react-widgets/commit/127f0be))
+* **react-container-message-composer:** Proptypes error from mention lib ([6213369](https://github.com/webex/react-widgets/commit/6213369))
+* **redux-module-activity:** Add filter to remove extra new lines ([280a04c](https://github.com/webex/react-widgets/commit/280a04c))
+* **redux-module-activity:** raw url converts properly ([1b84205](https://github.com/webex/react-widgets/commit/1b84205))
+* **widget-meet:** Use userId when fetching avatar for direct space ([189319a](https://github.com/webex/react-widgets/commit/189319a))
+* **widget-message:** Fix unhandled exception when adding invalid files ([6da933f](https://github.com/webex/react-widgets/commit/6da933f))
+* **widget-message:** Incorrect events payload ([b5fafc4](https://github.com/webex/react-widgets/commit/b5fafc4))
+* **widget-module-flags:** Prevent multiple flagging calls ([c752e1b](https://github.com/webex/react-widgets/commit/c752e1b))
 
 
 ### Features
 
-* **react-component-activity-item-base:** add action pending class ([181730e](https://github.com/webex/react-ciscospark/commit/181730e))
-* **react-component-activity-list:** add support for isFlagPending ([1ebf5fa](https://github.com/webex/react-ciscospark/commit/1ebf5fa))
-* **react-container-activity-list:** add support for isFlagPending ([b4dec3b](https://github.com/webex/react-ciscospark/commit/b4dec3b))
+* **react-component-activity-item-base:** add action pending class ([181730e](https://github.com/webex/react-widgets/commit/181730e))
+* **react-component-activity-list:** add support for isFlagPending ([1ebf5fa](https://github.com/webex/react-widgets/commit/1ebf5fa))
+* **react-container-activity-list:** add support for isFlagPending ([b4dec3b](https://github.com/webex/react-widgets/commit/b4dec3b))
 
 
 
 <a name="0.1.262"></a>
-## [0.1.262](https://github.com/webex/react-ciscospark/compare/v0.1.261...v0.1.262) (2018-03-01)
+## [0.1.262](https://github.com/webex/react-widgets/compare/v0.1.261...v0.1.262) (2018-03-01)
 
 
 ### Bug Fixes
 
-* **react-container-activity-list:** timestamp does not update when minute changes ([2849357](https://github.com/webex/react-ciscospark/commit/2849357))
+* **react-container-activity-list:** timestamp does not update when minute changes ([2849357](https://github.com/webex/react-widgets/commit/2849357))
 
 
 
 <a name="0.1.261"></a>
-## [0.1.261](https://github.com/webex/react-ciscospark/compare/v0.1.260...v0.1.261) (2018-02-28)
+## [0.1.261](https://github.com/webex/react-widgets/compare/v0.1.260...v0.1.261) (2018-02-28)
 
 
 ### Bug Fixes
 
-* **redux-module-spaces:** add support for empty lastReadableActivityDate ([82c3284](https://github.com/webex/react-ciscospark/commit/82c3284))
-* **widget-recents:** add incoming call to selector ([95a4009](https://github.com/webex/react-ciscospark/commit/95a4009))
-* **widget-recents:** add support for empty latestActivity ([b98e1db](https://github.com/webex/react-ciscospark/commit/b98e1db))
+* **redux-module-spaces:** add support for empty lastReadableActivityDate ([82c3284](https://github.com/webex/react-widgets/commit/82c3284))
+* **widget-recents:** add incoming call to selector ([95a4009](https://github.com/webex/react-widgets/commit/95a4009))
+* **widget-recents:** add support for empty latestActivity ([b98e1db](https://github.com/webex/react-widgets/commit/b98e1db))
 
 
 ### Features
 
-* **redux-module-media:** add isIncoming prop to call record ([2dfaa96](https://github.com/webex/react-ciscospark/commit/2dfaa96))
+* **redux-module-media:** add isIncoming prop to call record ([2dfaa96](https://github.com/webex/react-widgets/commit/2dfaa96))
 
 
 
 <a name="0.1.260"></a>
-## [0.1.260](https://github.com/webex/react-ciscospark/compare/v0.1.259...v0.1.260) (2018-02-28)
+## [0.1.260](https://github.com/webex/react-widgets/compare/v0.1.259...v0.1.260) (2018-02-28)
 
 
 ### Features
 
-* **journeys:** add single integration suite to run all tests ([69bafe2](https://github.com/webex/react-ciscospark/commit/69bafe2))
+* **journeys:** add single integration suite to run all tests ([69bafe2](https://github.com/webex/react-widgets/commit/69bafe2))
 
 
 
 <a name="0.1.259"></a>
-## [0.1.259](https://github.com/webex/react-ciscospark/compare/v0.1.258...v0.1.259) (2018-02-24)
+## [0.1.259](https://github.com/webex/react-widgets/compare/v0.1.258...v0.1.259) (2018-02-24)
 
 
 
 <a name="0.1.258"></a>
-## [0.1.258](https://github.com/webex/react-ciscospark/compare/v0.1.257...v0.1.258) (2018-02-22)
+## [0.1.258](https://github.com/webex/react-widgets/compare/v0.1.257...v0.1.258) (2018-02-22)
 
 
 ### Bug Fixes
 
-* **react-container-message-composer:** check for empty message before submit ([b4d21df](https://github.com/webex/react-ciscospark/commit/b4d21df))
-* **react-container-notifications:** eslint errors ([41aa9a2](https://github.com/webex/react-ciscospark/commit/41aa9a2))
-* **redux-module-activity:** check for empty message before submit ([bddf2af](https://github.com/webex/react-ciscospark/commit/bddf2af))
-* **widget-recents:** Small fixes for validation ([70ea113](https://github.com/webex/react-ciscospark/commit/70ea113))
-* **widget-space:** Allow passing to prop to meet ([f7b7b96](https://github.com/webex/react-ciscospark/commit/f7b7b96))
-* remove debug code and fix journey test error messages ([e2f3844](https://github.com/webex/react-ciscospark/commit/e2f3844))
+* **react-container-message-composer:** check for empty message before submit ([b4d21df](https://github.com/webex/react-widgets/commit/b4d21df))
+* **react-container-notifications:** eslint errors ([41aa9a2](https://github.com/webex/react-widgets/commit/41aa9a2))
+* **redux-module-activity:** check for empty message before submit ([bddf2af](https://github.com/webex/react-widgets/commit/bddf2af))
+* **widget-recents:** Small fixes for validation ([70ea113](https://github.com/webex/react-widgets/commit/70ea113))
+* **widget-space:** Allow passing to prop to meet ([f7b7b96](https://github.com/webex/react-widgets/commit/f7b7b96))
+* remove debug code and fix journey test error messages ([e2f3844](https://github.com/webex/react-widgets/commit/e2f3844))
 
 
 
 <a name="0.1.257"></a>
-## [0.1.257](https://github.com/webex/react-ciscospark/compare/v0.1.256...v0.1.257) (2018-02-21)
+## [0.1.257](https://github.com/webex/react-widgets/compare/v0.1.256...v0.1.257) (2018-02-21)
 
 
 ### Bug Fixes
 
-* **react-container-message-composer:** check for empty message before submit ([9912c6e](https://github.com/webex/react-ciscospark/commit/9912c6e))
-* **react-container-notifications:** eslint errors ([b35d95f](https://github.com/webex/react-ciscospark/commit/b35d95f))
-* **react-container-notifications:** eslint errors ([cdf5346](https://github.com/webex/react-ciscospark/commit/cdf5346))
-* **redux-module-activity:** check for empty message before submit ([2c1a5fd](https://github.com/webex/react-ciscospark/commit/2c1a5fd))
+* **react-container-message-composer:** check for empty message before submit ([9912c6e](https://github.com/webex/react-widgets/commit/9912c6e))
+* **react-container-notifications:** eslint errors ([b35d95f](https://github.com/webex/react-widgets/commit/b35d95f))
+* **react-container-notifications:** eslint errors ([cdf5346](https://github.com/webex/react-widgets/commit/cdf5346))
+* **redux-module-activity:** check for empty message before submit ([2c1a5fd](https://github.com/webex/react-widgets/commit/2c1a5fd))
 
 
 
 <a name="0.1.256"></a>
-## [0.1.256](https://github.com/webex/react-ciscospark/compare/v0.1.255...v0.1.256) (2018-02-19)
+## [0.1.256](https://github.com/webex/react-widgets/compare/v0.1.255...v0.1.256) (2018-02-19)
 
 
 
 <a name="0.1.255"></a>
-## [0.1.255](https://github.com/webex/react-ciscospark/compare/v0.1.254...v0.1.255) (2018-02-19)
+## [0.1.255](https://github.com/webex/react-widgets/compare/v0.1.254...v0.1.255) (2018-02-19)
 
 
 ### Bug Fixes
 
-* **react-container-notifications:** Add checks to unsent selector ([68b0531](https://github.com/webex/react-ciscospark/commit/68b0531))
-* **redux-module-media:** listen for declined incoming events ([f07154f](https://github.com/webex/react-ciscospark/commit/f07154f))
-* **redux-module-users:** Check for photo before trying to save ([be62793](https://github.com/webex/react-ciscospark/commit/be62793))
-* **widget-recents:** Misaligned object keys ([f65f0f7](https://github.com/webex/react-ciscospark/commit/f65f0f7))
-* **widget-recents:** Missed activities module updates ([7403d63](https://github.com/webex/react-ciscospark/commit/7403d63))
+* **react-container-notifications:** Add checks to unsent selector ([68b0531](https://github.com/webex/react-widgets/commit/68b0531))
+* **redux-module-media:** listen for declined incoming events ([f07154f](https://github.com/webex/react-widgets/commit/f07154f))
+* **redux-module-users:** Check for photo before trying to save ([be62793](https://github.com/webex/react-widgets/commit/be62793))
+* **widget-recents:** Misaligned object keys ([f65f0f7](https://github.com/webex/react-widgets/commit/f65f0f7))
+* **widget-recents:** Missed activities module updates ([7403d63](https://github.com/webex/react-widgets/commit/7403d63))
 
 
 ### Features
 
-* **widget-meet:** use isDismissed call flag ([5cd6b7c](https://github.com/webex/react-ciscospark/commit/5cd6b7c))
-* **widget-recents:** use isAnswered for incoming call status ([03ddb8e](https://github.com/webex/react-ciscospark/commit/03ddb8e))
-* **widget-space:** use isDismissed call flag ([e458c25](https://github.com/webex/react-ciscospark/commit/e458c25))
-* Update widget build to use production env ([e78275e](https://github.com/webex/react-ciscospark/commit/e78275e))
+* **widget-meet:** use isDismissed call flag ([5cd6b7c](https://github.com/webex/react-widgets/commit/5cd6b7c))
+* **widget-recents:** use isAnswered for incoming call status ([03ddb8e](https://github.com/webex/react-widgets/commit/03ddb8e))
+* **widget-space:** use isDismissed call flag ([e458c25](https://github.com/webex/react-widgets/commit/e458c25))
+* Update widget build to use production env ([e78275e](https://github.com/webex/react-widgets/commit/e78275e))
 
 
 
 <a name="0.1.254"></a>
-## [0.1.254](https://github.com/webex/react-ciscospark/compare/v0.1.253...v0.1.254) (2018-02-19)
+## [0.1.254](https://github.com/webex/react-widgets/compare/v0.1.253...v0.1.254) (2018-02-19)
 
 
 ### Bug Fixes
 
-* **react-container-notification:** Remove conversation dependency ([4f87917](https://github.com/webex/react-ciscospark/commit/4f87917))
-* **redux-module-media:** Missing exports, undefined errors, eslint ([737db2c](https://github.com/webex/react-ciscospark/commit/737db2c))
-* **redux-module-spaces:** Add initial space placeholder ([8a53ea6](https://github.com/webex/react-ciscospark/commit/8a53ea6))
+* **react-container-notification:** Remove conversation dependency ([4f87917](https://github.com/webex/react-widgets/commit/4f87917))
+* **redux-module-media:** Missing exports, undefined errors, eslint ([737db2c](https://github.com/webex/react-widgets/commit/737db2c))
+* **redux-module-spaces:** Add initial space placeholder ([8a53ea6](https://github.com/webex/react-widgets/commit/8a53ea6))
 
 
 ### Features
 
-* **react-component-utils:** Add more hoc and string helpers ([558f0c4](https://github.com/webex/react-ciscospark/commit/558f0c4))
-* **react-container-activity-list:** Update to use users redux module ([cb2f236](https://github.com/webex/react-ciscospark/commit/cb2f236))
-* **react-container-message-composer:** Migrate to users module ([6e76d03](https://github.com/webex/react-ciscospark/commit/6e76d03))
-* **react-container-read-receipts:** Migrate to users module ([bdae229](https://github.com/webex/react-ciscospark/commit/bdae229))
-* **react-redux-spark:** Migrate to immutable Records ([e34f86d](https://github.com/webex/react-ciscospark/commit/e34f86d))
-* **redux-module-activities:** Update to use Records for initialState ([53f8d7e](https://github.com/webex/react-ciscospark/commit/53f8d7e))
-* **redux-module-avatar:** Export addAvatar action ([5aefdb6](https://github.com/webex/react-ciscospark/commit/5aefdb6))
-* **redux-module-mercury:** Add connect to mercury enhancer ([dbbe092](https://github.com/webex/react-ciscospark/commit/dbbe092))
-* **redux-module-spaces:** Use immutable Records ([4f8dbca](https://github.com/webex/react-ciscospark/commit/4f8dbca))
-* **redux-modules-users:** Add avatar storage when storing users ([95160da](https://github.com/webex/react-ciscospark/commit/95160da))
-* **widget-meet:** Add meet index.html page ([35702dd](https://github.com/webex/react-ciscospark/commit/35702dd))
-* **widget-message:** Migrate to users module ([8a71e37](https://github.com/webex/react-ciscospark/commit/8a71e37))
+* **react-component-utils:** Add more hoc and string helpers ([558f0c4](https://github.com/webex/react-widgets/commit/558f0c4))
+* **react-container-activity-list:** Update to use users redux module ([cb2f236](https://github.com/webex/react-widgets/commit/cb2f236))
+* **react-container-message-composer:** Migrate to users module ([6e76d03](https://github.com/webex/react-widgets/commit/6e76d03))
+* **react-container-read-receipts:** Migrate to users module ([bdae229](https://github.com/webex/react-widgets/commit/bdae229))
+* **react-redux-spark:** Migrate to immutable Records ([e34f86d](https://github.com/webex/react-widgets/commit/e34f86d))
+* **redux-module-activities:** Update to use Records for initialState ([53f8d7e](https://github.com/webex/react-widgets/commit/53f8d7e))
+* **redux-module-avatar:** Export addAvatar action ([5aefdb6](https://github.com/webex/react-widgets/commit/5aefdb6))
+* **redux-module-mercury:** Add connect to mercury enhancer ([dbbe092](https://github.com/webex/react-widgets/commit/dbbe092))
+* **redux-module-spaces:** Use immutable Records ([4f8dbca](https://github.com/webex/react-widgets/commit/4f8dbca))
+* **redux-modules-users:** Add avatar storage when storing users ([95160da](https://github.com/webex/react-widgets/commit/95160da))
+* **widget-meet:** Add meet index.html page ([35702dd](https://github.com/webex/react-widgets/commit/35702dd))
+* **widget-message:** Migrate to users module ([8a71e37](https://github.com/webex/react-widgets/commit/8a71e37))
 
 
 
 <a name="0.1.253"></a>
-## [0.1.253](https://github.com/webex/react-ciscospark/compare/v0.1.252...v0.1.253) (2018-02-16)
+## [0.1.253](https://github.com/webex/react-widgets/compare/v0.1.252...v0.1.253) (2018-02-16)
 
 
 
 <a name="0.1.252"></a>
-## [0.1.252](https://github.com/webex/react-ciscospark/compare/v0.1.251...v0.1.252) (2018-02-16)
+## [0.1.252](https://github.com/webex/react-widgets/compare/v0.1.251...v0.1.252) (2018-02-16)
 
 
 ### Bug Fixes
 
-* **journeys:** moveToObject uses offsets differently than actions ([83d1265](https://github.com/webex/react-ciscospark/commit/83d1265))
-* **journeys:** tests do not wait for menu button to be visible ([5ca3c56](https://github.com/webex/react-ciscospark/commit/5ca3c56))
-* **spark-widget-base:** Apply middleware correctly to re-enable logger. ([7a6cce1](https://github.com/webex/react-ciscospark/commit/7a6cce1))
+* **journeys:** moveToObject uses offsets differently than actions ([83d1265](https://github.com/webex/react-widgets/commit/83d1265))
+* **journeys:** tests do not wait for menu button to be visible ([5ca3c56](https://github.com/webex/react-widgets/commit/5ca3c56))
+* **spark-widget-base:** Apply middleware correctly to re-enable logger. ([7a6cce1](https://github.com/webex/react-widgets/commit/7a6cce1))
 
 
 ### Features
 
-* **redux-module-activities:** New activities module ([6961e73](https://github.com/webex/react-ciscospark/commit/6961e73))
+* **redux-module-activities:** New activities module ([6961e73](https://github.com/webex/react-widgets/commit/6961e73))
 
 
 
 <a name="0.1.251"></a>
-## [0.1.251](https://github.com/webex/react-ciscospark/compare/v0.1.250...v0.1.251) (2018-02-07)
+## [0.1.251](https://github.com/webex/react-widgets/compare/v0.1.250...v0.1.251) (2018-02-07)
 
 
 
 <a name="0.1.250"></a>
-## [0.1.250](https://github.com/webex/react-ciscospark/compare/v0.1.249...v0.1.250) (2018-02-07)
+## [0.1.250](https://github.com/webex/react-widgets/compare/v0.1.249...v0.1.250) (2018-02-07)
 
 
 ### Features
 
-* **react-redux-spark:** add ability to use jwt token to authenticate ([27f541d](https://github.com/webex/react-ciscospark/commit/27f541d))
-* **widget-demo:** ability to open widget with jwtToken ([e576606](https://github.com/webex/react-ciscospark/commit/e576606))
+* **react-redux-spark:** add ability to use jwt token to authenticate ([27f541d](https://github.com/webex/react-widgets/commit/27f541d))
+* **widget-demo:** ability to open widget with jwtToken ([e576606](https://github.com/webex/react-widgets/commit/e576606))
 
 
 
 <a name="0.1.249"></a>
-## [0.1.249](https://github.com/webex/react-ciscospark/compare/v0.1.248...v0.1.249) (2018-02-06)
+## [0.1.249](https://github.com/webex/react-widgets/compare/v0.1.248...v0.1.249) (2018-02-06)
 
 
 ### Bug Fixes
 
-* **spark-widget-base:** Add version and fix .on events ([c853ac0](https://github.com/webex/react-ciscospark/commit/c853ac0))
-* **spark-widget-base:** Fix event details structure ([9308fdb](https://github.com/webex/react-ciscospark/commit/9308fdb))
+* **spark-widget-base:** Add version and fix .on events ([c853ac0](https://github.com/webex/react-widgets/commit/c853ac0))
+* **spark-widget-base:** Fix event details structure ([9308fdb](https://github.com/webex/react-widgets/commit/9308fdb))
 
 
 
 <a name="0.1.248"></a>
-## [0.1.248](https://github.com/webex/react-ciscospark/compare/v0.1.247...v0.1.248) (2018-02-05)
+## [0.1.248](https://github.com/webex/react-widgets/compare/v0.1.247...v0.1.248) (2018-02-05)
 
 
 ### Bug Fixes
 
-* **tooling:** Increase maxDuration for journey tests ([0dbbf30](https://github.com/webex/react-ciscospark/commit/0dbbf30))
+* **tooling:** Increase maxDuration for journey tests ([0dbbf30](https://github.com/webex/react-widgets/commit/0dbbf30))
 
 
 
 <a name="0.1.247"></a>
-## [0.1.247](https://github.com/webex/react-ciscospark/compare/v0.1.246...v0.1.247) (2018-01-25)
+## [0.1.247](https://github.com/webex/react-widgets/compare/v0.1.246...v0.1.247) (2018-01-25)
 
 
 ### Features
 
-* **journeys:** use location and size of element to move mouse in FF ([ba81df9](https://github.com/webex/react-ciscospark/commit/ba81df9))
-* **journeys:** use new moveMouse defaults ([3ca3583](https://github.com/webex/react-ciscospark/commit/3ca3583))
-* **react-component-typing-avatar:** changed style to match web client ([6188f6a](https://github.com/webex/react-ciscospark/commit/6188f6a))
+* **journeys:** use location and size of element to move mouse in FF ([ba81df9](https://github.com/webex/react-widgets/commit/ba81df9))
+* **journeys:** use new moveMouse defaults ([3ca3583](https://github.com/webex/react-widgets/commit/3ca3583))
+* **react-component-typing-avatar:** changed style to match web client ([6188f6a](https://github.com/webex/react-widgets/commit/6188f6a))
 
 
 
 <a name="0.1.246"></a>
-## [0.1.246](https://github.com/webex/react-ciscospark/compare/v0.1.245...v0.1.246) (2018-01-19)
+## [0.1.246](https://github.com/webex/react-widgets/compare/v0.1.245...v0.1.246) (2018-01-19)
 
 
 
 <a name="0.1.245"></a>
-## [0.1.245](https://github.com/webex/react-ciscospark/compare/v0.1.244...v0.1.245) (2018-01-19)
+## [0.1.245](https://github.com/webex/react-widgets/compare/v0.1.244...v0.1.245) (2018-01-19)
 
 
 
 <a name="0.1.244"></a>
-## [0.1.244](https://github.com/webex/react-ciscospark/compare/v0.1.243...v0.1.244) (2018-01-19)
+## [0.1.244](https://github.com/webex/react-widgets/compare/v0.1.243...v0.1.244) (2018-01-19)
 
 
 
 <a name="0.1.243"></a>
-## [0.1.243](https://github.com/webex/react-ciscospark/compare/v0.1.242...v0.1.243) (2018-01-18)
+## [0.1.243](https://github.com/webex/react-widgets/compare/v0.1.242...v0.1.243) (2018-01-18)
 
 
 
 <a name="0.1.242"></a>
-## [0.1.242](https://github.com/webex/react-ciscospark/compare/v0.1.241...v0.1.242) (2018-01-17)
+## [0.1.242](https://github.com/webex/react-widgets/compare/v0.1.241...v0.1.242) (2018-01-17)
 
 
 
 <a name="0.1.241"></a>
-## [0.1.241](https://github.com/webex/react-ciscospark/compare/v0.1.240...v0.1.241) (2018-01-16)
+## [0.1.241](https://github.com/webex/react-widgets/compare/v0.1.240...v0.1.241) (2018-01-16)
 
 
 
 <a name="0.1.240"></a>
-## [0.1.240](https://github.com/webex/react-ciscospark/compare/v0.1.239...v0.1.240) (2018-01-16)
+## [0.1.240](https://github.com/webex/react-widgets/compare/v0.1.239...v0.1.240) (2018-01-16)
 
 
 
 <a name="0.1.239"></a>
-## [0.1.239](https://github.com/webex/react-ciscospark/compare/v0.1.238...v0.1.239) (2018-01-16)
+## [0.1.239](https://github.com/webex/react-widgets/compare/v0.1.238...v0.1.239) (2018-01-16)
 
 
 
 <a name="0.1.238"></a>
-## [0.1.238](https://github.com/webex/react-ciscospark/compare/v0.1.237...v0.1.238) (2018-01-16)
+## [0.1.238](https://github.com/webex/react-widgets/compare/v0.1.237...v0.1.238) (2018-01-16)
 
 
 
 <a name="0.1.237"></a>
-## [0.1.237](https://github.com/webex/react-ciscospark/compare/v0.1.236...v0.1.237) (2018-01-16)
+## [0.1.237](https://github.com/webex/react-widgets/compare/v0.1.236...v0.1.237) (2018-01-16)
 
 
 
 <a name="0.1.236"></a>
-## [0.1.236](https://github.com/webex/react-ciscospark/compare/v0.1.235...v0.1.236) (2018-01-16)
+## [0.1.236](https://github.com/webex/react-widgets/compare/v0.1.235...v0.1.236) (2018-01-16)
 
 
 ### Bug Fixes
 
-* **all:** Add files and remove version from package.json ([4722e98](https://github.com/webex/react-ciscospark/commit/4722e98))
-* **redux-module-activity:** add message parsing abilities to match other clients ([b73dac9](https://github.com/webex/react-ciscospark/commit/b73dac9))
-* **widget-recents:** handle latestActivity that contains html ([51f8d9a](https://github.com/webex/react-ciscospark/commit/51f8d9a))
-* **widget-roster:** display in flight participants properly ([534fdf2](https://github.com/webex/react-ciscospark/commit/534fdf2))
+* **all:** Add files and remove version from package.json ([4722e98](https://github.com/webex/react-widgets/commit/4722e98))
+* **redux-module-activity:** add message parsing abilities to match other clients ([b73dac9](https://github.com/webex/react-widgets/commit/b73dac9))
+* **widget-recents:** handle latestActivity that contains html ([51f8d9a](https://github.com/webex/react-widgets/commit/51f8d9a))
+* **widget-roster:** display in flight participants properly ([534fdf2](https://github.com/webex/react-widgets/commit/534fdf2))
 
 
 ### Features
 
-* **react-component-activity-share-thumbnail:** add image alt text ([efb99c7](https://github.com/webex/react-ciscospark/commit/efb99c7))
-* **react-component-people-list:** add email display on hover ([03532a2](https://github.com/webex/react-ciscospark/commit/03532a2))
-* **widget-demo:** add ability to close running space when opening new one ([9bf42a5](https://github.com/webex/react-ciscospark/commit/9bf42a5))
+* **react-component-activity-share-thumbnail:** add image alt text ([efb99c7](https://github.com/webex/react-widgets/commit/efb99c7))
+* **react-component-people-list:** add email display on hover ([03532a2](https://github.com/webex/react-widgets/commit/03532a2))
+* **widget-demo:** add ability to close running space when opening new one ([9bf42a5](https://github.com/webex/react-widgets/commit/9bf42a5))
 
 
 
 <a name="0.1.235"></a>
-## [0.1.235](https://github.com/webex/react-ciscospark/compare/v0.1.234...v0.1.235) (2018-01-10)
+## [0.1.235](https://github.com/webex/react-widgets/compare/v0.1.234...v0.1.235) (2018-01-10)
 
 
 ### Features
 
-* **redux-module-media:** add incoming flags to call record ([9f3a3a6](https://github.com/webex/react-ciscospark/commit/9f3a3a6))
-* **redux-module-media:** change call object to Record ([39c48ca](https://github.com/webex/react-ciscospark/commit/39c48ca))
-* **widget-meet:** update to call object record ([d282d1d](https://github.com/webex/react-ciscospark/commit/d282d1d))
-* **widget-recents:** use incoming call methods from media module ([19c46e9](https://github.com/webex/react-ciscospark/commit/19c46e9))
-* **widget-recents:** use media module webRTC check ([59c74f2](https://github.com/webex/react-ciscospark/commit/59c74f2))
+* **redux-module-media:** add incoming flags to call record ([9f3a3a6](https://github.com/webex/react-widgets/commit/9f3a3a6))
+* **redux-module-media:** change call object to Record ([39c48ca](https://github.com/webex/react-widgets/commit/39c48ca))
+* **widget-meet:** update to call object record ([d282d1d](https://github.com/webex/react-widgets/commit/d282d1d))
+* **widget-recents:** use incoming call methods from media module ([19c46e9](https://github.com/webex/react-widgets/commit/19c46e9))
+* **widget-recents:** use media module webRTC check ([59c74f2](https://github.com/webex/react-widgets/commit/59c74f2))
 
 
 
 <a name="0.1.234"></a>
-## [0.1.234](https://github.com/webex/react-ciscospark/compare/v0.1.233...v0.1.234) (2018-01-08)
+## [0.1.234](https://github.com/webex/react-widgets/compare/v0.1.233...v0.1.234) (2018-01-08)
 
 
 
 <a name="0.1.233"></a>
-## [0.1.233](https://github.com/webex/react-ciscospark/compare/v0.1.232...v0.1.233) (2018-01-08)
+## [0.1.233](https://github.com/webex/react-widgets/compare/v0.1.232...v0.1.233) (2018-01-08)
 
 
 
 <a name="0.1.232"></a>
-## [0.1.232](https://github.com/webex/react-ciscospark/compare/v0.1.231...v0.1.232) (2018-01-08)
+## [0.1.232](https://github.com/webex/react-widgets/compare/v0.1.231...v0.1.232) (2018-01-08)
 
 
 ### Bug Fixes
 
-* **redux-module-spaces:** Use snapshot for checking exports ([753628c](https://github.com/webex/react-ciscospark/commit/753628c))
+* **redux-module-spaces:** Use snapshot for checking exports ([753628c](https://github.com/webex/react-widgets/commit/753628c))
 
 
 ### Features
 
-* **widget-message:** change scroll lock behavior ([3d4ad5b](https://github.com/webex/react-ciscospark/commit/3d4ad5b))
+* **widget-message:** change scroll lock behavior ([3d4ad5b](https://github.com/webex/react-widgets/commit/3d4ad5b))
 
 
 
 <a name="0.1.231"></a>
-## [0.1.231](https://github.com/webex/react-ciscospark/compare/v0.1.230...v0.1.231) (2018-01-08)
+## [0.1.231](https://github.com/webex/react-widgets/compare/v0.1.230...v0.1.231) (2018-01-08)
 
 
 
 <a name="0.1.230"></a>
-## [0.1.230](https://github.com/webex/react-ciscospark/compare/v0.1.229...v0.1.230) (2018-01-08)
+## [0.1.230](https://github.com/webex/react-widgets/compare/v0.1.229...v0.1.230) (2018-01-08)
 
 
 ### Bug Fixes
 
-* **redux-module-spaces:** Fix failed snapshot tests ([424af0f](https://github.com/webex/react-ciscospark/commit/424af0f))
-* **spark-widget-base:** Fix missing props not being passed ([ba87360](https://github.com/webex/react-ciscospark/commit/ba87360))
-* **widget-base:** Remove old base ([e8aea00](https://github.com/webex/react-ciscospark/commit/e8aea00))
+* **redux-module-spaces:** Fix failed snapshot tests ([424af0f](https://github.com/webex/react-widgets/commit/424af0f))
+* **spark-widget-base:** Fix missing props not being passed ([ba87360](https://github.com/webex/react-widgets/commit/ba87360))
+* **widget-base:** Remove old base ([e8aea00](https://github.com/webex/react-widgets/commit/e8aea00))
 
 
 ### Features
 
-* **react-component-utils:** Add deconstruct Hydra ID ([f942663](https://github.com/webex/react-ciscospark/commit/f942663))
-* **redux-module-spaces:** Add users module support ([51daa6a](https://github.com/webex/react-ciscospark/commit/51daa6a))
-* **redux-module-users:** New users module ([b98050b](https://github.com/webex/react-ciscospark/commit/b98050b))
-* **space-widget-base:** Add currrent user prop to intial setup ([11f0f7a](https://github.com/webex/react-ciscospark/commit/11f0f7a))
-* **widget-demo:** add ability to open space from recents ([acb2439](https://github.com/webex/react-ciscospark/commit/acb2439))
-* **widget-recents:** Convert to use new users module ([7b883ee](https://github.com/webex/react-ciscospark/commit/7b883ee))
+* **react-component-utils:** Add deconstruct Hydra ID ([f942663](https://github.com/webex/react-widgets/commit/f942663))
+* **redux-module-spaces:** Add users module support ([51daa6a](https://github.com/webex/react-widgets/commit/51daa6a))
+* **redux-module-users:** New users module ([b98050b](https://github.com/webex/react-widgets/commit/b98050b))
+* **space-widget-base:** Add currrent user prop to intial setup ([11f0f7a](https://github.com/webex/react-widgets/commit/11f0f7a))
+* **widget-demo:** add ability to open space from recents ([acb2439](https://github.com/webex/react-widgets/commit/acb2439))
+* **widget-recents:** Convert to use new users module ([7b883ee](https://github.com/webex/react-widgets/commit/7b883ee))
 
 
 
 <a name="0.1.229"></a>
-## [0.1.229](https://github.com/webex/react-ciscospark/compare/v0.1.228...v0.1.229) (2018-01-05)
+## [0.1.229](https://github.com/webex/react-widgets/compare/v0.1.228...v0.1.229) (2018-01-05)
 
 
 ### Features
 
-* **react-component-activity-menu-header:** initial component ([b142852](https://github.com/webex/react-ciscospark/commit/b142852))
-* **react-component-file-share-display:** initial component ([4ee6c8c](https://github.com/webex/react-ciscospark/commit/4ee6c8c))
-* **react-component-icon:** add files icon ([f64da28](https://github.com/webex/react-ciscospark/commit/f64da28))
-* **widget-files:** initial implementation ([253d2f5](https://github.com/webex/react-ciscospark/commit/253d2f5))
-* **widget-files:** use file downloader component ([faf605c](https://github.com/webex/react-ciscospark/commit/faf605c))
-* **widget-files:** use FileShareDisplay component ([e60df81](https://github.com/webex/react-ciscospark/commit/e60df81))
-* **widget-space:** add files button to menu ([6b4926e](https://github.com/webex/react-ciscospark/commit/6b4926e))
-* **widget-space:** show error when no space destination is provided ([6a24c28](https://github.com/webex/react-ciscospark/commit/6a24c28))
+* **react-component-activity-menu-header:** initial component ([b142852](https://github.com/webex/react-widgets/commit/b142852))
+* **react-component-file-share-display:** initial component ([4ee6c8c](https://github.com/webex/react-widgets/commit/4ee6c8c))
+* **react-component-icon:** add files icon ([f64da28](https://github.com/webex/react-widgets/commit/f64da28))
+* **widget-files:** initial implementation ([253d2f5](https://github.com/webex/react-widgets/commit/253d2f5))
+* **widget-files:** use file downloader component ([faf605c](https://github.com/webex/react-widgets/commit/faf605c))
+* **widget-files:** use FileShareDisplay component ([e60df81](https://github.com/webex/react-widgets/commit/e60df81))
+* **widget-space:** add files button to menu ([6b4926e](https://github.com/webex/react-widgets/commit/6b4926e))
+* **widget-space:** show error when no space destination is provided ([6a24c28](https://github.com/webex/react-widgets/commit/6a24c28))
 
 
 
 <a name="0.1.228"></a>
-## [0.1.228](https://github.com/webex/react-ciscospark/compare/v0.1.227...v0.1.228) (2018-01-05)
+## [0.1.228](https://github.com/webex/react-widgets/compare/v0.1.227...v0.1.228) (2018-01-05)
 
 
 ### Bug Fixes
 
-* **tooling:** Add build URL to SRI ([5a61864](https://github.com/webex/react-ciscospark/commit/5a61864))
+* **tooling:** Add build URL to SRI ([5a61864](https://github.com/webex/react-widgets/commit/5a61864))
 
 
 
 <a name="0.1.227"></a>
-## [0.1.227](https://github.com/webex/react-ciscospark/compare/v0.1.226...v0.1.227) (2018-01-05)
+## [0.1.227](https://github.com/webex/react-widgets/compare/v0.1.226...v0.1.227) (2018-01-05)
 
 
 
 <a name="0.1.226"></a>
-## [0.1.226](https://github.com/webex/react-ciscospark/compare/v0.1.225...v0.1.226) (2018-01-05)
+## [0.1.226](https://github.com/webex/react-widgets/compare/v0.1.225...v0.1.226) (2018-01-05)
 
 
 
 <a name="0.1.225"></a>
-## [0.1.225](https://github.com/webex/react-ciscospark/compare/v0.1.224...v0.1.225) (2018-01-04)
+## [0.1.225](https://github.com/webex/react-widgets/compare/v0.1.224...v0.1.225) (2018-01-04)
 
 
 ### Bug Fixes
 
-* **widget-message:** activities are no longer an immutable object ([d793e7b](https://github.com/webex/react-ciscospark/commit/d793e7b))
+* **widget-message:** activities are no longer an immutable object ([d793e7b](https://github.com/webex/react-widgets/commit/d793e7b))
 
 
 ### Features
 
-* **widget-demo:** initial package ([9ac14ee](https://github.com/webex/react-ciscospark/commit/9ac14ee))
+* **widget-demo:** initial package ([9ac14ee](https://github.com/webex/react-widgets/commit/9ac14ee))
 
 
 
 <a name="0.1.224"></a>
-## [0.1.224](https://github.com/webex/react-ciscospark/compare/v0.1.223...v0.1.224) (2018-01-04)
+## [0.1.224](https://github.com/webex/react-widgets/compare/v0.1.223...v0.1.224) (2018-01-04)
 
 
 ### Bug Fixes
 
-* **tooling:** Fix jenkins error ([912f99e](https://github.com/webex/react-ciscospark/commit/912f99e))
+* **tooling:** Fix jenkins error ([912f99e](https://github.com/webex/react-widgets/commit/912f99e))
 
 
 
 <a name="0.1.223"></a>
-## [0.1.223](https://github.com/webex/react-ciscospark/compare/v0.1.222...v0.1.223) (2018-01-03)
+## [0.1.223](https://github.com/webex/react-widgets/compare/v0.1.222...v0.1.223) (2018-01-03)
 
 
 ### Bug Fixes
 
-* **tooling:** Move redux-logger to main dep ([d0c3a24](https://github.com/webex/react-ciscospark/commit/d0c3a24))
+* **tooling:** Move redux-logger to main dep ([d0c3a24](https://github.com/webex/react-widgets/commit/d0c3a24))
 
 
 
 <a name="0.1.222"></a>
-## [0.1.222](https://github.com/webex/react-ciscospark/compare/v0.1.221...v0.1.222) (2018-01-03)
+## [0.1.222](https://github.com/webex/react-widgets/compare/v0.1.221...v0.1.222) (2018-01-03)
 
 
 ### Bug Fixes
 
-* **spark-widget-base:** Fix eventing API ([8ef4f66](https://github.com/webex/react-ciscospark/commit/8ef4f66))
+* **spark-widget-base:** Fix eventing API ([8ef4f66](https://github.com/webex/react-widgets/commit/8ef4f66))
 
 
 
 <a name="0.1.221"></a>
-## [0.1.221](https://github.com/webex/react-ciscospark/compare/0426d8e...v0.1.221) (2018-01-02)
+## [0.1.221](https://github.com/webex/react-widgets/compare/0426d8e...v0.1.221) (2018-01-02)
 
 
 ### Bug Fixes
 
-* Add check for immutable object is defined ([6dde18b](https://github.com/webex/react-ciscospark/commit/6dde18b))
-* Add file-saver dep ([04254d7](https://github.com/webex/react-ciscospark/commit/04254d7))
-* add static version of webrtc-adapter ([8894969](https://github.com/webex/react-ciscospark/commit/8894969))
-* All eslint errors and jest snapshots ([786028f](https://github.com/webex/react-ciscospark/commit/786028f))
-* Check for currentUser before accessing props ([0aaa461](https://github.com/webex/react-ciscospark/commit/0aaa461))
-* Cleanup build all script ([1a8746a](https://github.com/webex/react-ciscospark/commit/1a8746a))
-* **redux-module-activity:** Fix marked cleaning process ([ebf318d](https://github.com/webex/react-ciscospark/commit/ebf318d))
-* Cleanup extraneous files and missing gitignores ([937f95c](https://github.com/webex/react-ciscospark/commit/937f95c))
-* **@ciscospark/react-redux-spark:** quiet the logger in production ([cf6e5aa](https://github.com/webex/react-ciscospark/commit/cf6e5aa))
-* **container-file-downloader:** Remove console.log ([b65b0c3](https://github.com/webex/react-ciscospark/commit/b65b0c3))
-* **container-file-downloader:** Update tests and mocks ([04072c9](https://github.com/webex/react-ciscospark/commit/04072c9))
-* **demo:** Add demo to root bundle ([5bfaeab](https://github.com/webex/react-ciscospark/commit/5bfaeab))
-* **demo:** load the proper widget files for demo ([338d61b](https://github.com/webex/react-ciscospark/commit/338d61b))
-* **demo:** removing oauth from demo ([10ccdd3](https://github.com/webex/react-ciscospark/commit/10ccdd3))
-* **metrics:** Added additional metrics, consts for names ([d2bcffa](https://github.com/webex/react-ciscospark/commit/d2bcffa))
-* **package:** update [@ciscospark](https://github.com/webex)/internal-plugin-conversation to version 1.11.0 ([a56073a](https://github.com/webex/react-ciscospark/commit/a56073a))
-* **package:** update [@ciscospark](https://github.com/webex)/plugin-people to version 1.10.4 ([a7dfe12](https://github.com/webex/react-ciscospark/commit/a7dfe12))
-* **package:** update [@ciscospark](https://github.com/webex)/plugin-people to version 1.12.0 ([76b9a5a](https://github.com/webex/react-ciscospark/commit/76b9a5a))
-* **package:** update [@ciscospark](https://github.com/webex)/plugin-phone to version 1.12.0 ([914a0c6](https://github.com/webex/react-ciscospark/commit/914a0c6))
-* **package:** update core-decorators to version 0.20.0 ([6de559f](https://github.com/webex/react-ciscospark/commit/6de559f))
-* **package:** update material-ui to version 0.19.4 ([8af435d](https://github.com/webex/react-ciscospark/commit/8af435d)), closes [#429](https://github.com/webex/react-ciscospark/issues/429)
-* **package:** update react to version 16.1.0 ([b1f071c](https://github.com/webex/react-ciscospark/commit/b1f071c)), closes [#484](https://github.com/webex/react-ciscospark/issues/484)
-* **package:** update react-dom to version 16.0.0 ([4cd7e75](https://github.com/webex/react-ciscospark/commit/4cd7e75))
-* **package:** update react-dom to version 16.1.0 ([dd51c73](https://github.com/webex/react-ciscospark/commit/dd51c73)), closes [#485](https://github.com/webex/react-ciscospark/issues/485)
-* **package:** update react-draggable to version 3.0.3 ([f24c9a8](https://github.com/webex/react-ciscospark/commit/f24c9a8)), closes [#438](https://github.com/webex/react-ciscospark/issues/438)
-* **package:** update react-dropzone to version 4.1.3 ([c165f1b](https://github.com/webex/react-ciscospark/commit/c165f1b)), closes [#396](https://github.com/webex/react-ciscospark/issues/396)
-* **package:** update reselect to version 3.0.0 ([a9a94b6](https://github.com/webex/react-ciscospark/commit/a9a94b6))
-* **react-component-activity-item-base:** Remove required name propType ([e2a132d](https://github.com/webex/react-ciscospark/commit/e2a132d))
-* **react-component-activity-menu:** namespace css class names ([ee5546a](https://github.com/webex/react-ciscospark/commit/ee5546a))
-* **react-component-avatar:** Eslint error ([993df79](https://github.com/webex/react-ciscospark/commit/993df79))
-* **react-component-avatar:** size avatar-self properly ([67e7a44](https://github.com/webex/react-ciscospark/commit/67e7a44))
-* **react-component-button:** Add extra specificity to button classes ([bb0dfc3](https://github.com/webex/react-ciscospark/commit/bb0dfc3))
-* **react-component-button:** change key handler ([4c908d3](https://github.com/webex/react-ciscospark/commit/4c908d3))
-* **react-component-button-controls:** ensure a key is provided to map ([673a746](https://github.com/webex/react-ciscospark/commit/673a746))
-* **react-component-button-controls:** remove manual assignment of a11y label ([891880d](https://github.com/webex/react-ciscospark/commit/891880d))
-* **react-component-icon:** use specific classname ([12a140b](https://github.com/webex/react-ciscospark/commit/12a140b))
-* **react-component-people-list:** Fix onItemClick binding ([cb2ac0f](https://github.com/webex/react-ciscospark/commit/cb2ac0f))
-* **react-component-ringtone:** Add try/catch for creating audio ([adcecc6](https://github.com/webex/react-ciscospark/commit/adcecc6))
-* **react-component-spark-fonts:** remove unreferenced fonts ([34bc17f](https://github.com/webex/react-ciscospark/commit/34bc17f))
-* **react-component-spark-fonts:** remove wrapper component ([cf7d79e](https://github.com/webex/react-ciscospark/commit/cf7d79e))
-* **react-component-system-message:** Move messages to separate file ([2674828](https://github.com/webex/react-ciscospark/commit/2674828))
-* **react-component-utils:** Disable metrics ([7b4f948](https://github.com/webex/react-ciscospark/commit/7b4f948))
-* **react-component-utils:** rename uuid utils to not conflict with uuid package ([b4d6123](https://github.com/webex/react-ciscospark/commit/b4d6123))
-* **react-component-video:** Change prop names ([b4d0c3b](https://github.com/webex/react-ciscospark/commit/b4d0c3b))
-* **react-component-video:** Remove video muted props ([591eadc](https://github.com/webex/react-ciscospark/commit/591eadc))
-* **react-container-activity-list:** Add whitelist for activity types ([d14b6be](https://github.com/webex/react-ciscospark/commit/d14b6be))
-* **react-container-file-downloader:** Update browser-saveas to file-saver ([8d1a75a](https://github.com/webex/react-ciscospark/commit/8d1a75a))
-* **react-container-file-uploader:** Ensure button is clickable ([54a9e3b](https://github.com/webex/react-ciscospark/commit/54a9e3b))
-* **react-container-message-composer:** Add timeout for stop typing ([9598459](https://github.com/webex/react-ciscospark/commit/9598459))
-* **react-container-message-composer:** Do not send event on every keypress ([a173577](https://github.com/webex/react-ciscospark/commit/a173577))
-* **react-container-message-composer:** Fix failing tests ([4ee63f9](https://github.com/webex/react-ciscospark/commit/4ee63f9))
-* **react-container-message-composer:** Hide current user in mention suggestions ([702aeea](https://github.com/webex/react-ciscospark/commit/702aeea))
-* **react-container-message-composer:** Spacing issues ([479b3af](https://github.com/webex/react-ciscospark/commit/479b3af))
-* **react-container-notifications:** Fix addEventListener ([1286f3f](https://github.com/webex/react-ciscospark/commit/1286f3f))
-* **react-container-read-receipts:** fix participants selector being immutable aware ([0256dfc](https://github.com/webex/react-ciscospark/commit/0256dfc))
-* **react-container-read-receipts:** fix slice props ([1ef32cd](https://github.com/webex/react-ciscospark/commit/1ef32cd))
-* **react-container-read-receipts:** fix vertical stacking of read receipts ([0f542e6](https://github.com/webex/react-ciscospark/commit/0f542e6))
-* **react-redux-spark:** Export correct HOC ([576a918](https://github.com/webex/react-ciscospark/commit/576a918))
-* **react-redux-spark:** stop attempting to register on failure ([46facec](https://github.com/webex/react-ciscospark/commit/46facec))
-* **react-redux-spark-metrics:** Order of props override ([aba9869](https://github.com/webex/react-ciscospark/commit/aba9869))
-* **redux-mmodule-mercury:** Fix metric typo ([638e31b](https://github.com/webex/react-ciscospark/commit/638e31b))
-* **redux-module-activity:** add support for empty strings in #createMessageObject ([e014735](https://github.com/webex/react-ciscospark/commit/e014735))
-* **redux-module-activity:** clear typing indicator when sending activity ([0a9d81c](https://github.com/webex/react-ciscospark/commit/0a9d81c))
-* **redux-module-activity:** Fix sending messages with html ([0613337](https://github.com/webex/react-ciscospark/commit/0613337))
-* **redux-module-avatar:** Avatar storage and retrieval issue ([c122423](https://github.com/webex/react-ciscospark/commit/c122423))
-* **redux-module-avatar:** Redefine direct space with 2 participants ([8818581](https://github.com/webex/react-ciscospark/commit/8818581))
-* **redux-module-conversation:** add param to previous message load ([27f8f82](https://github.com/webex/react-ciscospark/commit/27f8f82))
-* **redux-module-conversation:** call computeRoomProperties on create ([bcc6c32](https://github.com/webex/react-ciscospark/commit/bcc6c32))
-* **redux-module-conversation:** fix acknowledge activity to use immutable for participants ([841d7b7](https://github.com/webex/react-ciscospark/commit/841d7b7))
-* **redux-module-conversation:** fix and use updateConversationState ([3631046](https://github.com/webex/react-ciscospark/commit/3631046))
-* **redux-module-conversation:** Remove extraneous state ([cab995e](https://github.com/webex/react-ciscospark/commit/cab995e))
-* **redux-module-conversation:** Remove single participant drops more than one ([f39667a](https://github.com/webex/react-ciscospark/commit/f39667a))
-* **redux-module-errors:** change to proper name #addError ([9619418](https://github.com/webex/react-ciscospark/commit/9619418))
-* **redux-module-errors:** fix hasError calculation ([6375ab6](https://github.com/webex/react-ciscospark/commit/6375ab6))
-* **redux-module-errors:** fix hasError calculation ([cd7b65c](https://github.com/webex/react-ciscospark/commit/cd7b65c))
-* **redux-module-flags:** Fix tests and broken immutable getters ([0b469a4](https://github.com/webex/react-ciscospark/commit/0b469a4))
-* **redux-module-flags:** Fixed extraneous then ([3789c1f](https://github.com/webex/react-ciscospark/commit/3789c1f))
-* **redux-module-media:** Add returns to thunks ([181e1d8](https://github.com/webex/react-ciscospark/commit/181e1d8))
-* **redux-module-media:** Adjust status name ([40f7cc0](https://github.com/webex/react-ciscospark/commit/40f7cc0))
-* **redux-module-media:** Call decline immedately declines call ([adfc6f8](https://github.com/webex/react-ciscospark/commit/adfc6f8))
-* **redux-module-media:** compute activeParticipantsCount for call state ([a186d23](https://github.com/webex/react-ciscospark/commit/a186d23))
-* **redux-module-media:** Convert prop to object ([838942f](https://github.com/webex/react-ciscospark/commit/838942f))
-* **redux-module-media:** Fix calling not recieving remote media ([1a16015](https://github.com/webex/react-ciscospark/commit/1a16015))
-* **redux-module-media:** Fix eslint error and connect event listeners ([f3c7a62](https://github.com/webex/react-ciscospark/commit/f3c7a62))
-* **redux-module-media:** Fix event firing order for local self view display ([574f052](https://github.com/webex/react-ciscospark/commit/574f052))
-* **redux-module-media:** Locus id to locus url ([71f1a87](https://github.com/webex/react-ciscospark/commit/71f1a87))
-* **redux-module-media:** Maintain webRTC isSupported state ([7640c72](https://github.com/webex/react-ciscospark/commit/7640c72))
-* **redux-module-media:** pass proper offer options to call object ([b98136a](https://github.com/webex/react-ciscospark/commit/b98136a))
-* **redux-module-media:** properly get current state on incoming call ([aa817f3](https://github.com/webex/react-ciscospark/commit/aa817f3))
-* **redux-module-media:** Release camera on call failure ([77102bd](https://github.com/webex/react-ciscospark/commit/77102bd))
-* **redux-module-media:** smarter local media stream handling ([13148a0](https://github.com/webex/react-ciscospark/commit/13148a0))
-* **redux-module-media:** Split audio and video tracks to fix video mute ([8cf55f7](https://github.com/webex/react-ciscospark/commit/8cf55f7))
-* **redux-module-media:** store call once we have a locus ([23084ec](https://github.com/webex/react-ciscospark/commit/23084ec))
-* **redux-module-mercury:** Return on thunk ([159738b](https://github.com/webex/react-ciscospark/commit/159738b))
-* **redux-module-presence:** fix eslint errors ([0c267b9](https://github.com/webex/react-ciscospark/commit/0c267b9))
-* **redux-module-spaces:** add support for directs with deleted users ([4aa898d](https://github.com/webex/react-ciscospark/commit/4aa898d))
-* **redux-module-spaces:** eslint and jsdoc fixes ([487a145](https://github.com/webex/react-ciscospark/commit/487a145))
-* **redux-module-spaces:** sort space results before getting the oldest ([09b8cd8](https://github.com/webex/react-ciscospark/commit/09b8cd8))
-* **redux-module-teams:** Fix wrong action names ([557501a](https://github.com/webex/react-ciscospark/commit/557501a))
-* **redux-module-teams:** Prevent infinite team fetching ([fcbf871](https://github.com/webex/react-ciscospark/commit/fcbf871))
-* **redux-module-user:** Make metric name uniform ([c5ce5bb](https://github.com/webex/react-ciscospark/commit/c5ce5bb))
-* **space-widget:** Fix bad element reference and remove unused component ([4884b7f](https://github.com/webex/react-ciscospark/commit/4884b7f))
-* **spark-widget-base:** Create new store on each widget instance ([266fd53](https://github.com/webex/react-ciscospark/commit/266fd53))
-* **spark-widget-base:** Do not remove clear on unmount ([f3566a1](https://github.com/webex/react-ciscospark/commit/f3566a1))
-* **tap:** widget message meet cannot use meet helper functions ([1d529a0](https://github.com/webex/react-ciscospark/commit/1d529a0))
-* **tests:** Fix wmm journey test ([5cd9a8f](https://github.com/webex/react-ciscospark/commit/5cd9a8f))
-* **tooling:** Add html build step, version to file header, global use strict ([0a41404](https://github.com/webex/react-ciscospark/commit/0a41404))
-* **tooling:** Add node 7 install to tap tests ([bec42bf](https://github.com/webex/react-ciscospark/commit/bec42bf))
-* **tooling:** Add node_env back to build commands ([cbf06d0](https://github.com/webex/react-ciscospark/commit/cbf06d0))
-* **tooling:** Add rebuild to tap tests ([972d6b1](https://github.com/webex/react-ciscospark/commit/972d6b1))
-* **tooling:** Add spark-widget-base to jest config ([ca505ad](https://github.com/webex/react-ciscospark/commit/ca505ad))
-* **tooling:** Add utc TZ to jest tests ([e8377c8](https://github.com/webex/react-ciscospark/commit/e8377c8))
-* **tooling:** Build output target issue ([511a5f9](https://github.com/webex/react-ciscospark/commit/511a5f9))
-* **tooling:** Chnage stylelint config to js ([af188fb](https://github.com/webex/react-ciscospark/commit/af188fb))
-* **tooling:** Clean build scripts, update Jenkinsfile ([8da1869](https://github.com/webex/react-ciscospark/commit/8da1869))
-* **tooling:** Clean local tags when building ([ef90800](https://github.com/webex/react-ciscospark/commit/ef90800))
-* **tooling:** Copy non-js files correctly on build ([32bf054](https://github.com/webex/react-ciscospark/commit/32bf054))
-* **tooling:** Fix circle npm install ([958a360](https://github.com/webex/react-ciscospark/commit/958a360))
-* **tooling:** Fix circle tests ([548a40e](https://github.com/webex/react-ciscospark/commit/548a40e))
-* **tooling:** Fix credentials ([d7dac40](https://github.com/webex/react-ciscospark/commit/d7dac40))
-* **tooling:** Fix git version bumping ([049a5ff](https://github.com/webex/react-ciscospark/commit/049a5ff))
-* **tooling:** Fix jenkinsfile syntax ([7499332](https://github.com/webex/react-ciscospark/commit/7499332))
-* **tooling:** Fix jenkinsfile syntax take 2 ([7a9a322](https://github.com/webex/react-ciscospark/commit/7a9a322))
-* **tooling:** Fix moment build, add react-intl ([a869dc0](https://github.com/webex/react-ciscospark/commit/a869dc0))
-* **tooling:** Fix syntax issue ([f2b8a0c](https://github.com/webex/react-ciscospark/commit/f2b8a0c))
-* **tooling:** Fix test user missing access token ([2b4b7e5](https://github.com/webex/react-ciscospark/commit/2b4b7e5))
-* **tooling:** Fix test user missing access token ([b71a9aa](https://github.com/webex/react-ciscospark/commit/b71a9aa))
-* **tooling:** Fix transpile and postcss script ([e759bde](https://github.com/webex/react-ciscospark/commit/e759bde))
-* **tooling:** Force git to reset and clean directory ([502eda8](https://github.com/webex/react-ciscospark/commit/502eda8))
-* **tooling:** Jenkins version bump variables ([10bb90a](https://github.com/webex/react-ciscospark/commit/10bb90a))
-* **tooling:** Jenkinsfile remove NPM_CONFIG_REGISTRY ([bb981e5](https://github.com/webex/react-ciscospark/commit/bb981e5))
-* **tooling:** Jenkinsfile remove npmrc after install ([d2a5d1b](https://github.com/webex/react-ciscospark/commit/d2a5d1b))
-* **tooling:** Move jenkinsfile.tap to procedural groovy ([241b5fb](https://github.com/webex/react-ciscospark/commit/241b5fb))
-* **tooling:** Move jsnext:main to module in package.json ([c407e46](https://github.com/webex/react-ciscospark/commit/c407e46))
-* **tooling:** Move redux-logger to main dep, add sri-toolbox ([488ade3](https://github.com/webex/react-ciscospark/commit/488ade3))
-* **tooling:** Patch for babel transform runtime bug ([ac6a069](https://github.com/webex/react-ciscospark/commit/ac6a069))
-* **tooling:** Point to correct CDN location ([ca7c820](https://github.com/webex/react-ciscospark/commit/ca7c820))
-* **tooling:** Remove npm rebuild from tap scripts ([5b189bd](https://github.com/webex/react-ciscospark/commit/5b189bd))
-* **tooling:** Reset all package package.json files" ([5e77e7e](https://github.com/webex/react-ciscospark/commit/5e77e7e))
-* **tooling:** Tweak dev server, add fonts to icon ([3a3f10e](https://github.com/webex/react-ciscospark/commit/3a3f10e))
-* **tooling:** Update deps, eslint-config still an issue ([0267bdf](https://github.com/webex/react-ciscospark/commit/0267bdf))
-* **tooling:** Update stylelint ([e6d00b9](https://github.com/webex/react-ciscospark/commit/e6d00b9))
-* **tooling:** Update transpile script to use babel-preset-env ([693d98d](https://github.com/webex/react-ciscospark/commit/693d98d))
-* **tooling:** Update unused release.sh ([4743f20](https://github.com/webex/react-ciscospark/commit/4743f20))
-* **tooling:** Whitelist env vars ([e6c1c15](https://github.com/webex/react-ciscospark/commit/e6c1c15))
-* **tools:** add NODE_ENV var to start script ([3a14ba4](https://github.com/webex/react-ciscospark/commit/3a14ba4))
-* **widget-base:** Add correct name detection ([ff947d9](https://github.com/webex/react-ciscospark/commit/ff947d9))
-* **widget-base:** Add spark reducer as default ([9fd6373](https://github.com/webex/react-ciscospark/commit/9fd6373))
-* **widget-base:** Broken Safari data-api ([9c23554](https://github.com/webex/react-ciscospark/commit/9c23554))
-* **widget-base:** Change console.warning to console.warn ([4762217](https://github.com/webex/react-ciscospark/commit/4762217))
-* **widget-base:** Fix initial store load when using ReactComponent ([5b01ae2](https://github.com/webex/react-ciscospark/commit/5b01ae2))
-* **widget-base:** Fix message-composer being blocked in Safari ([0bd6b0f](https://github.com/webex/react-ciscospark/commit/0bd6b0f))
-* **widget-base:** Fix onEvent calling ([9ec0bb4](https://github.com/webex/react-ciscospark/commit/9ec0bb4))
-* **widget-base:** Init new store for every top level widget ([afb205d](https://github.com/webex/react-ciscospark/commit/afb205d))
-* **widget-base:** Inject wrapper class if necessary ([99694c0](https://github.com/webex/react-ciscospark/commit/99694c0))
-* **widget-base:** Minor changes based on feedback ([43c97f6](https://github.com/webex/react-ciscospark/commit/43c97f6))
-* **widget-base:** Remove amp events when widget is removed ([87c745a](https://github.com/webex/react-ciscospark/commit/87c745a))
-* **widget-base:** Remove bad merge ([05e581d](https://github.com/webex/react-ciscospark/commit/05e581d))
-* **widget-base:** Remove old metrics, fix init timing issue ([8bb4d72](https://github.com/webex/react-ciscospark/commit/8bb4d72))
-* **widget-base:** Remove unused localStorageAdapter ([165fa22](https://github.com/webex/react-ciscospark/commit/165fa22))
-* **widget-base:** return unmount status during .remove() ([e2c25a0](https://github.com/webex/react-ciscospark/commit/e2c25a0))
-* **widget-base:** Update createLogger ([fc0f62b](https://github.com/webex/react-ciscospark/commit/fc0f62b))
-* **widget-meet:** add call from data on incoming call ([27bd414](https://github.com/webex/react-ciscospark/commit/27bd414))
-* **widget-meet:** All StartCall prop to accept string value ([47df59f](https://github.com/webex/react-ciscospark/commit/47df59f))
-* **widget-meet:** capitalize accessibility labels for control buttons ([59027ec](https://github.com/webex/react-ciscospark/commit/59027ec))
-* **widget-meet:** Disable eslint complexity rule ([f764412](https://github.com/webex/react-ciscospark/commit/f764412))
-* **widget-meet:** Do not display controls until call object is available ([6036514](https://github.com/webex/react-ciscospark/commit/6036514))
-* **widget-meet:** emit proper disconnect event ([90c37ca](https://github.com/webex/react-ciscospark/commit/90c37ca))
-* **widget-meet:** fix display of incoming call and inactive call components at same time ([6d1447a](https://github.com/webex/react-ciscospark/commit/6d1447a))
-* **widget-meet:** Fix start call flag ([e4d3439](https://github.com/webex/react-ciscospark/commit/e4d3439))
-* **widget-meet:** Fix webrtc detection in safari ([6ef3bac](https://github.com/webex/react-ciscospark/commit/6ef3bac))
-* **widget-meet:** Fix wrong PropType ([62a4119](https://github.com/webex/react-ciscospark/commit/62a4119))
-* **widget-meet:** Force mute buttons active until connect ([0684d6b](https://github.com/webex/react-ciscospark/commit/0684d6b))
-* **widget-meet:** hangup on unmount ([801d83d](https://github.com/webex/react-ciscospark/commit/801d83d))
-* **widget-meet:** keep video component in dom when video muted ([2cfb9ea](https://github.com/webex/react-ciscospark/commit/2cfb9ea))
-* **widget-meet:** Listen to incoming messages ([5ec20b8](https://github.com/webex/react-ciscospark/commit/5ec20b8))
-* **widget-meet:** load space avatar from avatars store ([dcb9bda](https://github.com/webex/react-ciscospark/commit/dcb9bda))
-* **widget-meet:** remove check for button state ([ca19da7](https://github.com/webex/react-ciscospark/commit/ca19da7))
-* **widget-meet:** space calling should go to hydra id ([870d984](https://github.com/webex/react-ciscospark/commit/870d984))
-* **widget-meet:** Update messaging ([ea81e26](https://github.com/webex/react-ciscospark/commit/ea81e26))
-* **widget-meet:** Update sdk to get facing mode fix ([a50f18c](https://github.com/webex/react-ciscospark/commit/a50f18c))
-* **widget-message:** Add check for buffer state listener ([afd0a62](https://github.com/webex/react-ciscospark/commit/afd0a62))
-* **widget-message:** add detail is listening flags ([47de0f4](https://github.com/webex/react-ciscospark/commit/47de0f4))
-* **widget-message:** Add getFeature method ([067833c](https://github.com/webex/react-ciscospark/commit/067833c))
-* **widget-message:** Add getFeature to proptypes ([3bdd12a](https://github.com/webex/react-ciscospark/commit/3bdd12a))
-* **widget-message:** bind handle flag action ([45e4e60](https://github.com/webex/react-ciscospark/commit/45e4e60))
-* **widget-message:** Blank name in message composer ([ff3888a](https://github.com/webex/react-ciscospark/commit/ff3888a))
-* **widget-message:** change to use widgetMessage props ([89f3301](https://github.com/webex/react-ciscospark/commit/89f3301))
-* **widget-message:** Check for activity before test ([bafd1ad](https://github.com/webex/react-ciscospark/commit/bafd1ad))
-* **widget-message:** Do not display message composer until conversation is loaded ([688199f](https://github.com/webex/react-ciscospark/commit/688199f))
-* **widget-message:** Do not fire messages:unread when this user sends ([ea646c6](https://github.com/webex/react-ciscospark/commit/ea646c6))
-* **widget-message:** Fix at mention structure and proptype ([0bf82a4](https://github.com/webex/react-ciscospark/commit/0bf82a4))
-* **widget-message:** Fix overwriting issue with target id ([9d00b89](https://github.com/webex/react-ciscospark/commit/9d00b89))
-* **widget-message:** Fix style issue in composer ([8aeee50](https://github.com/webex/react-ciscospark/commit/8aeee50))
-* **widget-message:** get immutable widget properties properly ([58213b2](https://github.com/webex/react-ciscospark/commit/58213b2))
-* **widget-message:** handle empty toUser ([fb348c7](https://github.com/webex/react-ciscospark/commit/fb348c7))
-* **widget-message:** Load history scroll not sticking ([238fa61](https://github.com/webex/react-ciscospark/commit/238fa61))
-* **widget-message:** Move messages:created to before rooms:unread ([23d5612](https://github.com/webex/react-ciscospark/commit/23d5612))
-* **widget-message:** Move props to selector, fix text placeholder ([c529dc8](https://github.com/webex/react-ciscospark/commit/c529dc8))
-* **widget-message:** remove empty notification of locus events ([ccf80cb](https://github.com/webex/react-ciscospark/commit/ccf80cb))
-* **widget-message:** store current user id outside event block ([4972c05](https://github.com/webex/react-ciscospark/commit/4972c05))
-* **widget-message:** Wait for device registration before createconvo ([a1b6665](https://github.com/webex/react-ciscospark/commit/a1b6665))
-* **widget-message-meet:** Add border-box, fix title bar overlap ([cd0232f](https://github.com/webex/react-ciscospark/commit/cd0232f))
-* **widget-message-meet:** Add eslint ignore for complexity ([4f1da96](https://github.com/webex/react-ciscospark/commit/4f1da96))
-* **widget-message-meet:** Allow conversation with user with no account ([fd75c39](https://github.com/webex/react-ciscospark/commit/fd75c39))
-* **widget-message-meet:** Check for required data before load ([589165b](https://github.com/webex/react-ciscospark/commit/589165b))
-* **widget-message-meet:** Compile issue causes global class issue ([1096502](https://github.com/webex/react-ciscospark/commit/1096502))
-* **widget-message-meet:** display only one widget in demo ([823e67d](https://github.com/webex/react-ciscospark/commit/823e67d))
-* **widget-message-meet:** Fix auth issue and adjusted styles ([2947835](https://github.com/webex/react-ciscospark/commit/2947835))
-* **widget-message-meet:** fix bad merge and misspelling ([d1d7d2e](https://github.com/webex/react-ciscospark/commit/d1d7d2e))
-* **widget-message-meet:** Fix style issues in FF, and proptypes errors ([5da911c](https://github.com/webex/react-ciscospark/commit/5da911c))
-* **widget-message-meet:** Move checks to allow more parallel requests ([e59eac0](https://github.com/webex/react-ciscospark/commit/e59eac0))
-* **widget-message-meet:** pass proper property to meet ([493119a](https://github.com/webex/react-ciscospark/commit/493119a))
-* **widget-message-meet:** properly load avatar in title bar ([bf97a13](https://github.com/webex/react-ciscospark/commit/bf97a13))
-* **widget-message-meet:** Revert container to just message widget" ([1e2ac73](https://github.com/webex/react-ciscospark/commit/1e2ac73))
-* **widget-message-meet:** Switch to meet on incoming call ([eada7e7](https://github.com/webex/react-ciscospark/commit/eada7e7))
-* **widget-message-meet-demo:** clear token cookie properly ([2fc0df7](https://github.com/webex/react-ciscospark/commit/2fc0df7))
-* **widget-recents:** Add recents to jenkinsfile, toJS fix ([a3249c3](https://github.com/webex/react-ciscospark/commit/a3249c3))
-* **widget-recents:** Correct event removal issue on incoming calls ([ae5af79](https://github.com/webex/react-ciscospark/commit/ae5af79))
-* **widget-recents:** delete incoming call when connected ([a5d867d](https://github.com/webex/react-ciscospark/commit/a5d867d))
-* **widget-recents:** Do not mark rooms user sent message in as unread ([9139906](https://github.com/webex/react-ciscospark/commit/9139906))
-* **widget-recents:** Fix complexity eslit error ([7c1f210](https://github.com/webex/react-ciscospark/commit/7c1f210))
-* **widget-recents:** Fix membership:created event ([a9ec826](https://github.com/webex/react-ciscospark/commit/a9ec826))
-* **widget-recents:** Fix space click bug ([bb5dcdf](https://github.com/webex/react-ciscospark/commit/bb5dcdf))
-* **widget-recents:** Fix space name split error ([58b0988](https://github.com/webex/react-ciscospark/commit/58b0988))
-* **widget-recents:** Prevent call button for group spaces ([1161eb0](https://github.com/webex/react-ciscospark/commit/1161eb0))
-* **widget-recents:** Prevent stack range error on call logger ([1952ed3](https://github.com/webex/react-ciscospark/commit/1952ed3))
-* **widget-recents:** Rearranged action/reducer order, add jsdocs ([2d7eda4](https://github.com/webex/react-ciscospark/commit/2d7eda4))
-* **widget-recents:** Remove no-enter keypresses for selecting space ([e7b7ff5](https://github.com/webex/react-ciscospark/commit/e7b7ff5))
-* **widget-recents:** Show unread indicator when space has never been seen ([2b35b7a](https://github.com/webex/react-ciscospark/commit/2b35b7a))
-* **widget-recents:** support for untitled rooms ([9c65a8b](https://github.com/webex/react-ciscospark/commit/9c65a8b))
-* **widget-roster:** fix name of the roster from incorrect 'message' ([6f79d1e](https://github.com/webex/react-ciscospark/commit/6f79d1e)), closes [#565](https://github.com/webex/react-ciscospark/issues/565)
-* **widget-roster:** fix sort method and check for room properties ([a778f6c](https://github.com/webex/react-ciscospark/commit/a778f6c))
-* **widget-roster:** Remove unused PropType ([8ed8418](https://github.com/webex/react-ciscospark/commit/8ed8418))
-* **widget-space:** Add higher specificity to button style ([598b7e5](https://github.com/webex/react-ciscospark/commit/598b7e5))
-* **widget-space:** Add internal propType to prop filter ([79874ab](https://github.com/webex/react-ciscospark/commit/79874ab))
-* **widget-space:** Add jsdocs, fix test ([4b43842](https://github.com/webex/react-ciscospark/commit/4b43842))
-* **widget-space:** Allow closing of activity menu from sub widget ([b5c0651](https://github.com/webex/react-ciscospark/commit/b5c0651))
-* **widget-space:** Allow closing of activity menu from sub widget ([db905f9](https://github.com/webex/react-ciscospark/commit/db905f9))
-* **widget-space:** Allow user to call when direct spaceID is provided ([ee6a3d1](https://github.com/webex/react-ciscospark/commit/ee6a3d1))
-* **widget-space:** Ensure correct activity is initially loaded ([0de8b78](https://github.com/webex/react-ciscospark/commit/0de8b78))
-* **widget-space:** Fix eslint error ([c85e6ee](https://github.com/webex/react-ciscospark/commit/c85e6ee))
-* **widget-space:** Fix incoming calls not working ([7d75acc](https://github.com/webex/react-ciscospark/commit/7d75acc))
-* **widget-space:** Fix initialActivity setting with data-api ([7efa831](https://github.com/webex/react-ciscospark/commit/7efa831))
-* **widget-space:** Fix style issue on containers ([f56af28](https://github.com/webex/react-ciscospark/commit/f56af28))
-* **widget-space:** Fixed styles to correctly display activity widget ([9ae76d9](https://github.com/webex/react-ciscospark/commit/9ae76d9))
-* **widget-space:** load space avatar properly ([8bf9ca8](https://github.com/webex/react-ciscospark/commit/8bf9ca8))
-* **widget-space:** prop typo for initialActivity ([9b1a1b0](https://github.com/webex/react-ciscospark/commit/9b1a1b0))
-* **widget-space:** return to message view after call ([26ad8d6](https://github.com/webex/react-ciscospark/commit/26ad8d6))
-* **widget-space:** Revert test template ([a337cbf](https://github.com/webex/react-ciscospark/commit/a337cbf))
-* **widget-space:** Switch to message view after call hangup ([4edc4d4](https://github.com/webex/react-ciscospark/commit/4edc4d4))
-* **widget-space:** UI fixes and API changes ([e56d633](https://github.com/webex/react-ciscospark/commit/e56d633))
-* **widget-space-demo:** Fix package name collision ([f1aeada](https://github.com/webex/react-ciscospark/commit/f1aeada))
-* eslint errors and jest tests from presence merge ([114a1bf](https://github.com/webex/react-ciscospark/commit/114a1bf))
-* fix some lint errors with eslint --fix ([b5ac837](https://github.com/webex/react-ciscospark/commit/b5ac837))
-* gitattributes? ([a2784a0](https://github.com/webex/react-ciscospark/commit/a2784a0))
-* Jest tests, move to in memory object for metrics storage ([6062284](https://github.com/webex/react-ciscospark/commit/6062284))
-* remove extra eslint-disable and fix errors ([562a99c](https://github.com/webex/react-ciscospark/commit/562a99c))
-* Remove extraneous required proptypes ([916fe03](https://github.com/webex/react-ciscospark/commit/916fe03))
-* removing workaround for redux-logger ([fcdcd90](https://github.com/webex/react-ciscospark/commit/fcdcd90))
-* **widget-space-demo:** handle mode toggle properly ([a3557b4](https://github.com/webex/react-ciscospark/commit/a3557b4))
-* **widget-space-demo:** only pass property of selected mode ([0ef2032](https://github.com/webex/react-ciscospark/commit/0ef2032))
-* static method errors ([d9a0e99](https://github.com/webex/react-ciscospark/commit/d9a0e99))
-* Temporarily remove default props for certain objects ([7134dee](https://github.com/webex/react-ciscospark/commit/7134dee))
+* Add check for immutable object is defined ([6dde18b](https://github.com/webex/react-widgets/commit/6dde18b))
+* Add file-saver dep ([04254d7](https://github.com/webex/react-widgets/commit/04254d7))
+* add static version of webrtc-adapter ([8894969](https://github.com/webex/react-widgets/commit/8894969))
+* All eslint errors and jest snapshots ([786028f](https://github.com/webex/react-widgets/commit/786028f))
+* Check for currentUser before accessing props ([0aaa461](https://github.com/webex/react-widgets/commit/0aaa461))
+* Cleanup build all script ([1a8746a](https://github.com/webex/react-widgets/commit/1a8746a))
+* **redux-module-activity:** Fix marked cleaning process ([ebf318d](https://github.com/webex/react-widgets/commit/ebf318d))
+* Cleanup extraneous files and missing gitignores ([937f95c](https://github.com/webex/react-widgets/commit/937f95c))
+* **@ciscospark/react-redux-spark:** quiet the logger in production ([cf6e5aa](https://github.com/webex/react-widgets/commit/cf6e5aa))
+* **container-file-downloader:** Remove console.log ([b65b0c3](https://github.com/webex/react-widgets/commit/b65b0c3))
+* **container-file-downloader:** Update tests and mocks ([04072c9](https://github.com/webex/react-widgets/commit/04072c9))
+* **demo:** Add demo to root bundle ([5bfaeab](https://github.com/webex/react-widgets/commit/5bfaeab))
+* **demo:** load the proper widget files for demo ([338d61b](https://github.com/webex/react-widgets/commit/338d61b))
+* **demo:** removing oauth from demo ([10ccdd3](https://github.com/webex/react-widgets/commit/10ccdd3))
+* **metrics:** Added additional metrics, consts for names ([d2bcffa](https://github.com/webex/react-widgets/commit/d2bcffa))
+* **package:** update [@ciscospark](https://github.com/webex)/internal-plugin-conversation to version 1.11.0 ([a56073a](https://github.com/webex/react-widgets/commit/a56073a))
+* **package:** update [@ciscospark](https://github.com/webex)/plugin-people to version 1.10.4 ([a7dfe12](https://github.com/webex/react-widgets/commit/a7dfe12))
+* **package:** update [@ciscospark](https://github.com/webex)/plugin-people to version 1.12.0 ([76b9a5a](https://github.com/webex/react-widgets/commit/76b9a5a))
+* **package:** update [@ciscospark](https://github.com/webex)/plugin-phone to version 1.12.0 ([914a0c6](https://github.com/webex/react-widgets/commit/914a0c6))
+* **package:** update core-decorators to version 0.20.0 ([6de559f](https://github.com/webex/react-widgets/commit/6de559f))
+* **package:** update material-ui to version 0.19.4 ([8af435d](https://github.com/webex/react-widgets/commit/8af435d)), closes [#429](https://github.com/webex/react-widgets/issues/429)
+* **package:** update react to version 16.1.0 ([b1f071c](https://github.com/webex/react-widgets/commit/b1f071c)), closes [#484](https://github.com/webex/react-widgets/issues/484)
+* **package:** update react-dom to version 16.0.0 ([4cd7e75](https://github.com/webex/react-widgets/commit/4cd7e75))
+* **package:** update react-dom to version 16.1.0 ([dd51c73](https://github.com/webex/react-widgets/commit/dd51c73)), closes [#485](https://github.com/webex/react-widgets/issues/485)
+* **package:** update react-draggable to version 3.0.3 ([f24c9a8](https://github.com/webex/react-widgets/commit/f24c9a8)), closes [#438](https://github.com/webex/react-widgets/issues/438)
+* **package:** update react-dropzone to version 4.1.3 ([c165f1b](https://github.com/webex/react-widgets/commit/c165f1b)), closes [#396](https://github.com/webex/react-widgets/issues/396)
+* **package:** update reselect to version 3.0.0 ([a9a94b6](https://github.com/webex/react-widgets/commit/a9a94b6))
+* **react-component-activity-item-base:** Remove required name propType ([e2a132d](https://github.com/webex/react-widgets/commit/e2a132d))
+* **react-component-activity-menu:** namespace css class names ([ee5546a](https://github.com/webex/react-widgets/commit/ee5546a))
+* **react-component-avatar:** Eslint error ([993df79](https://github.com/webex/react-widgets/commit/993df79))
+* **react-component-avatar:** size avatar-self properly ([67e7a44](https://github.com/webex/react-widgets/commit/67e7a44))
+* **react-component-button:** Add extra specificity to button classes ([bb0dfc3](https://github.com/webex/react-widgets/commit/bb0dfc3))
+* **react-component-button:** change key handler ([4c908d3](https://github.com/webex/react-widgets/commit/4c908d3))
+* **react-component-button-controls:** ensure a key is provided to map ([673a746](https://github.com/webex/react-widgets/commit/673a746))
+* **react-component-button-controls:** remove manual assignment of a11y label ([891880d](https://github.com/webex/react-widgets/commit/891880d))
+* **react-component-icon:** use specific classname ([12a140b](https://github.com/webex/react-widgets/commit/12a140b))
+* **react-component-people-list:** Fix onItemClick binding ([cb2ac0f](https://github.com/webex/react-widgets/commit/cb2ac0f))
+* **react-component-ringtone:** Add try/catch for creating audio ([adcecc6](https://github.com/webex/react-widgets/commit/adcecc6))
+* **react-component-spark-fonts:** remove unreferenced fonts ([34bc17f](https://github.com/webex/react-widgets/commit/34bc17f))
+* **react-component-spark-fonts:** remove wrapper component ([cf7d79e](https://github.com/webex/react-widgets/commit/cf7d79e))
+* **react-component-system-message:** Move messages to separate file ([2674828](https://github.com/webex/react-widgets/commit/2674828))
+* **react-component-utils:** Disable metrics ([7b4f948](https://github.com/webex/react-widgets/commit/7b4f948))
+* **react-component-utils:** rename uuid utils to not conflict with uuid package ([b4d6123](https://github.com/webex/react-widgets/commit/b4d6123))
+* **react-component-video:** Change prop names ([b4d0c3b](https://github.com/webex/react-widgets/commit/b4d0c3b))
+* **react-component-video:** Remove video muted props ([591eadc](https://github.com/webex/react-widgets/commit/591eadc))
+* **react-container-activity-list:** Add whitelist for activity types ([d14b6be](https://github.com/webex/react-widgets/commit/d14b6be))
+* **react-container-file-downloader:** Update browser-saveas to file-saver ([8d1a75a](https://github.com/webex/react-widgets/commit/8d1a75a))
+* **react-container-file-uploader:** Ensure button is clickable ([54a9e3b](https://github.com/webex/react-widgets/commit/54a9e3b))
+* **react-container-message-composer:** Add timeout for stop typing ([9598459](https://github.com/webex/react-widgets/commit/9598459))
+* **react-container-message-composer:** Do not send event on every keypress ([a173577](https://github.com/webex/react-widgets/commit/a173577))
+* **react-container-message-composer:** Fix failing tests ([4ee63f9](https://github.com/webex/react-widgets/commit/4ee63f9))
+* **react-container-message-composer:** Hide current user in mention suggestions ([702aeea](https://github.com/webex/react-widgets/commit/702aeea))
+* **react-container-message-composer:** Spacing issues ([479b3af](https://github.com/webex/react-widgets/commit/479b3af))
+* **react-container-notifications:** Fix addEventListener ([1286f3f](https://github.com/webex/react-widgets/commit/1286f3f))
+* **react-container-read-receipts:** fix participants selector being immutable aware ([0256dfc](https://github.com/webex/react-widgets/commit/0256dfc))
+* **react-container-read-receipts:** fix slice props ([1ef32cd](https://github.com/webex/react-widgets/commit/1ef32cd))
+* **react-container-read-receipts:** fix vertical stacking of read receipts ([0f542e6](https://github.com/webex/react-widgets/commit/0f542e6))
+* **react-redux-spark:** Export correct HOC ([576a918](https://github.com/webex/react-widgets/commit/576a918))
+* **react-redux-spark:** stop attempting to register on failure ([46facec](https://github.com/webex/react-widgets/commit/46facec))
+* **react-redux-spark-metrics:** Order of props override ([aba9869](https://github.com/webex/react-widgets/commit/aba9869))
+* **redux-mmodule-mercury:** Fix metric typo ([638e31b](https://github.com/webex/react-widgets/commit/638e31b))
+* **redux-module-activity:** add support for empty strings in #createMessageObject ([e014735](https://github.com/webex/react-widgets/commit/e014735))
+* **redux-module-activity:** clear typing indicator when sending activity ([0a9d81c](https://github.com/webex/react-widgets/commit/0a9d81c))
+* **redux-module-activity:** Fix sending messages with html ([0613337](https://github.com/webex/react-widgets/commit/0613337))
+* **redux-module-avatar:** Avatar storage and retrieval issue ([c122423](https://github.com/webex/react-widgets/commit/c122423))
+* **redux-module-avatar:** Redefine direct space with 2 participants ([8818581](https://github.com/webex/react-widgets/commit/8818581))
+* **redux-module-conversation:** add param to previous message load ([27f8f82](https://github.com/webex/react-widgets/commit/27f8f82))
+* **redux-module-conversation:** call computeRoomProperties on create ([bcc6c32](https://github.com/webex/react-widgets/commit/bcc6c32))
+* **redux-module-conversation:** fix acknowledge activity to use immutable for participants ([841d7b7](https://github.com/webex/react-widgets/commit/841d7b7))
+* **redux-module-conversation:** fix and use updateConversationState ([3631046](https://github.com/webex/react-widgets/commit/3631046))
+* **redux-module-conversation:** Remove extraneous state ([cab995e](https://github.com/webex/react-widgets/commit/cab995e))
+* **redux-module-conversation:** Remove single participant drops more than one ([f39667a](https://github.com/webex/react-widgets/commit/f39667a))
+* **redux-module-errors:** change to proper name #addError ([9619418](https://github.com/webex/react-widgets/commit/9619418))
+* **redux-module-errors:** fix hasError calculation ([6375ab6](https://github.com/webex/react-widgets/commit/6375ab6))
+* **redux-module-errors:** fix hasError calculation ([cd7b65c](https://github.com/webex/react-widgets/commit/cd7b65c))
+* **redux-module-flags:** Fix tests and broken immutable getters ([0b469a4](https://github.com/webex/react-widgets/commit/0b469a4))
+* **redux-module-flags:** Fixed extraneous then ([3789c1f](https://github.com/webex/react-widgets/commit/3789c1f))
+* **redux-module-media:** Add returns to thunks ([181e1d8](https://github.com/webex/react-widgets/commit/181e1d8))
+* **redux-module-media:** Adjust status name ([40f7cc0](https://github.com/webex/react-widgets/commit/40f7cc0))
+* **redux-module-media:** Call decline immedately declines call ([adfc6f8](https://github.com/webex/react-widgets/commit/adfc6f8))
+* **redux-module-media:** compute activeParticipantsCount for call state ([a186d23](https://github.com/webex/react-widgets/commit/a186d23))
+* **redux-module-media:** Convert prop to object ([838942f](https://github.com/webex/react-widgets/commit/838942f))
+* **redux-module-media:** Fix calling not recieving remote media ([1a16015](https://github.com/webex/react-widgets/commit/1a16015))
+* **redux-module-media:** Fix eslint error and connect event listeners ([f3c7a62](https://github.com/webex/react-widgets/commit/f3c7a62))
+* **redux-module-media:** Fix event firing order for local self view display ([574f052](https://github.com/webex/react-widgets/commit/574f052))
+* **redux-module-media:** Locus id to locus url ([71f1a87](https://github.com/webex/react-widgets/commit/71f1a87))
+* **redux-module-media:** Maintain webRTC isSupported state ([7640c72](https://github.com/webex/react-widgets/commit/7640c72))
+* **redux-module-media:** pass proper offer options to call object ([b98136a](https://github.com/webex/react-widgets/commit/b98136a))
+* **redux-module-media:** properly get current state on incoming call ([aa817f3](https://github.com/webex/react-widgets/commit/aa817f3))
+* **redux-module-media:** Release camera on call failure ([77102bd](https://github.com/webex/react-widgets/commit/77102bd))
+* **redux-module-media:** smarter local media stream handling ([13148a0](https://github.com/webex/react-widgets/commit/13148a0))
+* **redux-module-media:** Split audio and video tracks to fix video mute ([8cf55f7](https://github.com/webex/react-widgets/commit/8cf55f7))
+* **redux-module-media:** store call once we have a locus ([23084ec](https://github.com/webex/react-widgets/commit/23084ec))
+* **redux-module-mercury:** Return on thunk ([159738b](https://github.com/webex/react-widgets/commit/159738b))
+* **redux-module-presence:** fix eslint errors ([0c267b9](https://github.com/webex/react-widgets/commit/0c267b9))
+* **redux-module-spaces:** add support for directs with deleted users ([4aa898d](https://github.com/webex/react-widgets/commit/4aa898d))
+* **redux-module-spaces:** eslint and jsdoc fixes ([487a145](https://github.com/webex/react-widgets/commit/487a145))
+* **redux-module-spaces:** sort space results before getting the oldest ([09b8cd8](https://github.com/webex/react-widgets/commit/09b8cd8))
+* **redux-module-teams:** Fix wrong action names ([557501a](https://github.com/webex/react-widgets/commit/557501a))
+* **redux-module-teams:** Prevent infinite team fetching ([fcbf871](https://github.com/webex/react-widgets/commit/fcbf871))
+* **redux-module-user:** Make metric name uniform ([c5ce5bb](https://github.com/webex/react-widgets/commit/c5ce5bb))
+* **space-widget:** Fix bad element reference and remove unused component ([4884b7f](https://github.com/webex/react-widgets/commit/4884b7f))
+* **spark-widget-base:** Create new store on each widget instance ([266fd53](https://github.com/webex/react-widgets/commit/266fd53))
+* **spark-widget-base:** Do not remove clear on unmount ([f3566a1](https://github.com/webex/react-widgets/commit/f3566a1))
+* **tap:** widget message meet cannot use meet helper functions ([1d529a0](https://github.com/webex/react-widgets/commit/1d529a0))
+* **tests:** Fix wmm journey test ([5cd9a8f](https://github.com/webex/react-widgets/commit/5cd9a8f))
+* **tooling:** Add html build step, version to file header, global use strict ([0a41404](https://github.com/webex/react-widgets/commit/0a41404))
+* **tooling:** Add node 7 install to tap tests ([bec42bf](https://github.com/webex/react-widgets/commit/bec42bf))
+* **tooling:** Add node_env back to build commands ([cbf06d0](https://github.com/webex/react-widgets/commit/cbf06d0))
+* **tooling:** Add rebuild to tap tests ([972d6b1](https://github.com/webex/react-widgets/commit/972d6b1))
+* **tooling:** Add spark-widget-base to jest config ([ca505ad](https://github.com/webex/react-widgets/commit/ca505ad))
+* **tooling:** Add utc TZ to jest tests ([e8377c8](https://github.com/webex/react-widgets/commit/e8377c8))
+* **tooling:** Build output target issue ([511a5f9](https://github.com/webex/react-widgets/commit/511a5f9))
+* **tooling:** Chnage stylelint config to js ([af188fb](https://github.com/webex/react-widgets/commit/af188fb))
+* **tooling:** Clean build scripts, update Jenkinsfile ([8da1869](https://github.com/webex/react-widgets/commit/8da1869))
+* **tooling:** Clean local tags when building ([ef90800](https://github.com/webex/react-widgets/commit/ef90800))
+* **tooling:** Copy non-js files correctly on build ([32bf054](https://github.com/webex/react-widgets/commit/32bf054))
+* **tooling:** Fix circle npm install ([958a360](https://github.com/webex/react-widgets/commit/958a360))
+* **tooling:** Fix circle tests ([548a40e](https://github.com/webex/react-widgets/commit/548a40e))
+* **tooling:** Fix credentials ([d7dac40](https://github.com/webex/react-widgets/commit/d7dac40))
+* **tooling:** Fix git version bumping ([049a5ff](https://github.com/webex/react-widgets/commit/049a5ff))
+* **tooling:** Fix jenkinsfile syntax ([7499332](https://github.com/webex/react-widgets/commit/7499332))
+* **tooling:** Fix jenkinsfile syntax take 2 ([7a9a322](https://github.com/webex/react-widgets/commit/7a9a322))
+* **tooling:** Fix moment build, add react-intl ([a869dc0](https://github.com/webex/react-widgets/commit/a869dc0))
+* **tooling:** Fix syntax issue ([f2b8a0c](https://github.com/webex/react-widgets/commit/f2b8a0c))
+* **tooling:** Fix test user missing access token ([2b4b7e5](https://github.com/webex/react-widgets/commit/2b4b7e5))
+* **tooling:** Fix test user missing access token ([b71a9aa](https://github.com/webex/react-widgets/commit/b71a9aa))
+* **tooling:** Fix transpile and postcss script ([e759bde](https://github.com/webex/react-widgets/commit/e759bde))
+* **tooling:** Force git to reset and clean directory ([502eda8](https://github.com/webex/react-widgets/commit/502eda8))
+* **tooling:** Jenkins version bump variables ([10bb90a](https://github.com/webex/react-widgets/commit/10bb90a))
+* **tooling:** Jenkinsfile remove NPM_CONFIG_REGISTRY ([bb981e5](https://github.com/webex/react-widgets/commit/bb981e5))
+* **tooling:** Jenkinsfile remove npmrc after install ([d2a5d1b](https://github.com/webex/react-widgets/commit/d2a5d1b))
+* **tooling:** Move jenkinsfile.tap to procedural groovy ([241b5fb](https://github.com/webex/react-widgets/commit/241b5fb))
+* **tooling:** Move jsnext:main to module in package.json ([c407e46](https://github.com/webex/react-widgets/commit/c407e46))
+* **tooling:** Move redux-logger to main dep, add sri-toolbox ([488ade3](https://github.com/webex/react-widgets/commit/488ade3))
+* **tooling:** Patch for babel transform runtime bug ([ac6a069](https://github.com/webex/react-widgets/commit/ac6a069))
+* **tooling:** Point to correct CDN location ([ca7c820](https://github.com/webex/react-widgets/commit/ca7c820))
+* **tooling:** Remove npm rebuild from tap scripts ([5b189bd](https://github.com/webex/react-widgets/commit/5b189bd))
+* **tooling:** Reset all package package.json files" ([5e77e7e](https://github.com/webex/react-widgets/commit/5e77e7e))
+* **tooling:** Tweak dev server, add fonts to icon ([3a3f10e](https://github.com/webex/react-widgets/commit/3a3f10e))
+* **tooling:** Update deps, eslint-config still an issue ([0267bdf](https://github.com/webex/react-widgets/commit/0267bdf))
+* **tooling:** Update stylelint ([e6d00b9](https://github.com/webex/react-widgets/commit/e6d00b9))
+* **tooling:** Update transpile script to use babel-preset-env ([693d98d](https://github.com/webex/react-widgets/commit/693d98d))
+* **tooling:** Update unused release.sh ([4743f20](https://github.com/webex/react-widgets/commit/4743f20))
+* **tooling:** Whitelist env vars ([e6c1c15](https://github.com/webex/react-widgets/commit/e6c1c15))
+* **tools:** add NODE_ENV var to start script ([3a14ba4](https://github.com/webex/react-widgets/commit/3a14ba4))
+* **widget-base:** Add correct name detection ([ff947d9](https://github.com/webex/react-widgets/commit/ff947d9))
+* **widget-base:** Add spark reducer as default ([9fd6373](https://github.com/webex/react-widgets/commit/9fd6373))
+* **widget-base:** Broken Safari data-api ([9c23554](https://github.com/webex/react-widgets/commit/9c23554))
+* **widget-base:** Change console.warning to console.warn ([4762217](https://github.com/webex/react-widgets/commit/4762217))
+* **widget-base:** Fix initial store load when using ReactComponent ([5b01ae2](https://github.com/webex/react-widgets/commit/5b01ae2))
+* **widget-base:** Fix message-composer being blocked in Safari ([0bd6b0f](https://github.com/webex/react-widgets/commit/0bd6b0f))
+* **widget-base:** Fix onEvent calling ([9ec0bb4](https://github.com/webex/react-widgets/commit/9ec0bb4))
+* **widget-base:** Init new store for every top level widget ([afb205d](https://github.com/webex/react-widgets/commit/afb205d))
+* **widget-base:** Inject wrapper class if necessary ([99694c0](https://github.com/webex/react-widgets/commit/99694c0))
+* **widget-base:** Minor changes based on feedback ([43c97f6](https://github.com/webex/react-widgets/commit/43c97f6))
+* **widget-base:** Remove amp events when widget is removed ([87c745a](https://github.com/webex/react-widgets/commit/87c745a))
+* **widget-base:** Remove bad merge ([05e581d](https://github.com/webex/react-widgets/commit/05e581d))
+* **widget-base:** Remove old metrics, fix init timing issue ([8bb4d72](https://github.com/webex/react-widgets/commit/8bb4d72))
+* **widget-base:** Remove unused localStorageAdapter ([165fa22](https://github.com/webex/react-widgets/commit/165fa22))
+* **widget-base:** return unmount status during .remove() ([e2c25a0](https://github.com/webex/react-widgets/commit/e2c25a0))
+* **widget-base:** Update createLogger ([fc0f62b](https://github.com/webex/react-widgets/commit/fc0f62b))
+* **widget-meet:** add call from data on incoming call ([27bd414](https://github.com/webex/react-widgets/commit/27bd414))
+* **widget-meet:** All StartCall prop to accept string value ([47df59f](https://github.com/webex/react-widgets/commit/47df59f))
+* **widget-meet:** capitalize accessibility labels for control buttons ([59027ec](https://github.com/webex/react-widgets/commit/59027ec))
+* **widget-meet:** Disable eslint complexity rule ([f764412](https://github.com/webex/react-widgets/commit/f764412))
+* **widget-meet:** Do not display controls until call object is available ([6036514](https://github.com/webex/react-widgets/commit/6036514))
+* **widget-meet:** emit proper disconnect event ([90c37ca](https://github.com/webex/react-widgets/commit/90c37ca))
+* **widget-meet:** fix display of incoming call and inactive call components at same time ([6d1447a](https://github.com/webex/react-widgets/commit/6d1447a))
+* **widget-meet:** Fix start call flag ([e4d3439](https://github.com/webex/react-widgets/commit/e4d3439))
+* **widget-meet:** Fix webrtc detection in safari ([6ef3bac](https://github.com/webex/react-widgets/commit/6ef3bac))
+* **widget-meet:** Fix wrong PropType ([62a4119](https://github.com/webex/react-widgets/commit/62a4119))
+* **widget-meet:** Force mute buttons active until connect ([0684d6b](https://github.com/webex/react-widgets/commit/0684d6b))
+* **widget-meet:** hangup on unmount ([801d83d](https://github.com/webex/react-widgets/commit/801d83d))
+* **widget-meet:** keep video component in dom when video muted ([2cfb9ea](https://github.com/webex/react-widgets/commit/2cfb9ea))
+* **widget-meet:** Listen to incoming messages ([5ec20b8](https://github.com/webex/react-widgets/commit/5ec20b8))
+* **widget-meet:** load space avatar from avatars store ([dcb9bda](https://github.com/webex/react-widgets/commit/dcb9bda))
+* **widget-meet:** remove check for button state ([ca19da7](https://github.com/webex/react-widgets/commit/ca19da7))
+* **widget-meet:** space calling should go to hydra id ([870d984](https://github.com/webex/react-widgets/commit/870d984))
+* **widget-meet:** Update messaging ([ea81e26](https://github.com/webex/react-widgets/commit/ea81e26))
+* **widget-meet:** Update sdk to get facing mode fix ([a50f18c](https://github.com/webex/react-widgets/commit/a50f18c))
+* **widget-message:** Add check for buffer state listener ([afd0a62](https://github.com/webex/react-widgets/commit/afd0a62))
+* **widget-message:** add detail is listening flags ([47de0f4](https://github.com/webex/react-widgets/commit/47de0f4))
+* **widget-message:** Add getFeature method ([067833c](https://github.com/webex/react-widgets/commit/067833c))
+* **widget-message:** Add getFeature to proptypes ([3bdd12a](https://github.com/webex/react-widgets/commit/3bdd12a))
+* **widget-message:** bind handle flag action ([45e4e60](https://github.com/webex/react-widgets/commit/45e4e60))
+* **widget-message:** Blank name in message composer ([ff3888a](https://github.com/webex/react-widgets/commit/ff3888a))
+* **widget-message:** change to use widgetMessage props ([89f3301](https://github.com/webex/react-widgets/commit/89f3301))
+* **widget-message:** Check for activity before test ([bafd1ad](https://github.com/webex/react-widgets/commit/bafd1ad))
+* **widget-message:** Do not display message composer until conversation is loaded ([688199f](https://github.com/webex/react-widgets/commit/688199f))
+* **widget-message:** Do not fire messages:unread when this user sends ([ea646c6](https://github.com/webex/react-widgets/commit/ea646c6))
+* **widget-message:** Fix at mention structure and proptype ([0bf82a4](https://github.com/webex/react-widgets/commit/0bf82a4))
+* **widget-message:** Fix overwriting issue with target id ([9d00b89](https://github.com/webex/react-widgets/commit/9d00b89))
+* **widget-message:** Fix style issue in composer ([8aeee50](https://github.com/webex/react-widgets/commit/8aeee50))
+* **widget-message:** get immutable widget properties properly ([58213b2](https://github.com/webex/react-widgets/commit/58213b2))
+* **widget-message:** handle empty toUser ([fb348c7](https://github.com/webex/react-widgets/commit/fb348c7))
+* **widget-message:** Load history scroll not sticking ([238fa61](https://github.com/webex/react-widgets/commit/238fa61))
+* **widget-message:** Move messages:created to before rooms:unread ([23d5612](https://github.com/webex/react-widgets/commit/23d5612))
+* **widget-message:** Move props to selector, fix text placeholder ([c529dc8](https://github.com/webex/react-widgets/commit/c529dc8))
+* **widget-message:** remove empty notification of locus events ([ccf80cb](https://github.com/webex/react-widgets/commit/ccf80cb))
+* **widget-message:** store current user id outside event block ([4972c05](https://github.com/webex/react-widgets/commit/4972c05))
+* **widget-message:** Wait for device registration before createconvo ([a1b6665](https://github.com/webex/react-widgets/commit/a1b6665))
+* **widget-message-meet:** Add border-box, fix title bar overlap ([cd0232f](https://github.com/webex/react-widgets/commit/cd0232f))
+* **widget-message-meet:** Add eslint ignore for complexity ([4f1da96](https://github.com/webex/react-widgets/commit/4f1da96))
+* **widget-message-meet:** Allow conversation with user with no account ([fd75c39](https://github.com/webex/react-widgets/commit/fd75c39))
+* **widget-message-meet:** Check for required data before load ([589165b](https://github.com/webex/react-widgets/commit/589165b))
+* **widget-message-meet:** Compile issue causes global class issue ([1096502](https://github.com/webex/react-widgets/commit/1096502))
+* **widget-message-meet:** display only one widget in demo ([823e67d](https://github.com/webex/react-widgets/commit/823e67d))
+* **widget-message-meet:** Fix auth issue and adjusted styles ([2947835](https://github.com/webex/react-widgets/commit/2947835))
+* **widget-message-meet:** fix bad merge and misspelling ([d1d7d2e](https://github.com/webex/react-widgets/commit/d1d7d2e))
+* **widget-message-meet:** Fix style issues in FF, and proptypes errors ([5da911c](https://github.com/webex/react-widgets/commit/5da911c))
+* **widget-message-meet:** Move checks to allow more parallel requests ([e59eac0](https://github.com/webex/react-widgets/commit/e59eac0))
+* **widget-message-meet:** pass proper property to meet ([493119a](https://github.com/webex/react-widgets/commit/493119a))
+* **widget-message-meet:** properly load avatar in title bar ([bf97a13](https://github.com/webex/react-widgets/commit/bf97a13))
+* **widget-message-meet:** Revert container to just message widget" ([1e2ac73](https://github.com/webex/react-widgets/commit/1e2ac73))
+* **widget-message-meet:** Switch to meet on incoming call ([eada7e7](https://github.com/webex/react-widgets/commit/eada7e7))
+* **widget-message-meet-demo:** clear token cookie properly ([2fc0df7](https://github.com/webex/react-widgets/commit/2fc0df7))
+* **widget-recents:** Add recents to jenkinsfile, toJS fix ([a3249c3](https://github.com/webex/react-widgets/commit/a3249c3))
+* **widget-recents:** Correct event removal issue on incoming calls ([ae5af79](https://github.com/webex/react-widgets/commit/ae5af79))
+* **widget-recents:** delete incoming call when connected ([a5d867d](https://github.com/webex/react-widgets/commit/a5d867d))
+* **widget-recents:** Do not mark rooms user sent message in as unread ([9139906](https://github.com/webex/react-widgets/commit/9139906))
+* **widget-recents:** Fix complexity eslit error ([7c1f210](https://github.com/webex/react-widgets/commit/7c1f210))
+* **widget-recents:** Fix membership:created event ([a9ec826](https://github.com/webex/react-widgets/commit/a9ec826))
+* **widget-recents:** Fix space click bug ([bb5dcdf](https://github.com/webex/react-widgets/commit/bb5dcdf))
+* **widget-recents:** Fix space name split error ([58b0988](https://github.com/webex/react-widgets/commit/58b0988))
+* **widget-recents:** Prevent call button for group spaces ([1161eb0](https://github.com/webex/react-widgets/commit/1161eb0))
+* **widget-recents:** Prevent stack range error on call logger ([1952ed3](https://github.com/webex/react-widgets/commit/1952ed3))
+* **widget-recents:** Rearranged action/reducer order, add jsdocs ([2d7eda4](https://github.com/webex/react-widgets/commit/2d7eda4))
+* **widget-recents:** Remove no-enter keypresses for selecting space ([e7b7ff5](https://github.com/webex/react-widgets/commit/e7b7ff5))
+* **widget-recents:** Show unread indicator when space has never been seen ([2b35b7a](https://github.com/webex/react-widgets/commit/2b35b7a))
+* **widget-recents:** support for untitled rooms ([9c65a8b](https://github.com/webex/react-widgets/commit/9c65a8b))
+* **widget-roster:** fix name of the roster from incorrect 'message' ([6f79d1e](https://github.com/webex/react-widgets/commit/6f79d1e)), closes [#565](https://github.com/webex/react-widgets/issues/565)
+* **widget-roster:** fix sort method and check for room properties ([a778f6c](https://github.com/webex/react-widgets/commit/a778f6c))
+* **widget-roster:** Remove unused PropType ([8ed8418](https://github.com/webex/react-widgets/commit/8ed8418))
+* **widget-space:** Add higher specificity to button style ([598b7e5](https://github.com/webex/react-widgets/commit/598b7e5))
+* **widget-space:** Add internal propType to prop filter ([79874ab](https://github.com/webex/react-widgets/commit/79874ab))
+* **widget-space:** Add jsdocs, fix test ([4b43842](https://github.com/webex/react-widgets/commit/4b43842))
+* **widget-space:** Allow closing of activity menu from sub widget ([b5c0651](https://github.com/webex/react-widgets/commit/b5c0651))
+* **widget-space:** Allow closing of activity menu from sub widget ([db905f9](https://github.com/webex/react-widgets/commit/db905f9))
+* **widget-space:** Allow user to call when direct spaceID is provided ([ee6a3d1](https://github.com/webex/react-widgets/commit/ee6a3d1))
+* **widget-space:** Ensure correct activity is initially loaded ([0de8b78](https://github.com/webex/react-widgets/commit/0de8b78))
+* **widget-space:** Fix eslint error ([c85e6ee](https://github.com/webex/react-widgets/commit/c85e6ee))
+* **widget-space:** Fix incoming calls not working ([7d75acc](https://github.com/webex/react-widgets/commit/7d75acc))
+* **widget-space:** Fix initialActivity setting with data-api ([7efa831](https://github.com/webex/react-widgets/commit/7efa831))
+* **widget-space:** Fix style issue on containers ([f56af28](https://github.com/webex/react-widgets/commit/f56af28))
+* **widget-space:** Fixed styles to correctly display activity widget ([9ae76d9](https://github.com/webex/react-widgets/commit/9ae76d9))
+* **widget-space:** load space avatar properly ([8bf9ca8](https://github.com/webex/react-widgets/commit/8bf9ca8))
+* **widget-space:** prop typo for initialActivity ([9b1a1b0](https://github.com/webex/react-widgets/commit/9b1a1b0))
+* **widget-space:** return to message view after call ([26ad8d6](https://github.com/webex/react-widgets/commit/26ad8d6))
+* **widget-space:** Revert test template ([a337cbf](https://github.com/webex/react-widgets/commit/a337cbf))
+* **widget-space:** Switch to message view after call hangup ([4edc4d4](https://github.com/webex/react-widgets/commit/4edc4d4))
+* **widget-space:** UI fixes and API changes ([e56d633](https://github.com/webex/react-widgets/commit/e56d633))
+* **widget-space-demo:** Fix package name collision ([f1aeada](https://github.com/webex/react-widgets/commit/f1aeada))
+* eslint errors and jest tests from presence merge ([114a1bf](https://github.com/webex/react-widgets/commit/114a1bf))
+* fix some lint errors with eslint --fix ([b5ac837](https://github.com/webex/react-widgets/commit/b5ac837))
+* gitattributes? ([a2784a0](https://github.com/webex/react-widgets/commit/a2784a0))
+* Jest tests, move to in memory object for metrics storage ([6062284](https://github.com/webex/react-widgets/commit/6062284))
+* remove extra eslint-disable and fix errors ([562a99c](https://github.com/webex/react-widgets/commit/562a99c))
+* Remove extraneous required proptypes ([916fe03](https://github.com/webex/react-widgets/commit/916fe03))
+* removing workaround for redux-logger ([fcdcd90](https://github.com/webex/react-widgets/commit/fcdcd90))
+* **widget-space-demo:** handle mode toggle properly ([a3557b4](https://github.com/webex/react-widgets/commit/a3557b4))
+* **widget-space-demo:** only pass property of selected mode ([0ef2032](https://github.com/webex/react-widgets/commit/0ef2032))
+* static method errors ([d9a0e99](https://github.com/webex/react-widgets/commit/d9a0e99))
+* Temporarily remove default props for certain objects ([7134dee](https://github.com/webex/react-widgets/commit/7134dee))
 
 
 ### Features
 
-* **redux-module-avatar:** check state before starting request ([e7b8128](https://github.com/webex/react-ciscospark/commit/e7b8128))
-* Components now build ([0426d8e](https://github.com/webex/react-ciscospark/commit/0426d8e))
-* **all:** add iconSize prop to PresenceAvatar implementations ([105a0c5](https://github.com/webex/react-ciscospark/commit/105a0c5))
-* **call-activity:** display locus call data in activity list ([886b7d8](https://github.com/webex/react-ciscospark/commit/886b7d8))
-* **components:** Add all activity list components ([caa1e42](https://github.com/webex/react-ciscospark/commit/caa1e42))
-* **components:** Add chip, modal, staging area, sparators, and utils ([2ff6707](https://github.com/webex/react-ciscospark/commit/2ff6707))
-* **components:** Add loading-screen and spinner ([f3db512](https://github.com/webex/react-ciscospark/commit/f3db512))
-* **components:** Add new message separator, fix tests ([c358b71](https://github.com/webex/react-ciscospark/commit/c358b71))
-* **components:** Add redux wrapper, activity items ([17ed13a](https://github.com/webex/react-ciscospark/commit/17ed13a))
-* **components:** Add scroll to bottom button ([fc3d90b](https://github.com/webex/react-ciscospark/commit/fc3d90b))
-* **components:** Add text area component ([aa96b9a](https://github.com/webex/react-ciscospark/commit/aa96b9a))
-* **components:** Add TitleBar component ([0a0e776](https://github.com/webex/react-ciscospark/commit/0a0e776))
-* **components:** Add typingAvatar and typingIndicator components ([9fab467](https://github.com/webex/react-ciscospark/commit/9fab467))
-* **components:** All components migrated. Tests updated. Some tests still failing ([537c49e](https://github.com/webex/react-ciscospark/commit/537c49e))
-* **demo:** add material-ui styling ([666af8c](https://github.com/webex/react-ciscospark/commit/666af8c))
-* **demo:** add message meet widget to demo ([2d8ea1a](https://github.com/webex/react-ciscospark/commit/2d8ea1a))
-* **demo:** change example to tabbed view ([aaf1a73](https://github.com/webex/react-ciscospark/commit/aaf1a73))
-* **demo:** demo login moved into its own component ([6e559e8](https://github.com/webex/react-ciscospark/commit/6e559e8))
-* **demo:** initial router setup ([b58c84e](https://github.com/webex/react-ciscospark/commit/b58c84e))
-* **demos:** use new react-cookies methods ([dde832d](https://github.com/webex/react-ciscospark/commit/dde832d))
-* **metrics:** Add store for metrics that aren't ready to be sent ([0e01e13](https://github.com/webex/react-ciscospark/commit/0e01e13))
-* **r-comp-activity-system-message:** add group call messages ([377df5e](https://github.com/webex/react-ciscospark/commit/377df5e))
-* **react-component-activity-item:** support for error activity retries ([3b2828b](https://github.com/webex/react-ciscospark/commit/3b2828b))
-* **react-component-activity-item-base:** add support for error activity retries ([2b56a78](https://github.com/webex/react-ciscospark/commit/2b56a78))
-* **react-component-activity-item-base:** build classes array for avatar classes ([e07d7aa](https://github.com/webex/react-ciscospark/commit/e07d7aa))
-* **react-component-activity-item-base:** display name "you" for self activities ([c40ab9a](https://github.com/webex/react-ciscospark/commit/c40ab9a))
-* **react-component-activity-item-base:** implement avatar size ([666fd67](https://github.com/webex/react-ciscospark/commit/666fd67))
-* **react-component-activity-item-base:** Show publish time without hover ([aab26c7](https://github.com/webex/react-ciscospark/commit/aab26c7))
-* **react-component-activity-item-base:** use PresenceAvatar component ([28320a7](https://github.com/webex/react-ciscospark/commit/28320a7))
-* **react-component-activity-list:** add support for group call data parsing ([459d8ae](https://github.com/webex/react-ciscospark/commit/459d8ae))
-* **react-component-activity-list:** add support for roster events ([2467264](https://github.com/webex/react-ciscospark/commit/2467264))
-* **react-component-activity-list:** pass actorId instead of avatar ([9620c09](https://github.com/webex/react-ciscospark/commit/9620c09))
-* **react-component-activity-list:** remove callData prop ([8aac635](https://github.com/webex/react-ciscospark/commit/8aac635))
-* **react-component-activity-list:** support for error activity retries ([51889e2](https://github.com/webex/react-ciscospark/commit/51889e2))
-* **react-component-activity-menu:** initial component creation ([1f4622d](https://github.com/webex/react-ciscospark/commit/1f4622d))
-* **react-component-activity-menu:** style the menu appropriately ([a9630cd](https://github.com/webex/react-ciscospark/commit/a9630cd))
-* **react-component-activity-system-message:** add support for roster events ([05747f3](https://github.com/webex/react-ciscospark/commit/05747f3))
-* **react-component-activity-system-message:** use CallDataActivityMessage ([be77c7d](https://github.com/webex/react-ciscospark/commit/be77c7d))
-* **react-component-activity-text:** Add html filter on dangerously set html ([1c056a8](https://github.com/webex/react-ciscospark/commit/1c056a8))
-* **react-component-activity-text:** add pre-wrap style for new lines ([61cc206](https://github.com/webex/react-ciscospark/commit/61cc206))
-* **react-component-activity-text:** use linkify to create links for text ([3426a60](https://github.com/webex/react-ciscospark/commit/3426a60))
-* **react-component-audio:** New audio component that supports srcObject ([6ca9d35](https://github.com/webex/react-ciscospark/commit/6ca9d35))
-* **react-component-avatar:** add conversion to uppercase for names ([e8e70e5](https://github.com/webex/react-ciscospark/commit/e8e70e5))
-* **react-component-avatar:** add size prop to avatar ([2e27f7b](https://github.com/webex/react-ciscospark/commit/2e27f7b))
-* **react-component-badge:** add tooltip support ([85cf5f5](https://github.com/webex/react-ciscospark/commit/85cf5f5))
-* **react-component-badge:** initial implementation ([875c912](https://github.com/webex/react-ciscospark/commit/875c912))
-* **react-component-button:** accessibility label prop added ([cd5fe32](https://github.com/webex/react-ciscospark/commit/cd5fe32))
-* **react-component-button:** accessibility label prop added ([ef89db8](https://github.com/webex/react-ciscospark/commit/ef89db8))
-* **react-component-button:** add aria-label to button ([484bce6](https://github.com/webex/react-ciscospark/commit/484bce6))
-* **react-component-button:** add aria-label to button ([cb649fe](https://github.com/webex/react-ciscospark/commit/cb649fe))
-* **react-component-button:** use icon title as aria label ([9653abb](https://github.com/webex/react-ciscospark/commit/9653abb))
-* **react-component-button-controls:** use button label as accessibility label ([8cceb2b](https://github.com/webex/react-ciscospark/commit/8cceb2b))
-* **react-component-call-data-activity:** initial component ([35bd069](https://github.com/webex/react-ciscospark/commit/35bd069))
-* **react-component-cover:** Create screen cover component ([8a3d42d](https://github.com/webex/react-ciscospark/commit/8a3d42d))
-* **react-component-error-display:** initial implementation ([6ac79e0](https://github.com/webex/react-ciscospark/commit/6ac79e0))
-* **react-component-icon:** add contact icon support ([c1b9b82](https://github.com/webex/react-ciscospark/commit/c1b9b82))
-* **react-component-icon:** add dnd and pto icons ([b7101eb](https://github.com/webex/react-ciscospark/commit/b7101eb))
-* **react-component-icon:** add invite icon ([2dc8a57](https://github.com/webex/react-ciscospark/commit/2dc8a57))
-* **react-component-icon:** add more icon ([fe250b3](https://github.com/webex/react-ciscospark/commit/fe250b3))
-* **react-component-icon:** make external user icons available ([9eb362c](https://github.com/webex/react-ciscospark/commit/9eb362c))
-* **react-component-icon:** upgrade to Neo-icons font ([2340b76](https://github.com/webex/react-ciscospark/commit/2340b76))
-* **react-component-incoming-call:** Moved component into package ([117cd1a](https://github.com/webex/react-ciscospark/commit/117cd1a))
-* **react-component-people-list:** Create people list component ([48261d4](https://github.com/webex/react-ciscospark/commit/48261d4))
-* **react-component-people-list:** use connected PresenceAvatar ([cb1d866](https://github.com/webex/react-ciscospark/commit/cb1d866))
-* **react-component-person-list-item:** change avatarUrl param to avatar ([25888ec](https://github.com/webex/react-ciscospark/commit/25888ec))
-* **react-component-person-list-item:** initial component ([5f4f0db](https://github.com/webex/react-ciscospark/commit/5f4f0db))
-* **react-component-presence-avatar:** initial implementation ([d8efdf9](https://github.com/webex/react-ciscospark/commit/d8efdf9))
-* **react-component-ringtone:** initial component ([059dec8](https://github.com/webex/react-ciscospark/commit/059dec8))
-* **react-component-spark-fonts:** initial component ([a6f73e4](https://github.com/webex/react-ciscospark/commit/a6f73e4))
-* **react-component-spark-logo:** initial component ([b1b0a4c](https://github.com/webex/react-ciscospark/commit/b1b0a4c))
-* **react-component-spark-oauth:** create new component from demo code ([7c13acc](https://github.com/webex/react-ciscospark/commit/7c13acc))
-* **react-component-spinner:** add bright flag to match new design ([b6c9dc4](https://github.com/webex/react-ciscospark/commit/b6c9dc4))
-* **react-component-title-bar:** add waffle menu ([e5148df](https://github.com/webex/react-ciscospark/commit/e5148df))
-* **react-component-title-bar:** style according to design ([fedb9dc](https://github.com/webex/react-ciscospark/commit/fedb9dc))
-* **react-component-title-bar:** use PresenceAvatar connected component ([3752a76](https://github.com/webex/react-ciscospark/commit/3752a76))
-* **react-component-typing-avatar:** add hover tooltip of name ([bef3ad6](https://github.com/webex/react-ciscospark/commit/bef3ad6))
-* **react-component-typing-avatar:** implement avatar size prop ([e2c82d8](https://github.com/webex/react-ciscospark/commit/e2c82d8))
-* **react-component-typing-avatar:** use PresenceAvatar component ([dc3f893](https://github.com/webex/react-ciscospark/commit/dc3f893))
-* **react-component-utils:** activity constructor requires full conversation object ([748ea19](https://github.com/webex/react-ciscospark/commit/748ea19))
-* **react-component-utils:** add #constructHydraId method ([51e826c](https://github.com/webex/react-ciscospark/commit/51e826c))
-* **react-component-utils:** Add sdk version to metrics ([7b885da](https://github.com/webex/react-ciscospark/commit/7b885da))
-* **react-component-utils:** add validateAndDecodeId function ([e128985](https://github.com/webex/react-ciscospark/commit/e128985))
-* **react-component-utils:** isUuid feature added ([fe9853e](https://github.com/webex/react-ciscospark/commit/fe9853e))
-* **react-component-utils:** store metadata about activity to recreate ([1317c21](https://github.com/webex/react-ciscospark/commit/1317c21))
-* **react-component-video:** change to audio tag if video muted ([5fa0bfe](https://github.com/webex/react-ciscospark/commit/5fa0bfe))
-* **react-container-activity-list:** Add at mention formatter ([34aeec4](https://github.com/webex/react-ciscospark/commit/34aeec4))
-* **react-container-activity-list:** Add at mention formatter and events ([1584f10](https://github.com/webex/react-ciscospark/commit/1584f10))
-* **react-container-activity-list:** add error activities to selector ([a87dcd8](https://github.com/webex/react-ciscospark/commit/a87dcd8))
-* **react-container-activity-list:** Add external formatters ([bf88dce](https://github.com/webex/react-ciscospark/commit/bf88dce))
-* **react-container-activity-list:** remove call data calculation ([06a8d79](https://github.com/webex/react-ciscospark/commit/06a8d79))
-* **react-container-activity-list:** show declined outbound calls as unavailable ([6577a01](https://github.com/webex/react-ciscospark/commit/6577a01))
-* **react-container-activity-list:** support for error activity retries ([4cfa4aa](https://github.com/webex/react-ciscospark/commit/4cfa4aa))
-* **react-container-call-incoming:** create container for handling incoming calls ([1ddaf19](https://github.com/webex/react-ciscospark/commit/1ddaf19))
-* **react-container-call-incoming:** emit event when call is incoming ([461cb24](https://github.com/webex/react-ciscospark/commit/461cb24))
-* **react-container-call-incoming:** implement ringtone component ([6660363](https://github.com/webex/react-ciscospark/commit/6660363))
-* **react-container-call-incoming:** plays ringtone when ringing ([ac58a51](https://github.com/webex/react-ciscospark/commit/ac58a51))
-* **react-container-message-composer:** Add avatar and cleaner styles ([f40a0b7](https://github.com/webex/react-ciscospark/commit/f40a0b7))
-* **react-container-message-composer:** Add debounce to setting UserTyping ([48a7a00](https://github.com/webex/react-ciscospark/commit/48a7a00))
-* **react-container-message-composer:** Add mention support ([5ce172d](https://github.com/webex/react-ciscospark/commit/5ce172d))
-* **react-container-message-composer:** grow text area for longer text inputs ([60b6a79](https://github.com/webex/react-ciscospark/commit/60b6a79))
-* **react-container-message-composer:** use disabled mentions input for text entry ([68b72c1](https://github.com/webex/react-ciscospark/commit/68b72c1))
-* **react-container-notifications:** add incoming call notification ([e6f2ec1](https://github.com/webex/react-ciscospark/commit/e6f2ec1))
-* **react-container-notifications:** Add support to multiple widgets ([f2dfbdd](https://github.com/webex/react-ciscospark/commit/f2dfbdd))
-* **react-container-notifications:** notification generation moved to external component ([a630d3a](https://github.com/webex/react-ciscospark/commit/a630d3a))
-* **react-container-presence-avatar:** initial module ([243da99](https://github.com/webex/react-ciscospark/commit/243da99))
-* **react-container-read-receipts:** add hidden users array ([cc912ae](https://github.com/webex/react-ciscospark/commit/cc912ae))
-* **react-container-read-receipts:** add sort so typing participants get priority ([78c0498](https://github.com/webex/react-ciscospark/commit/78c0498))
-* **react-container-read-receipts:** display count of supressed receipts ([1a26a48](https://github.com/webex/react-ciscospark/commit/1a26a48))
-* **react-container-read-receipts:** fetch avatars for displayed read receipt users ([4746e4e](https://github.com/webex/react-ciscospark/commit/4746e4e))
-* **react-container-read-receipts:** send user id prop ([746ec57](https://github.com/webex/react-ciscospark/commit/746ec57))
-* **react-container-read-receipts:** using selector to create props ([6ed2ba7](https://github.com/webex/react-ciscospark/commit/6ed2ba7))
-* **react-hoc-conversation-mercury:** add initial conversation events ([f38fbc7](https://github.com/webex/react-ciscospark/commit/f38fbc7))
-* **react-hoc-conversation-mercury:** add roster events as comments ([55277f9](https://github.com/webex/react-ciscospark/commit/55277f9))
-* **react-hoc-conversation-mercury:** implement addParticipant/removeParticipant ([5356a4d](https://github.com/webex/react-ciscospark/commit/5356a4d))
-* **react-redux-spark:** Add config options from widget to Spark SDK ([a9d4ba1](https://github.com/webex/react-ciscospark/commit/a9d4ba1))
-* **react-redux-spark:** Add forage storage adapter to cache encryption keys ([92c375f](https://github.com/webex/react-ciscospark/commit/92c375f))
-* **react-redux-spark:** Add longer KMS timeout ([5c4967d](https://github.com/webex/react-ciscospark/commit/5c4967d))
-* **react-redux-spark:** add plugin-people ([20c9b77](https://github.com/webex/react-ciscospark/commit/20c9b77))
-* **react-redux-spark:** Check for global instance before creating new ([2b69a9c](https://github.com/webex/react-ciscospark/commit/2b69a9c))
-* **react-redux-spark:** enable group calling config ([9c54e97](https://github.com/webex/react-ciscospark/commit/9c54e97))
-* **react-redux-spark:** only fire off mercury connect once ([52b75db](https://github.com/webex/react-ciscospark/commit/52b75db))
-* **react-redux-spark:** store registration errors ([989646e](https://github.com/webex/react-ciscospark/commit/989646e))
-* **react-redux-spark-metrics:** Add duration metrics ([a32c9b9](https://github.com/webex/react-ciscospark/commit/a32c9b9))
-* **react-redux-spark-metrics:** Add queuing of metrics ([57eb5d8](https://github.com/webex/react-ciscospark/commit/57eb5d8))
-* **react-redux-spark-metrics:** Clena up actions and add reducers ([1a7116e](https://github.com/webex/react-ciscospark/commit/1a7116e))
-* **react-redux-spark-metrics:** Finished queue and duration send ([783a551](https://github.com/webex/react-ciscospark/commit/783a551))
-* **react-redux-spark-metrics:** Initial metrics framework ([bd3a25b](https://github.com/webex/react-ciscospark/commit/bd3a25b))
-* **react-test-utils:** add shallow render intl helper ([e50729f](https://github.com/webex/react-ciscospark/commit/e50729f))
-* **redux-module-activity:** add ability to retry failed activity ([637715e](https://github.com/webex/react-ciscospark/commit/637715e))
-* **redux-module-activity:** add activity failures to store ([2b5fcf9](https://github.com/webex/react-ciscospark/commit/2b5fcf9))
-* **redux-module-avatar:** add space avatar support ([b32299b](https://github.com/webex/react-ciscospark/commit/b32299b))
-* **redux-module-avatar:** Download smaller avatars for people ([d56b422](https://github.com/webex/react-ciscospark/commit/d56b422))
-* **redux-module-avatar:** handle people api errors ([6f59720](https://github.com/webex/react-ciscospark/commit/6f59720))
-* **redux-module-avatar:** Move all avatar fetching to Promises ([37ff3ea](https://github.com/webex/react-ciscospark/commit/37ff3ea))
-* **redux-module-avatar:** use plugin-people to fetch avatar ([fa94e6c](https://github.com/webex/react-ciscospark/commit/fa94e6c))
-* **redux-module-conversation:** add #removeParticipantFromConversation ([8ef7252](https://github.com/webex/react-ciscospark/commit/8ef7252))
-* **redux-module-conversation:** add ability to add sideboarded participant ([cb78741](https://github.com/webex/react-ciscospark/commit/cb78741))
-* **redux-module-conversation:** add ability to load missing activities ([649ccc0](https://github.com/webex/react-ciscospark/commit/649ccc0))
-* **redux-module-conversation:** add addParticipant action ([c518411](https://github.com/webex/react-ciscospark/commit/c518411))
-* **redux-module-conversation:** add addParticipant and removeParticipant ([d594455](https://github.com/webex/react-ciscospark/commit/d594455))
-* **redux-module-conversation:** add computed room properties ([dc48df3](https://github.com/webex/react-ciscospark/commit/dc48df3))
-* **redux-module-conversation:** add conversation error handling ([2bcd1fd](https://github.com/webex/react-ciscospark/commit/2bcd1fd))
-* **redux-module-conversation:** create participants in flight ([1015796](https://github.com/webex/react-ciscospark/commit/1015796))
-* **redux-module-conversation:** Fix getConversation ([072f5c8](https://github.com/webex/react-ciscospark/commit/072f5c8))
-* **redux-module-conversation:** remove widget message status props ([38d6ad0](https://github.com/webex/react-ciscospark/commit/38d6ad0))
-* **redux-module-errors:** add hasError flag ([53ab035](https://github.com/webex/react-ciscospark/commit/53ab035))
-* **redux-module-errors:** add hasError flag ([5e2bd10](https://github.com/webex/react-ciscospark/commit/5e2bd10))
-* **redux-module-errors:** initial module ([6077d58](https://github.com/webex/react-ciscospark/commit/6077d58))
-* **redux-module-errors:** initial module ([d78087f](https://github.com/webex/react-ciscospark/commit/d78087f))
-* **redux-module-features:** add constants for feature flags ([9661830](https://github.com/webex/react-ciscospark/commit/9661830))
-* **redux-module-features:** initial implementation ([179293f](https://github.com/webex/react-ciscospark/commit/179293f))
-* **redux-module-media:** ability to listen for incoming calls ([06330d4](https://github.com/webex/react-ciscospark/commit/06330d4))
-* **redux-module-media:** add activeParticipantsCount to callState object ([e179878](https://github.com/webex/react-ciscospark/commit/e179878))
-* **redux-module-media:** Add browser support detection ([f2a1951](https://github.com/webex/react-ciscospark/commit/f2a1951))
-* **redux-module-media:** Add disconnect action ([a1dfa79](https://github.com/webex/react-ciscospark/commit/a1dfa79))
-* **redux-module-media:** Add locusUrl to call remove ([34e1b1f](https://github.com/webex/react-ciscospark/commit/34e1b1f))
-* **redux-module-media:** Add passing id for call association ([ef6b867](https://github.com/webex/react-ciscospark/commit/ef6b867))
-* **redux-module-media:** change incoming call handling to new methods ([d92d331](https://github.com/webex/react-ciscospark/commit/d92d331))
-* **redux-module-media:** hang up call on remote decline ([92699e8](https://github.com/webex/react-ciscospark/commit/92699e8))
-* **redux-module-media:** hangup call on disconnect ([aacec65](https://github.com/webex/react-ciscospark/commit/aacec65))
-* **redux-module-media:** make answer incoming call a specific action ([356c75e](https://github.com/webex/react-ciscospark/commit/356c75e))
-* **redux-module-media:** match call via locus url ([f5b2cb9](https://github.com/webex/react-ciscospark/commit/f5b2cb9))
-* **redux-module-media:** remove call.status reference ([bc5406b](https://github.com/webex/react-ciscospark/commit/bc5406b))
-* **redux-module-media:** remove media stream creation ([9be01c1](https://github.com/webex/react-ciscospark/commit/9be01c1))
-* **redux-module-media:** return thunk with call user action ([19b2c7d](https://github.com/webex/react-ciscospark/commit/19b2c7d))
-* **redux-module-media:** store call errors in call state ([32784ac](https://github.com/webex/react-ciscospark/commit/32784ac))
-* **redux-module-media:** update to group supported call events ([0876dc3](https://github.com/webex/react-ciscospark/commit/0876dc3))
-* **redux-module-mercury:** add status object ([7523fc4](https://github.com/webex/react-ciscospark/commit/7523fc4))
-* **redux-module-mercury:** listen to device registration changes ([e6dba57](https://github.com/webex/react-ciscospark/commit/e6dba57))
-* **redux-module-mercury:** listen to device registration changes ([aed4f8b](https://github.com/webex/react-ciscospark/commit/aed4f8b))
-* **redux-module-mercury:** move mercury status out of spark module ([2de0205](https://github.com/webex/react-ciscospark/commit/2de0205))
-* **redux-module-mercury:** Set mercury to connected if already connected from instance ([53f209a](https://github.com/webex/react-ciscospark/commit/53f209a))
-* **redux-module-presence:** initial module ([4f3fcb0](https://github.com/webex/react-ciscospark/commit/4f3fcb0))
-* **redux-module-presence:** use spark presence plugin ([d9dea1a](https://github.com/webex/react-ciscospark/commit/d9dea1a))
-* **redux-module-search:** Add return for results in user search ([efe56b0](https://github.com/webex/react-ciscospark/commit/efe56b0))
-* **redux-module-search:** add search hydra for email ([0f35130](https://github.com/webex/react-ciscospark/commit/0f35130))
-* **redux-module-search:** initial module ([b671b93](https://github.com/webex/react-ciscospark/commit/b671b93))
-* **redux-module-spaces:** Add action to hide space ([991f75d](https://github.com/webex/react-ciscospark/commit/991f75d))
-* **redux-module-spaces:** Add hidden flag and update space storage ([9f29da0](https://github.com/webex/react-ciscospark/commit/9f29da0))
-* **redux-module-spaces:** Add support for defer decryption ([33c0611](https://github.com/webex/react-ciscospark/commit/33c0611))
-* **redux-module-spaces:** filter for latestActivity in #fetchSpace ([3b2fe5e](https://github.com/webex/react-ciscospark/commit/3b2fe5e))
-* **redux-module-spaces:** remove avatar fetch ([c61ae2d](https://github.com/webex/react-ciscospark/commit/c61ae2d))
-* **redux-module-spaces:** Remove teams from module ([ec770f7](https://github.com/webex/react-ciscospark/commit/ec770f7))
-* **redux-module-spaces:** removes ability to fetch direct space avatar ([368f266](https://github.com/webex/react-ciscospark/commit/368f266))
-* **redux-module-spaces:** shorten initial fetch ([1ef1da6](https://github.com/webex/react-ciscospark/commit/1ef1da6))
-* **redux-module-spaces:** Simplify convo retrieval ([dcf9a89](https://github.com/webex/react-ciscospark/commit/dcf9a89))
-* **redux-module-teams:** Add error catch and correct status updates ([8f3a136](https://github.com/webex/react-ciscospark/commit/8f3a136))
-* **redux-module-teams:** Add teams module ([57b1461](https://github.com/webex/react-ciscospark/commit/57b1461))
-* **redux-module-user:** convert request to use people plugin ([3799407](https://github.com/webex/react-ciscospark/commit/3799407))
-* **spark-widget-base:** Add data api and widget removal ([85db05c](https://github.com/webex/react-ciscospark/commit/85db05c))
-* **spark-widget-base:** Create new base widget ([55f7210](https://github.com/webex/react-ciscospark/commit/55f7210))
-* **tooling:** add firefox tests to jenkinsfile ([d5c4c92](https://github.com/webex/react-ciscospark/commit/d5c4c92))
-* **tooling:** Add jest, stylelint and initial circle config ([9e020c7](https://github.com/webex/react-ciscospark/commit/9e020c7))
-* **tooling:** add junit reporting ([126c415](https://github.com/webex/react-ciscospark/commit/126c415))
-* **tooling:** Add npm publish for components ([c2f9369](https://github.com/webex/react-ciscospark/commit/c2f9369))
-* **tooling:** Add public key to repo ([d7dcea1](https://github.com/webex/react-ciscospark/commit/d7dcea1))
-* **tooling:** add sauce job names ([b5eba26](https://github.com/webex/react-ciscospark/commit/b5eba26))
-* **tooling:** Add sri build command ([07d0ed7](https://github.com/webex/react-ciscospark/commit/07d0ed7))
-* **tooling:** Add sri generation and credentials to Jenkinsfile ([733f434](https://github.com/webex/react-ciscospark/commit/733f434))
-* **tooling:** Add SRI generation scripts ([4210488](https://github.com/webex/react-ciscospark/commit/4210488))
-* **tooling:** Add treeshaking ([2a0b5b3](https://github.com/webex/react-ciscospark/commit/2a0b5b3))
-* **tooling:** Added base components with build and dev server ([a1c9faa](https://github.com/webex/react-ciscospark/commit/a1c9faa))
-* **tooling:** Added config to bypass Jest issue with node_modules. ([248e5ba](https://github.com/webex/react-ciscospark/commit/248e5ba))
-* **tooling:** Allow any host connection to local dev ([71b03e9](https://github.com/webex/react-ciscospark/commit/71b03e9))
-* **tooling:** firefox compatibility for journey tests ([7e3f809](https://github.com/webex/react-ciscospark/commit/7e3f809))
-* **tooling:** Fix bad builds, add split package builds ([d652c4c](https://github.com/webex/react-ciscospark/commit/d652c4c))
-* **tooling:** Fix css compile, add file button ([292246e](https://github.com/webex/react-ciscospark/commit/292246e))
-* **tooling:** Remove storybook, add avatar, adjust add file styles ([87b2c01](https://github.com/webex/react-ciscospark/commit/87b2c01))
-* **tooling:** Set version number in webpack build path ([069d9d7](https://github.com/webex/react-ciscospark/commit/069d9d7))
-* **widget:** Add event support for new init methods ([f5cf10b](https://github.com/webex/react-ciscospark/commit/f5cf10b))
-* **widget-base:** Add log level proptypes ([78257c2](https://github.com/webex/react-ciscospark/commit/78257c2))
-* **widget-base:** Add promise and callback to widget.remove() ([200790b](https://github.com/webex/react-ciscospark/commit/200790b))
-* **widget-base:** Add top level allowed props filtering ([199ea9d](https://github.com/webex/react-ciscospark/commit/199ea9d))
-* **widget-base:** Add version to constructor and instance ([43a0448](https://github.com/webex/react-ciscospark/commit/43a0448))
-* **widget-base:** Allow data api to use browser globals if they are available ([b6f0494](https://github.com/webex/react-ciscospark/commit/b6f0494))
-* **widget-base:** Allow for connection in multiple tabs ([dc80faa](https://github.com/webex/react-ciscospark/commit/dc80faa))
-* **widget-base:** Create single constructSparkWidget method ([4c82639](https://github.com/webex/react-ciscospark/commit/4c82639))
-* **widget-base:** update redux devtools implementation ([22f546c](https://github.com/webex/react-ciscospark/commit/22f546c))
-* **widget-example:** Example app that uses new base ([72e2234](https://github.com/webex/react-ciscospark/commit/72e2234))
-* **widget-meet:** accessibility label prop added to call controls ([763b7f9](https://github.com/webex/react-ciscospark/commit/763b7f9))
-* **widget-meet:** accessibility label prop added to call controls ([1c04eef](https://github.com/webex/react-ciscospark/commit/1c04eef))
-* **widget-meet:** Add browser support UI message ([9165fae](https://github.com/webex/react-ciscospark/commit/9165fae))
-* **widget-meet:** Add call controls, 3 views for call state ([6874537](https://github.com/webex/react-ciscospark/commit/6874537))
-* **widget-meet:** Add connect and disconnect button ([9f890d7](https://github.com/webex/react-ciscospark/commit/9f890d7))
-* **widget-meet:** add error when failing to connect call ([c1940db](https://github.com/webex/react-ciscospark/commit/c1940db))
-* **widget-meet:** Add events for call membership changes ([c22bf79](https://github.com/webex/react-ciscospark/commit/c22bf79))
-* **widget-meet:** Add full calling flow scaffolding ([379f77a](https://github.com/webex/react-ciscospark/commit/379f77a))
-* **widget-meet:** Add fuzzy background ([202477d](https://github.com/webex/react-ciscospark/commit/202477d))
-* **widget-meet:** Add incoming and outgoing ringtone ([04f5c82](https://github.com/webex/react-ciscospark/commit/04f5c82))
-* **widget-meet:** Add initial outbound calling ([7400443](https://github.com/webex/react-ciscospark/commit/7400443))
-* **widget-meet:** Add local video draggability ([3c19e2f](https://github.com/webex/react-ciscospark/commit/3c19e2f))
-* **widget-meet:** Add notification events ([3c99eb8](https://github.com/webex/react-ciscospark/commit/3c99eb8))
-* **widget-meet:** Add remote video display ([e957173](https://github.com/webex/react-ciscospark/commit/e957173))
-* **widget-meet:** Add snapping to place to local video drag ([723ff14](https://github.com/webex/react-ciscospark/commit/723ff14))
-* **widget-meet:** Cleanup button styles, add remote audio/video mute ([5da943e](https://github.com/webex/react-ciscospark/commit/5da943e))
-* **widget-meet:** convert container to use selector props ([474bf77](https://github.com/webex/react-ciscospark/commit/474bf77))
-* **widget-meet:** display error for security requirement ([f2b49fc](https://github.com/webex/react-ciscospark/commit/f2b49fc))
-* **widget-meet:** display incoming call screen ([518637d](https://github.com/webex/react-ciscospark/commit/518637d))
-* **widget-meet:** display waiting for participants message ([b49127e](https://github.com/webex/react-ciscospark/commit/b49127e))
-* **widget-meet:** emit event after call user ([d810c09](https://github.com/webex/react-ciscospark/commit/d810c09))
-* **widget-meet:** emit event on call connected ([7822272](https://github.com/webex/react-ciscospark/commit/7822272))
-* **widget-meet:** Fix call state views ([dd8a9ae](https://github.com/webex/react-ciscospark/commit/dd8a9ae))
-* **widget-meet:** handle call state errors ([e3ec5ea](https://github.com/webex/react-ciscospark/commit/e3ec5ea))
-* **widget-meet:** optimize render function with selector ([552fb5a](https://github.com/webex/react-ciscospark/commit/552fb5a))
-* **widget-meet:** Render video srcObject instead of url ([a537aa9](https://github.com/webex/react-ciscospark/commit/a537aa9))
-* **widget-meet:** send locus url to accept incoming call method ([d956f3e](https://github.com/webex/react-ciscospark/commit/d956f3e))
-* **widget-meet:** update call error messages ([ed8533d](https://github.com/webex/react-ciscospark/commit/ed8533d))
-* **widget-meet:** Update call event structure ([2a301f3](https://github.com/webex/react-ciscospark/commit/2a301f3))
-* **widget-meet:** Update styles, move controls into containers ([e57c0b7](https://github.com/webex/react-ciscospark/commit/e57c0b7))
-* **widget-meet:** use #placeCall ([c4c64a7](https://github.com/webex/react-ciscospark/commit/c4c64a7))
-* **widget-message:** add actorName to message event data ([dde2a47](https://github.com/webex/react-ciscospark/commit/dde2a47))
-* **widget-message:** add display of conversation error ([af45cfe](https://github.com/webex/react-ciscospark/commit/af45cfe))
-* **widget-message:** Add feature flag for mentions ([0ca45ba](https://github.com/webex/react-ciscospark/commit/0ca45ba))
-* **widget-message:** add isAcknowledgementsDisabled prop ([76ec124](https://github.com/webex/react-ciscospark/commit/76ec124))
-* **widget-message:** add more detailed activity verb processing ([b751e42](https://github.com/webex/react-ciscospark/commit/b751e42))
-* **widget-message:** Add notification events ([d402aa2](https://github.com/webex/react-ciscospark/commit/d402aa2))
-* **widget-message:** Add roomId to activity event payload ([385bf17](https://github.com/webex/react-ciscospark/commit/385bf17))
-* **widget-message:** enable presence subscription ([79a095f](https://github.com/webex/react-ciscospark/commit/79a095f))
-* **widget-message:** implement activity retry feature ([07760df](https://github.com/webex/react-ciscospark/commit/07760df))
-* **widget-message:** implement buffer state watcher ([57f4585](https://github.com/webex/react-ciscospark/commit/57f4585))
-* **widget-message:** implement hoc-conversation-mercury ([2818a8a](https://github.com/webex/react-ciscospark/commit/2818a8a))
-* **widget-message:** Load conversation before websocket established ([57f9e9d](https://github.com/webex/react-ciscospark/commit/57f9e9d))
-* **widget-message:** mark conversation as read with mouse move ([b32c120](https://github.com/webex/react-ciscospark/commit/b32c120))
-* **widget-message:** Update events model ([a9e85c9](https://github.com/webex/react-ciscospark/commit/a9e85c9))
-* **widget-message:** use feature flag constants ([01eb2b5](https://github.com/webex/react-ciscospark/commit/01eb2b5))
-* **widget-message:** use fetchAvatars method ([14109c2](https://github.com/webex/react-ciscospark/commit/14109c2))
-* **widget-message-meet:** ability to start call via data props ([e21b143](https://github.com/webex/react-ciscospark/commit/e21b143))
-* **widget-message-meet:** Add ability to pass event names ([1ba8342](https://github.com/webex/react-ciscospark/commit/1ba8342))
-* **widget-message-meet:** add accessibility label to main menu ([7d1fc2f](https://github.com/webex/react-ciscospark/commit/7d1fc2f))
-* **widget-message-meet:** add accessibility label to main menu ([3d82113](https://github.com/webex/react-ciscospark/commit/3d82113))
-* **widget-message-meet:** add action for widget menu ([7b7efd7](https://github.com/webex/react-ciscospark/commit/7b7efd7))
-* **widget-message-meet:** Add browser global, additional props ([6e8b718](https://github.com/webex/react-ciscospark/commit/6e8b718))
-* **widget-message-meet:** Add call duration to title bar ([9889b45](https://github.com/webex/react-ciscospark/commit/9889b45))
-* **widget-message-meet:** Add callback and event support ([c980ea3](https://github.com/webex/react-ciscospark/commit/c980ea3))
-* **widget-message-meet:** Add intl support ([759ff03](https://github.com/webex/react-ciscospark/commit/759ff03))
-* **widget-message-meet:** Allow multiple widgets and removal ([ba2878c](https://github.com/webex/react-ciscospark/commit/ba2878c))
-* **widget-message-meet:** do not remove meet widget from dom ([fe2b3e5](https://github.com/webex/react-ciscospark/commit/fe2b3e5))
-* **widget-message-meet:** Go to message view after call ends ([ea36cf4](https://github.com/webex/react-ciscospark/commit/ea36cf4))
-* **widget-message-meet:** hangup active call on unload ([914c80f](https://github.com/webex/react-ciscospark/commit/914c80f))
-* **widget-message-meet:** implement activity menu ([1842c5d](https://github.com/webex/react-ciscospark/commit/1842c5d))
-* **widget-message-meet:** implement initial activity feature ([31486c6](https://github.com/webex/react-ciscospark/commit/31486c6))
-* **widget-message-meet:** in flight message preview ([d08dd8f](https://github.com/webex/react-ciscospark/commit/d08dd8f))
-* **widget-message-meet:** move activity menu from title bar to top ([62b428c](https://github.com/webex/react-ciscospark/commit/62b428c))
-* **widget-message-meet:** Move all widgets to new widget-base ([37e3592](https://github.com/webex/react-ciscospark/commit/37e3592))
-* **widget-message-meet:** properly define imports and exports of widgets ([10ee466](https://github.com/webex/react-ciscospark/commit/10ee466))
-* **widget-message-meet:** properly define imports and exports of widgets ([964a7af](https://github.com/webex/react-ciscospark/commit/964a7af))
-* **widget-message-meet:** toggle between message and meet ([cc8342b](https://github.com/webex/react-ciscospark/commit/cc8342b))
-* **widget-message-meet-demo:** initial implementation ([e38c130](https://github.com/webex/react-ciscospark/commit/e38c130))
-* **widget-recent:** Add incoming call event ([7f5ba02](https://github.com/webex/react-ciscospark/commit/7f5ba02))
-* **widget-recents:** Add ability to load spaces in increments ([af349e0](https://github.com/webex/react-ciscospark/commit/af349e0))
-* **widget-recents:** add accessibility label to call button ([f93d9b6](https://github.com/webex/react-ciscospark/commit/f93d9b6))
-* **widget-recents:** Add activity sender name to preview ([682e6f9](https://github.com/webex/react-ciscospark/commit/682e6f9))
-* **widget-recents:** Add all styles and UI fixes ([f9c439e](https://github.com/webex/react-ciscospark/commit/f9c439e))
-* **widget-recents:** Add direct call button ([b505846](https://github.com/webex/react-ciscospark/commit/b505846))
-* **widget-recents:** add features module ([703e193](https://github.com/webex/react-ciscospark/commit/703e193))
-* **widget-recents:** add fetch space when delete event arrives ([a63db43](https://github.com/webex/react-ciscospark/commit/a63db43))
-* **widget-recents:** Add filter for hidden spaces and move listeners ([84a3796](https://github.com/webex/react-ciscospark/commit/84a3796))
-* **widget-recents:** add group calling feature check ([9f6224d](https://github.com/webex/react-ciscospark/commit/9f6224d))
-* **widget-recents:** Add incoming call view into widgets ([6a81412](https://github.com/webex/react-ciscospark/commit/6a81412))
-* **widget-recents:** Add list constructors ([6d09d5d](https://github.com/webex/react-ciscospark/commit/6d09d5d))
-* **widget-recents:** Add listeners and events for moderation and shares ([5bd448a](https://github.com/webex/react-ciscospark/commit/5bd448a))
-* **widget-recents:** Add listeners for new messages and acknowledges ([b608dc7](https://github.com/webex/react-ciscospark/commit/b608dc7))
-* **widget-recents:** Add membership events ([b12ffbf](https://github.com/webex/react-ciscospark/commit/b12ffbf))
-* **widget-recents:** Add progressive avatar loading ([f1c2e1f](https://github.com/webex/react-ciscospark/commit/f1c2e1f))
-* **widget-recents:** Add rooms:unread and messages:created events ([8f4763b](https://github.com/webex/react-ciscospark/commit/8f4763b))
-* **widget-recents:** Add smaller initial spaces fetch ([0895a1a](https://github.com/webex/react-ciscospark/commit/0895a1a))
-* **widget-recents:** Add spaces fetching ([80b149d](https://github.com/webex/react-ciscospark/commit/80b149d))
-* **widget-recents:** add toPersonEmail to event data ([6ea08ed](https://github.com/webex/react-ciscospark/commit/6ea08ed))
-* **widget-recents:** Add unread indicator ([c0c7880](https://github.com/webex/react-ciscospark/commit/c0c7880))
-* **widget-recents:** Add view for pending space and decrypt support ([775d8bf](https://github.com/webex/react-ciscospark/commit/775d8bf))
-* **widget-recents:** Added initial avatars to direct spaces ([02298da](https://github.com/webex/react-ciscospark/commit/02298da))
-* **widget-recents:** Added non-text messages to list ([ce853cf](https://github.com/webex/react-ciscospark/commit/ce853cf))
-* **widget-recents:** display call button for group spaces ([29503b6](https://github.com/webex/react-ciscospark/commit/29503b6))
-* **widget-recents:** Hide incoming call ui when webrtc is not available ([3a70073](https://github.com/webex/react-ciscospark/commit/3a70073))
-* **widget-recents:** Initial reducers and containers ([07c3959](https://github.com/webex/react-ciscospark/commit/07c3959))
-* **widget-recents:** Progressive fetch rooms if unfetched ([0cffe9e](https://github.com/webex/react-ciscospark/commit/0cffe9e))
-* **widget-recents:** update incoming call listener for group calls ([78c557d](https://github.com/webex/react-ciscospark/commit/78c557d))
-* **widget-recents:** Update to use teams redux module ([0352175](https://github.com/webex/react-ciscospark/commit/0352175))
-* **widget-recents:** use avatar module for direct space avatars ([dc0c13d](https://github.com/webex/react-ciscospark/commit/dc0c13d))
-* **widget-recents:** use avatars module for space avatars ([2c84534](https://github.com/webex/react-ciscospark/commit/2c84534))
-* **widget-recents:** use bright spinner ([c21b20e](https://github.com/webex/react-ciscospark/commit/c21b20e))
-* **widget-recents:** use CallDataActivityMessage in space-item ([ac53694](https://github.com/webex/react-ciscospark/commit/ac53694))
-* **widget-recents:** use space read method ([d249015](https://github.com/webex/react-ciscospark/commit/d249015))
-* **widget-recents:** utilize errors module for display of errors ([c8384af](https://github.com/webex/react-ciscospark/commit/c8384af))
-* **widget-recents-demo:** add aria labels ([729d54d](https://github.com/webex/react-ciscospark/commit/729d54d))
-* **widget-recents-demo:** add support for events array ([a1e976b](https://github.com/webex/react-ciscospark/commit/a1e976b))
-* **widget-recents-demo:** change to basic input ([cf5aaaf](https://github.com/webex/react-ciscospark/commit/cf5aaaf))
-* **widget-recents-demo:** initial implementation ([afafb0e](https://github.com/webex/react-ciscospark/commit/afafb0e))
-* **widget-recents-demo:** use browser global method for widget creation ([b7f8eff](https://github.com/webex/react-ciscospark/commit/b7f8eff))
-* **widget-roster:** Add active call state tracking ([737b613](https://github.com/webex/react-ciscospark/commit/737b613))
-* **widget-roster:** add avatar component to list item ([9077a2d](https://github.com/webex/react-ciscospark/commit/9077a2d))
-* **widget-roster:** add avatar support ([0476511](https://github.com/webex/react-ciscospark/commit/0476511))
-* **widget-roster:** add edit button to roster items ([3bd5cd3](https://github.com/webex/react-ciscospark/commit/3bd5cd3))
-* **widget-roster:** add editingParticipant store data ([833fa2e](https://github.com/webex/react-ciscospark/commit/833fa2e))
-* **widget-roster:** add header bar ([7173b81](https://github.com/webex/react-ciscospark/commit/7173b81))
-* **widget-roster:** add invite email user ([4d11892](https://github.com/webex/react-ciscospark/commit/4d11892))
-* **widget-roster:** add keyboard interaction to add-participant ([81e9a05](https://github.com/webex/react-ciscospark/commit/81e9a05))
-* **widget-roster:** add moderators section to list ([5ee9c2c](https://github.com/webex/react-ciscospark/commit/5ee9c2c))
-* **widget-roster:** add participant details modal ([6cd7132](https://github.com/webex/react-ciscospark/commit/6cd7132))
-* **widget-roster:** add participant settings to redux state ([062f945](https://github.com/webex/react-ciscospark/commit/062f945))
-* **widget-roster:** add PersonListItem display to add participant ([fd7a040](https://github.com/webex/react-ciscospark/commit/fd7a040))
-* **widget-roster:** add roster header component ([3567cdf](https://github.com/webex/react-ciscospark/commit/3567cdf))
-* **widget-roster:** add scroll support for roster list ([af6b927](https://github.com/webex/react-ciscospark/commit/af6b927))
-* **widget-roster:** add search input ([f9c3d30](https://github.com/webex/react-ciscospark/commit/f9c3d30))
-* **widget-roster:** add search module capabilities ([1f577c6](https://github.com/webex/react-ciscospark/commit/1f577c6))
-* **widget-roster:** add user avatars to search results ([6697e9d](https://github.com/webex/react-ciscospark/commit/6697e9d))
-* **widget-roster:** create initial implementation ([58896af](https://github.com/webex/react-ciscospark/commit/58896af))
-* **widget-roster:** display add people button ([c4bf8b7](https://github.com/webex/react-ciscospark/commit/c4bf8b7))
-* **widget-roster:** display external status of users ([fc6cefc](https://github.com/webex/react-ciscospark/commit/fc6cefc))
-* **widget-roster:** display in flight participants ([166a516](https://github.com/webex/react-ciscospark/commit/166a516))
-* **widget-roster:** implement addParticipantToConversation ([f74aed0](https://github.com/webex/react-ciscospark/commit/f74aed0))
-* **widget-roster:** limit consumer org members to email only search ([71edce1](https://github.com/webex/react-ciscospark/commit/71edce1))
-* **widget-roster:** move external message to component ([63ce2f4](https://github.com/webex/react-ciscospark/commit/63ce2f4))
-* **widget-roster:** remove avatar from selector ([4f15360](https://github.com/webex/react-ciscospark/commit/4f15360))
-* **widget-roster:** separate list between current user and others ([4f36a70](https://github.com/webex/react-ciscospark/commit/4f36a70))
-* **widget-roster:** update accessibility label ([ca6176d](https://github.com/webex/react-ciscospark/commit/ca6176d))
-* **widget-roster:** use components to display roster list ([219aa7b](https://github.com/webex/react-ciscospark/commit/219aa7b))
-* **widget-roster:** use react-intl messages for text display ([808eebf](https://github.com/webex/react-ciscospark/commit/808eebf))
-* **widget-space:** add ability to pass props to activities ([915995a](https://github.com/webex/react-ciscospark/commit/915995a))
-* **widget-space:** add ability to update widget status ([17290e5](https://github.com/webex/react-ciscospark/commit/17290e5))
-* **widget-space:** Add Activity Imports for widgets ([bf16319](https://github.com/webex/react-ciscospark/commit/bf16319))
-* **widget-space:** Add activity menu ([6d07c84](https://github.com/webex/react-ciscospark/commit/6d07c84))
-* **widget-space:** Add actorName to calling and rooms events ([d402f82](https://github.com/webex/react-ciscospark/commit/d402f82))
-* **widget-space:** Add call start time ([6adc061](https://github.com/webex/react-ciscospark/commit/6adc061))
-* **widget-space:** add feature ability to activity menu ([96a203f](https://github.com/webex/react-ciscospark/commit/96a203f))
-* **widget-space:** add features module ([771c1d4](https://github.com/webex/react-ciscospark/commit/771c1d4))
-* **widget-space:** add group calling activity menu icon ([43d3e92](https://github.com/webex/react-ciscospark/commit/43d3e92))
-* **widget-space:** add id validation to getSpaceDetails ([981d13b](https://github.com/webex/react-ciscospark/commit/981d13b))
-* **widget-space:** add secondary activity to store ([8e3ded2](https://github.com/webex/react-ciscospark/commit/8e3ded2))
-* **widget-space:** add support for conversation errors ([4a4ff0f](https://github.com/webex/react-ciscospark/commit/4a4ff0f))
-* **widget-space:** add support for feature hide activities ([3f66f78](https://github.com/webex/react-ciscospark/commit/3f66f78))
-* **widget-space:** Add title bar data. Fix eslint errors ([5ab077a](https://github.com/webex/react-ciscospark/commit/5ab077a))
-* **widget-space:** change activity menu to return activity object ([fb4d56a](https://github.com/webex/react-ciscospark/commit/fb4d56a))
-* **widget-space:** change roster feature flag type to developer ([90443e7](https://github.com/webex/react-ciscospark/commit/90443e7))
-* **widget-space:** check error message if error name not matched ([a6dd9ff](https://github.com/webex/react-ciscospark/commit/a6dd9ff))
-* **widget-space:** Create initial container and component ([d84655f](https://github.com/webex/react-ciscospark/commit/d84655f))
-* **widget-space:** display error if to user is self ([7befc72](https://github.com/webex/react-ciscospark/commit/7befc72))
-* **widget-space:** display error on mercury disconnect ([999b2e0](https://github.com/webex/react-ciscospark/commit/999b2e0))
-* **widget-space:** display error on mercury disconnect ([8ba8eb8](https://github.com/webex/react-ciscospark/commit/8ba8eb8))
-* **widget-space:** display secondary widget when chosen ([b22bfbb](https://github.com/webex/react-ciscospark/commit/b22bfbb))
-* **widget-space:** display space errors on load ([27ebf63](https://github.com/webex/react-ciscospark/commit/27ebf63))
-* **widget-space:** Initial frame for widget ([bcce56d](https://github.com/webex/react-ciscospark/commit/bcce56d))
-* **widget-space:** Initial working widgets with message and calling ([d9acb33](https://github.com/webex/react-ciscospark/commit/d9acb33))
-* **widget-space:** move menu button to passed child of title bar ([0873b22](https://github.com/webex/react-ciscospark/commit/0873b22))
-* **widget-space:** remove avatar lookup ([ad18f34](https://github.com/webex/react-ciscospark/commit/ad18f34))
-* **widget-space:** remove call state watcher to switch modes ([d3f138a](https://github.com/webex/react-ciscospark/commit/d3f138a))
-* **widget-space:** Retrieve space details from public api ([4e9ca8e](https://github.com/webex/react-ciscospark/commit/4e9ca8e))
-* **widget-space:** store space details failures ([a52b5f1](https://github.com/webex/react-ciscospark/commit/a52b5f1))
-* **widget-space:** support for error actions ([bcacf75](https://github.com/webex/react-ciscospark/commit/bcacf75))
-* **widget-space:** update space not found message ([d8f2a72](https://github.com/webex/react-ciscospark/commit/d8f2a72))
-* **widget-space:** use errors module to display errors ([0d7806f](https://github.com/webex/react-ciscospark/commit/0d7806f))
-* **widget-space:** use errors module to display errors ([93d8d26](https://github.com/webex/react-ciscospark/commit/93d8d26))
-* **widget-space:** use feature flag constants ([dfc921a](https://github.com/webex/react-ciscospark/commit/dfc921a))
-* **widget-space:** use instanceof for error interpreting ([3709d41](https://github.com/webex/react-ciscospark/commit/3709d41))
-* **widget-space:** widget error object added to selector ([02b29ff](https://github.com/webex/react-ciscospark/commit/02b29ff))
-* **widget-space-demo:** add aria labels to inputs ([6301afd](https://github.com/webex/react-ciscospark/commit/6301afd))
-* **widget-space-demo:** add remove widget button ([df79074](https://github.com/webex/react-ciscospark/commit/df79074))
-* **widget-space-demo:** add support for events array ([da5ef34](https://github.com/webex/react-ciscospark/commit/da5ef34))
-* **widget-space-demo:** add toggle to show token in example code ([c88424e](https://github.com/webex/react-ciscospark/commit/c88424e))
-* **widget-space-demo:** add widget-space to bundle for dev builds ([be95d36](https://github.com/webex/react-ciscospark/commit/be95d36))
-* **widget-space-demo:** change to basic input ([7e61311](https://github.com/webex/react-ciscospark/commit/7e61311))
-* **widget-space-demo:** convert widget creation to global method ([4d5f9d7](https://github.com/webex/react-ciscospark/commit/4d5f9d7))
-* **widget-space-demo:** display global code demo option ([d5ccf11](https://github.com/webex/react-ciscospark/commit/d5ccf11))
-* **widget-space-demo:** initial implementation ([a946852](https://github.com/webex/react-ciscospark/commit/a946852))
-* **widget-space-demo:** revamped look with material cards ([5ae183c](https://github.com/webex/react-ciscospark/commit/5ae183c))
-* **widget-space-demo:** use injected bundle paths ([13e1517](https://github.com/webex/react-ciscospark/commit/13e1517))
-* **wiget-meet:** remove call.joined references ([c6d9f20](https://github.com/webex/react-ciscospark/commit/c6d9f20))
+* **redux-module-avatar:** check state before starting request ([e7b8128](https://github.com/webex/react-widgets/commit/e7b8128))
+* Components now build ([0426d8e](https://github.com/webex/react-widgets/commit/0426d8e))
+* **all:** add iconSize prop to PresenceAvatar implementations ([105a0c5](https://github.com/webex/react-widgets/commit/105a0c5))
+* **call-activity:** display locus call data in activity list ([886b7d8](https://github.com/webex/react-widgets/commit/886b7d8))
+* **components:** Add all activity list components ([caa1e42](https://github.com/webex/react-widgets/commit/caa1e42))
+* **components:** Add chip, modal, staging area, sparators, and utils ([2ff6707](https://github.com/webex/react-widgets/commit/2ff6707))
+* **components:** Add loading-screen and spinner ([f3db512](https://github.com/webex/react-widgets/commit/f3db512))
+* **components:** Add new message separator, fix tests ([c358b71](https://github.com/webex/react-widgets/commit/c358b71))
+* **components:** Add redux wrapper, activity items ([17ed13a](https://github.com/webex/react-widgets/commit/17ed13a))
+* **components:** Add scroll to bottom button ([fc3d90b](https://github.com/webex/react-widgets/commit/fc3d90b))
+* **components:** Add text area component ([aa96b9a](https://github.com/webex/react-widgets/commit/aa96b9a))
+* **components:** Add TitleBar component ([0a0e776](https://github.com/webex/react-widgets/commit/0a0e776))
+* **components:** Add typingAvatar and typingIndicator components ([9fab467](https://github.com/webex/react-widgets/commit/9fab467))
+* **components:** All components migrated. Tests updated. Some tests still failing ([537c49e](https://github.com/webex/react-widgets/commit/537c49e))
+* **demo:** add material-ui styling ([666af8c](https://github.com/webex/react-widgets/commit/666af8c))
+* **demo:** add message meet widget to demo ([2d8ea1a](https://github.com/webex/react-widgets/commit/2d8ea1a))
+* **demo:** change example to tabbed view ([aaf1a73](https://github.com/webex/react-widgets/commit/aaf1a73))
+* **demo:** demo login moved into its own component ([6e559e8](https://github.com/webex/react-widgets/commit/6e559e8))
+* **demo:** initial router setup ([b58c84e](https://github.com/webex/react-widgets/commit/b58c84e))
+* **demos:** use new react-cookies methods ([dde832d](https://github.com/webex/react-widgets/commit/dde832d))
+* **metrics:** Add store for metrics that aren't ready to be sent ([0e01e13](https://github.com/webex/react-widgets/commit/0e01e13))
+* **r-comp-activity-system-message:** add group call messages ([377df5e](https://github.com/webex/react-widgets/commit/377df5e))
+* **react-component-activity-item:** support for error activity retries ([3b2828b](https://github.com/webex/react-widgets/commit/3b2828b))
+* **react-component-activity-item-base:** add support for error activity retries ([2b56a78](https://github.com/webex/react-widgets/commit/2b56a78))
+* **react-component-activity-item-base:** build classes array for avatar classes ([e07d7aa](https://github.com/webex/react-widgets/commit/e07d7aa))
+* **react-component-activity-item-base:** display name "you" for self activities ([c40ab9a](https://github.com/webex/react-widgets/commit/c40ab9a))
+* **react-component-activity-item-base:** implement avatar size ([666fd67](https://github.com/webex/react-widgets/commit/666fd67))
+* **react-component-activity-item-base:** Show publish time without hover ([aab26c7](https://github.com/webex/react-widgets/commit/aab26c7))
+* **react-component-activity-item-base:** use PresenceAvatar component ([28320a7](https://github.com/webex/react-widgets/commit/28320a7))
+* **react-component-activity-list:** add support for group call data parsing ([459d8ae](https://github.com/webex/react-widgets/commit/459d8ae))
+* **react-component-activity-list:** add support for roster events ([2467264](https://github.com/webex/react-widgets/commit/2467264))
+* **react-component-activity-list:** pass actorId instead of avatar ([9620c09](https://github.com/webex/react-widgets/commit/9620c09))
+* **react-component-activity-list:** remove callData prop ([8aac635](https://github.com/webex/react-widgets/commit/8aac635))
+* **react-component-activity-list:** support for error activity retries ([51889e2](https://github.com/webex/react-widgets/commit/51889e2))
+* **react-component-activity-menu:** initial component creation ([1f4622d](https://github.com/webex/react-widgets/commit/1f4622d))
+* **react-component-activity-menu:** style the menu appropriately ([a9630cd](https://github.com/webex/react-widgets/commit/a9630cd))
+* **react-component-activity-system-message:** add support for roster events ([05747f3](https://github.com/webex/react-widgets/commit/05747f3))
+* **react-component-activity-system-message:** use CallDataActivityMessage ([be77c7d](https://github.com/webex/react-widgets/commit/be77c7d))
+* **react-component-activity-text:** Add html filter on dangerously set html ([1c056a8](https://github.com/webex/react-widgets/commit/1c056a8))
+* **react-component-activity-text:** add pre-wrap style for new lines ([61cc206](https://github.com/webex/react-widgets/commit/61cc206))
+* **react-component-activity-text:** use linkify to create links for text ([3426a60](https://github.com/webex/react-widgets/commit/3426a60))
+* **react-component-audio:** New audio component that supports srcObject ([6ca9d35](https://github.com/webex/react-widgets/commit/6ca9d35))
+* **react-component-avatar:** add conversion to uppercase for names ([e8e70e5](https://github.com/webex/react-widgets/commit/e8e70e5))
+* **react-component-avatar:** add size prop to avatar ([2e27f7b](https://github.com/webex/react-widgets/commit/2e27f7b))
+* **react-component-badge:** add tooltip support ([85cf5f5](https://github.com/webex/react-widgets/commit/85cf5f5))
+* **react-component-badge:** initial implementation ([875c912](https://github.com/webex/react-widgets/commit/875c912))
+* **react-component-button:** accessibility label prop added ([cd5fe32](https://github.com/webex/react-widgets/commit/cd5fe32))
+* **react-component-button:** accessibility label prop added ([ef89db8](https://github.com/webex/react-widgets/commit/ef89db8))
+* **react-component-button:** add aria-label to button ([484bce6](https://github.com/webex/react-widgets/commit/484bce6))
+* **react-component-button:** add aria-label to button ([cb649fe](https://github.com/webex/react-widgets/commit/cb649fe))
+* **react-component-button:** use icon title as aria label ([9653abb](https://github.com/webex/react-widgets/commit/9653abb))
+* **react-component-button-controls:** use button label as accessibility label ([8cceb2b](https://github.com/webex/react-widgets/commit/8cceb2b))
+* **react-component-call-data-activity:** initial component ([35bd069](https://github.com/webex/react-widgets/commit/35bd069))
+* **react-component-cover:** Create screen cover component ([8a3d42d](https://github.com/webex/react-widgets/commit/8a3d42d))
+* **react-component-error-display:** initial implementation ([6ac79e0](https://github.com/webex/react-widgets/commit/6ac79e0))
+* **react-component-icon:** add contact icon support ([c1b9b82](https://github.com/webex/react-widgets/commit/c1b9b82))
+* **react-component-icon:** add dnd and pto icons ([b7101eb](https://github.com/webex/react-widgets/commit/b7101eb))
+* **react-component-icon:** add invite icon ([2dc8a57](https://github.com/webex/react-widgets/commit/2dc8a57))
+* **react-component-icon:** add more icon ([fe250b3](https://github.com/webex/react-widgets/commit/fe250b3))
+* **react-component-icon:** make external user icons available ([9eb362c](https://github.com/webex/react-widgets/commit/9eb362c))
+* **react-component-icon:** upgrade to Neo-icons font ([2340b76](https://github.com/webex/react-widgets/commit/2340b76))
+* **react-component-incoming-call:** Moved component into package ([117cd1a](https://github.com/webex/react-widgets/commit/117cd1a))
+* **react-component-people-list:** Create people list component ([48261d4](https://github.com/webex/react-widgets/commit/48261d4))
+* **react-component-people-list:** use connected PresenceAvatar ([cb1d866](https://github.com/webex/react-widgets/commit/cb1d866))
+* **react-component-person-list-item:** change avatarUrl param to avatar ([25888ec](https://github.com/webex/react-widgets/commit/25888ec))
+* **react-component-person-list-item:** initial component ([5f4f0db](https://github.com/webex/react-widgets/commit/5f4f0db))
+* **react-component-presence-avatar:** initial implementation ([d8efdf9](https://github.com/webex/react-widgets/commit/d8efdf9))
+* **react-component-ringtone:** initial component ([059dec8](https://github.com/webex/react-widgets/commit/059dec8))
+* **react-component-spark-fonts:** initial component ([a6f73e4](https://github.com/webex/react-widgets/commit/a6f73e4))
+* **react-component-spark-logo:** initial component ([b1b0a4c](https://github.com/webex/react-widgets/commit/b1b0a4c))
+* **react-component-spark-oauth:** create new component from demo code ([7c13acc](https://github.com/webex/react-widgets/commit/7c13acc))
+* **react-component-spinner:** add bright flag to match new design ([b6c9dc4](https://github.com/webex/react-widgets/commit/b6c9dc4))
+* **react-component-title-bar:** add waffle menu ([e5148df](https://github.com/webex/react-widgets/commit/e5148df))
+* **react-component-title-bar:** style according to design ([fedb9dc](https://github.com/webex/react-widgets/commit/fedb9dc))
+* **react-component-title-bar:** use PresenceAvatar connected component ([3752a76](https://github.com/webex/react-widgets/commit/3752a76))
+* **react-component-typing-avatar:** add hover tooltip of name ([bef3ad6](https://github.com/webex/react-widgets/commit/bef3ad6))
+* **react-component-typing-avatar:** implement avatar size prop ([e2c82d8](https://github.com/webex/react-widgets/commit/e2c82d8))
+* **react-component-typing-avatar:** use PresenceAvatar component ([dc3f893](https://github.com/webex/react-widgets/commit/dc3f893))
+* **react-component-utils:** activity constructor requires full conversation object ([748ea19](https://github.com/webex/react-widgets/commit/748ea19))
+* **react-component-utils:** add #constructHydraId method ([51e826c](https://github.com/webex/react-widgets/commit/51e826c))
+* **react-component-utils:** Add sdk version to metrics ([7b885da](https://github.com/webex/react-widgets/commit/7b885da))
+* **react-component-utils:** add validateAndDecodeId function ([e128985](https://github.com/webex/react-widgets/commit/e128985))
+* **react-component-utils:** isUuid feature added ([fe9853e](https://github.com/webex/react-widgets/commit/fe9853e))
+* **react-component-utils:** store metadata about activity to recreate ([1317c21](https://github.com/webex/react-widgets/commit/1317c21))
+* **react-component-video:** change to audio tag if video muted ([5fa0bfe](https://github.com/webex/react-widgets/commit/5fa0bfe))
+* **react-container-activity-list:** Add at mention formatter ([34aeec4](https://github.com/webex/react-widgets/commit/34aeec4))
+* **react-container-activity-list:** Add at mention formatter and events ([1584f10](https://github.com/webex/react-widgets/commit/1584f10))
+* **react-container-activity-list:** add error activities to selector ([a87dcd8](https://github.com/webex/react-widgets/commit/a87dcd8))
+* **react-container-activity-list:** Add external formatters ([bf88dce](https://github.com/webex/react-widgets/commit/bf88dce))
+* **react-container-activity-list:** remove call data calculation ([06a8d79](https://github.com/webex/react-widgets/commit/06a8d79))
+* **react-container-activity-list:** show declined outbound calls as unavailable ([6577a01](https://github.com/webex/react-widgets/commit/6577a01))
+* **react-container-activity-list:** support for error activity retries ([4cfa4aa](https://github.com/webex/react-widgets/commit/4cfa4aa))
+* **react-container-call-incoming:** create container for handling incoming calls ([1ddaf19](https://github.com/webex/react-widgets/commit/1ddaf19))
+* **react-container-call-incoming:** emit event when call is incoming ([461cb24](https://github.com/webex/react-widgets/commit/461cb24))
+* **react-container-call-incoming:** implement ringtone component ([6660363](https://github.com/webex/react-widgets/commit/6660363))
+* **react-container-call-incoming:** plays ringtone when ringing ([ac58a51](https://github.com/webex/react-widgets/commit/ac58a51))
+* **react-container-message-composer:** Add avatar and cleaner styles ([f40a0b7](https://github.com/webex/react-widgets/commit/f40a0b7))
+* **react-container-message-composer:** Add debounce to setting UserTyping ([48a7a00](https://github.com/webex/react-widgets/commit/48a7a00))
+* **react-container-message-composer:** Add mention support ([5ce172d](https://github.com/webex/react-widgets/commit/5ce172d))
+* **react-container-message-composer:** grow text area for longer text inputs ([60b6a79](https://github.com/webex/react-widgets/commit/60b6a79))
+* **react-container-message-composer:** use disabled mentions input for text entry ([68b72c1](https://github.com/webex/react-widgets/commit/68b72c1))
+* **react-container-notifications:** add incoming call notification ([e6f2ec1](https://github.com/webex/react-widgets/commit/e6f2ec1))
+* **react-container-notifications:** Add support to multiple widgets ([f2dfbdd](https://github.com/webex/react-widgets/commit/f2dfbdd))
+* **react-container-notifications:** notification generation moved to external component ([a630d3a](https://github.com/webex/react-widgets/commit/a630d3a))
+* **react-container-presence-avatar:** initial module ([243da99](https://github.com/webex/react-widgets/commit/243da99))
+* **react-container-read-receipts:** add hidden users array ([cc912ae](https://github.com/webex/react-widgets/commit/cc912ae))
+* **react-container-read-receipts:** add sort so typing participants get priority ([78c0498](https://github.com/webex/react-widgets/commit/78c0498))
+* **react-container-read-receipts:** display count of supressed receipts ([1a26a48](https://github.com/webex/react-widgets/commit/1a26a48))
+* **react-container-read-receipts:** fetch avatars for displayed read receipt users ([4746e4e](https://github.com/webex/react-widgets/commit/4746e4e))
+* **react-container-read-receipts:** send user id prop ([746ec57](https://github.com/webex/react-widgets/commit/746ec57))
+* **react-container-read-receipts:** using selector to create props ([6ed2ba7](https://github.com/webex/react-widgets/commit/6ed2ba7))
+* **react-hoc-conversation-mercury:** add initial conversation events ([f38fbc7](https://github.com/webex/react-widgets/commit/f38fbc7))
+* **react-hoc-conversation-mercury:** add roster events as comments ([55277f9](https://github.com/webex/react-widgets/commit/55277f9))
+* **react-hoc-conversation-mercury:** implement addParticipant/removeParticipant ([5356a4d](https://github.com/webex/react-widgets/commit/5356a4d))
+* **react-redux-spark:** Add config options from widget to Spark SDK ([a9d4ba1](https://github.com/webex/react-widgets/commit/a9d4ba1))
+* **react-redux-spark:** Add forage storage adapter to cache encryption keys ([92c375f](https://github.com/webex/react-widgets/commit/92c375f))
+* **react-redux-spark:** Add longer KMS timeout ([5c4967d](https://github.com/webex/react-widgets/commit/5c4967d))
+* **react-redux-spark:** add plugin-people ([20c9b77](https://github.com/webex/react-widgets/commit/20c9b77))
+* **react-redux-spark:** Check for global instance before creating new ([2b69a9c](https://github.com/webex/react-widgets/commit/2b69a9c))
+* **react-redux-spark:** enable group calling config ([9c54e97](https://github.com/webex/react-widgets/commit/9c54e97))
+* **react-redux-spark:** only fire off mercury connect once ([52b75db](https://github.com/webex/react-widgets/commit/52b75db))
+* **react-redux-spark:** store registration errors ([989646e](https://github.com/webex/react-widgets/commit/989646e))
+* **react-redux-spark-metrics:** Add duration metrics ([a32c9b9](https://github.com/webex/react-widgets/commit/a32c9b9))
+* **react-redux-spark-metrics:** Add queuing of metrics ([57eb5d8](https://github.com/webex/react-widgets/commit/57eb5d8))
+* **react-redux-spark-metrics:** Clena up actions and add reducers ([1a7116e](https://github.com/webex/react-widgets/commit/1a7116e))
+* **react-redux-spark-metrics:** Finished queue and duration send ([783a551](https://github.com/webex/react-widgets/commit/783a551))
+* **react-redux-spark-metrics:** Initial metrics framework ([bd3a25b](https://github.com/webex/react-widgets/commit/bd3a25b))
+* **react-test-utils:** add shallow render intl helper ([e50729f](https://github.com/webex/react-widgets/commit/e50729f))
+* **redux-module-activity:** add ability to retry failed activity ([637715e](https://github.com/webex/react-widgets/commit/637715e))
+* **redux-module-activity:** add activity failures to store ([2b5fcf9](https://github.com/webex/react-widgets/commit/2b5fcf9))
+* **redux-module-avatar:** add space avatar support ([b32299b](https://github.com/webex/react-widgets/commit/b32299b))
+* **redux-module-avatar:** Download smaller avatars for people ([d56b422](https://github.com/webex/react-widgets/commit/d56b422))
+* **redux-module-avatar:** handle people api errors ([6f59720](https://github.com/webex/react-widgets/commit/6f59720))
+* **redux-module-avatar:** Move all avatar fetching to Promises ([37ff3ea](https://github.com/webex/react-widgets/commit/37ff3ea))
+* **redux-module-avatar:** use plugin-people to fetch avatar ([fa94e6c](https://github.com/webex/react-widgets/commit/fa94e6c))
+* **redux-module-conversation:** add #removeParticipantFromConversation ([8ef7252](https://github.com/webex/react-widgets/commit/8ef7252))
+* **redux-module-conversation:** add ability to add sideboarded participant ([cb78741](https://github.com/webex/react-widgets/commit/cb78741))
+* **redux-module-conversation:** add ability to load missing activities ([649ccc0](https://github.com/webex/react-widgets/commit/649ccc0))
+* **redux-module-conversation:** add addParticipant action ([c518411](https://github.com/webex/react-widgets/commit/c518411))
+* **redux-module-conversation:** add addParticipant and removeParticipant ([d594455](https://github.com/webex/react-widgets/commit/d594455))
+* **redux-module-conversation:** add computed room properties ([dc48df3](https://github.com/webex/react-widgets/commit/dc48df3))
+* **redux-module-conversation:** add conversation error handling ([2bcd1fd](https://github.com/webex/react-widgets/commit/2bcd1fd))
+* **redux-module-conversation:** create participants in flight ([1015796](https://github.com/webex/react-widgets/commit/1015796))
+* **redux-module-conversation:** Fix getConversation ([072f5c8](https://github.com/webex/react-widgets/commit/072f5c8))
+* **redux-module-conversation:** remove widget message status props ([38d6ad0](https://github.com/webex/react-widgets/commit/38d6ad0))
+* **redux-module-errors:** add hasError flag ([53ab035](https://github.com/webex/react-widgets/commit/53ab035))
+* **redux-module-errors:** add hasError flag ([5e2bd10](https://github.com/webex/react-widgets/commit/5e2bd10))
+* **redux-module-errors:** initial module ([6077d58](https://github.com/webex/react-widgets/commit/6077d58))
+* **redux-module-errors:** initial module ([d78087f](https://github.com/webex/react-widgets/commit/d78087f))
+* **redux-module-features:** add constants for feature flags ([9661830](https://github.com/webex/react-widgets/commit/9661830))
+* **redux-module-features:** initial implementation ([179293f](https://github.com/webex/react-widgets/commit/179293f))
+* **redux-module-media:** ability to listen for incoming calls ([06330d4](https://github.com/webex/react-widgets/commit/06330d4))
+* **redux-module-media:** add activeParticipantsCount to callState object ([e179878](https://github.com/webex/react-widgets/commit/e179878))
+* **redux-module-media:** Add browser support detection ([f2a1951](https://github.com/webex/react-widgets/commit/f2a1951))
+* **redux-module-media:** Add disconnect action ([a1dfa79](https://github.com/webex/react-widgets/commit/a1dfa79))
+* **redux-module-media:** Add locusUrl to call remove ([34e1b1f](https://github.com/webex/react-widgets/commit/34e1b1f))
+* **redux-module-media:** Add passing id for call association ([ef6b867](https://github.com/webex/react-widgets/commit/ef6b867))
+* **redux-module-media:** change incoming call handling to new methods ([d92d331](https://github.com/webex/react-widgets/commit/d92d331))
+* **redux-module-media:** hang up call on remote decline ([92699e8](https://github.com/webex/react-widgets/commit/92699e8))
+* **redux-module-media:** hangup call on disconnect ([aacec65](https://github.com/webex/react-widgets/commit/aacec65))
+* **redux-module-media:** make answer incoming call a specific action ([356c75e](https://github.com/webex/react-widgets/commit/356c75e))
+* **redux-module-media:** match call via locus url ([f5b2cb9](https://github.com/webex/react-widgets/commit/f5b2cb9))
+* **redux-module-media:** remove call.status reference ([bc5406b](https://github.com/webex/react-widgets/commit/bc5406b))
+* **redux-module-media:** remove media stream creation ([9be01c1](https://github.com/webex/react-widgets/commit/9be01c1))
+* **redux-module-media:** return thunk with call user action ([19b2c7d](https://github.com/webex/react-widgets/commit/19b2c7d))
+* **redux-module-media:** store call errors in call state ([32784ac](https://github.com/webex/react-widgets/commit/32784ac))
+* **redux-module-media:** update to group supported call events ([0876dc3](https://github.com/webex/react-widgets/commit/0876dc3))
+* **redux-module-mercury:** add status object ([7523fc4](https://github.com/webex/react-widgets/commit/7523fc4))
+* **redux-module-mercury:** listen to device registration changes ([e6dba57](https://github.com/webex/react-widgets/commit/e6dba57))
+* **redux-module-mercury:** listen to device registration changes ([aed4f8b](https://github.com/webex/react-widgets/commit/aed4f8b))
+* **redux-module-mercury:** move mercury status out of spark module ([2de0205](https://github.com/webex/react-widgets/commit/2de0205))
+* **redux-module-mercury:** Set mercury to connected if already connected from instance ([53f209a](https://github.com/webex/react-widgets/commit/53f209a))
+* **redux-module-presence:** initial module ([4f3fcb0](https://github.com/webex/react-widgets/commit/4f3fcb0))
+* **redux-module-presence:** use spark presence plugin ([d9dea1a](https://github.com/webex/react-widgets/commit/d9dea1a))
+* **redux-module-search:** Add return for results in user search ([efe56b0](https://github.com/webex/react-widgets/commit/efe56b0))
+* **redux-module-search:** add search hydra for email ([0f35130](https://github.com/webex/react-widgets/commit/0f35130))
+* **redux-module-search:** initial module ([b671b93](https://github.com/webex/react-widgets/commit/b671b93))
+* **redux-module-spaces:** Add action to hide space ([991f75d](https://github.com/webex/react-widgets/commit/991f75d))
+* **redux-module-spaces:** Add hidden flag and update space storage ([9f29da0](https://github.com/webex/react-widgets/commit/9f29da0))
+* **redux-module-spaces:** Add support for defer decryption ([33c0611](https://github.com/webex/react-widgets/commit/33c0611))
+* **redux-module-spaces:** filter for latestActivity in #fetchSpace ([3b2fe5e](https://github.com/webex/react-widgets/commit/3b2fe5e))
+* **redux-module-spaces:** remove avatar fetch ([c61ae2d](https://github.com/webex/react-widgets/commit/c61ae2d))
+* **redux-module-spaces:** Remove teams from module ([ec770f7](https://github.com/webex/react-widgets/commit/ec770f7))
+* **redux-module-spaces:** removes ability to fetch direct space avatar ([368f266](https://github.com/webex/react-widgets/commit/368f266))
+* **redux-module-spaces:** shorten initial fetch ([1ef1da6](https://github.com/webex/react-widgets/commit/1ef1da6))
+* **redux-module-spaces:** Simplify convo retrieval ([dcf9a89](https://github.com/webex/react-widgets/commit/dcf9a89))
+* **redux-module-teams:** Add error catch and correct status updates ([8f3a136](https://github.com/webex/react-widgets/commit/8f3a136))
+* **redux-module-teams:** Add teams module ([57b1461](https://github.com/webex/react-widgets/commit/57b1461))
+* **redux-module-user:** convert request to use people plugin ([3799407](https://github.com/webex/react-widgets/commit/3799407))
+* **spark-widget-base:** Add data api and widget removal ([85db05c](https://github.com/webex/react-widgets/commit/85db05c))
+* **spark-widget-base:** Create new base widget ([55f7210](https://github.com/webex/react-widgets/commit/55f7210))
+* **tooling:** add firefox tests to jenkinsfile ([d5c4c92](https://github.com/webex/react-widgets/commit/d5c4c92))
+* **tooling:** Add jest, stylelint and initial circle config ([9e020c7](https://github.com/webex/react-widgets/commit/9e020c7))
+* **tooling:** add junit reporting ([126c415](https://github.com/webex/react-widgets/commit/126c415))
+* **tooling:** Add npm publish for components ([c2f9369](https://github.com/webex/react-widgets/commit/c2f9369))
+* **tooling:** Add public key to repo ([d7dcea1](https://github.com/webex/react-widgets/commit/d7dcea1))
+* **tooling:** add sauce job names ([b5eba26](https://github.com/webex/react-widgets/commit/b5eba26))
+* **tooling:** Add sri build command ([07d0ed7](https://github.com/webex/react-widgets/commit/07d0ed7))
+* **tooling:** Add sri generation and credentials to Jenkinsfile ([733f434](https://github.com/webex/react-widgets/commit/733f434))
+* **tooling:** Add SRI generation scripts ([4210488](https://github.com/webex/react-widgets/commit/4210488))
+* **tooling:** Add treeshaking ([2a0b5b3](https://github.com/webex/react-widgets/commit/2a0b5b3))
+* **tooling:** Added base components with build and dev server ([a1c9faa](https://github.com/webex/react-widgets/commit/a1c9faa))
+* **tooling:** Added config to bypass Jest issue with node_modules. ([248e5ba](https://github.com/webex/react-widgets/commit/248e5ba))
+* **tooling:** Allow any host connection to local dev ([71b03e9](https://github.com/webex/react-widgets/commit/71b03e9))
+* **tooling:** firefox compatibility for journey tests ([7e3f809](https://github.com/webex/react-widgets/commit/7e3f809))
+* **tooling:** Fix bad builds, add split package builds ([d652c4c](https://github.com/webex/react-widgets/commit/d652c4c))
+* **tooling:** Fix css compile, add file button ([292246e](https://github.com/webex/react-widgets/commit/292246e))
+* **tooling:** Remove storybook, add avatar, adjust add file styles ([87b2c01](https://github.com/webex/react-widgets/commit/87b2c01))
+* **tooling:** Set version number in webpack build path ([069d9d7](https://github.com/webex/react-widgets/commit/069d9d7))
+* **widget:** Add event support for new init methods ([f5cf10b](https://github.com/webex/react-widgets/commit/f5cf10b))
+* **widget-base:** Add log level proptypes ([78257c2](https://github.com/webex/react-widgets/commit/78257c2))
+* **widget-base:** Add promise and callback to widget.remove() ([200790b](https://github.com/webex/react-widgets/commit/200790b))
+* **widget-base:** Add top level allowed props filtering ([199ea9d](https://github.com/webex/react-widgets/commit/199ea9d))
+* **widget-base:** Add version to constructor and instance ([43a0448](https://github.com/webex/react-widgets/commit/43a0448))
+* **widget-base:** Allow data api to use browser globals if they are available ([b6f0494](https://github.com/webex/react-widgets/commit/b6f0494))
+* **widget-base:** Allow for connection in multiple tabs ([dc80faa](https://github.com/webex/react-widgets/commit/dc80faa))
+* **widget-base:** Create single constructSparkWidget method ([4c82639](https://github.com/webex/react-widgets/commit/4c82639))
+* **widget-base:** update redux devtools implementation ([22f546c](https://github.com/webex/react-widgets/commit/22f546c))
+* **widget-example:** Example app that uses new base ([72e2234](https://github.com/webex/react-widgets/commit/72e2234))
+* **widget-meet:** accessibility label prop added to call controls ([763b7f9](https://github.com/webex/react-widgets/commit/763b7f9))
+* **widget-meet:** accessibility label prop added to call controls ([1c04eef](https://github.com/webex/react-widgets/commit/1c04eef))
+* **widget-meet:** Add browser support UI message ([9165fae](https://github.com/webex/react-widgets/commit/9165fae))
+* **widget-meet:** Add call controls, 3 views for call state ([6874537](https://github.com/webex/react-widgets/commit/6874537))
+* **widget-meet:** Add connect and disconnect button ([9f890d7](https://github.com/webex/react-widgets/commit/9f890d7))
+* **widget-meet:** add error when failing to connect call ([c1940db](https://github.com/webex/react-widgets/commit/c1940db))
+* **widget-meet:** Add events for call membership changes ([c22bf79](https://github.com/webex/react-widgets/commit/c22bf79))
+* **widget-meet:** Add full calling flow scaffolding ([379f77a](https://github.com/webex/react-widgets/commit/379f77a))
+* **widget-meet:** Add fuzzy background ([202477d](https://github.com/webex/react-widgets/commit/202477d))
+* **widget-meet:** Add incoming and outgoing ringtone ([04f5c82](https://github.com/webex/react-widgets/commit/04f5c82))
+* **widget-meet:** Add initial outbound calling ([7400443](https://github.com/webex/react-widgets/commit/7400443))
+* **widget-meet:** Add local video draggability ([3c19e2f](https://github.com/webex/react-widgets/commit/3c19e2f))
+* **widget-meet:** Add notification events ([3c99eb8](https://github.com/webex/react-widgets/commit/3c99eb8))
+* **widget-meet:** Add remote video display ([e957173](https://github.com/webex/react-widgets/commit/e957173))
+* **widget-meet:** Add snapping to place to local video drag ([723ff14](https://github.com/webex/react-widgets/commit/723ff14))
+* **widget-meet:** Cleanup button styles, add remote audio/video mute ([5da943e](https://github.com/webex/react-widgets/commit/5da943e))
+* **widget-meet:** convert container to use selector props ([474bf77](https://github.com/webex/react-widgets/commit/474bf77))
+* **widget-meet:** display error for security requirement ([f2b49fc](https://github.com/webex/react-widgets/commit/f2b49fc))
+* **widget-meet:** display incoming call screen ([518637d](https://github.com/webex/react-widgets/commit/518637d))
+* **widget-meet:** display waiting for participants message ([b49127e](https://github.com/webex/react-widgets/commit/b49127e))
+* **widget-meet:** emit event after call user ([d810c09](https://github.com/webex/react-widgets/commit/d810c09))
+* **widget-meet:** emit event on call connected ([7822272](https://github.com/webex/react-widgets/commit/7822272))
+* **widget-meet:** Fix call state views ([dd8a9ae](https://github.com/webex/react-widgets/commit/dd8a9ae))
+* **widget-meet:** handle call state errors ([e3ec5ea](https://github.com/webex/react-widgets/commit/e3ec5ea))
+* **widget-meet:** optimize render function with selector ([552fb5a](https://github.com/webex/react-widgets/commit/552fb5a))
+* **widget-meet:** Render video srcObject instead of url ([a537aa9](https://github.com/webex/react-widgets/commit/a537aa9))
+* **widget-meet:** send locus url to accept incoming call method ([d956f3e](https://github.com/webex/react-widgets/commit/d956f3e))
+* **widget-meet:** update call error messages ([ed8533d](https://github.com/webex/react-widgets/commit/ed8533d))
+* **widget-meet:** Update call event structure ([2a301f3](https://github.com/webex/react-widgets/commit/2a301f3))
+* **widget-meet:** Update styles, move controls into containers ([e57c0b7](https://github.com/webex/react-widgets/commit/e57c0b7))
+* **widget-meet:** use #placeCall ([c4c64a7](https://github.com/webex/react-widgets/commit/c4c64a7))
+* **widget-message:** add actorName to message event data ([dde2a47](https://github.com/webex/react-widgets/commit/dde2a47))
+* **widget-message:** add display of conversation error ([af45cfe](https://github.com/webex/react-widgets/commit/af45cfe))
+* **widget-message:** Add feature flag for mentions ([0ca45ba](https://github.com/webex/react-widgets/commit/0ca45ba))
+* **widget-message:** add isAcknowledgementsDisabled prop ([76ec124](https://github.com/webex/react-widgets/commit/76ec124))
+* **widget-message:** add more detailed activity verb processing ([b751e42](https://github.com/webex/react-widgets/commit/b751e42))
+* **widget-message:** Add notification events ([d402aa2](https://github.com/webex/react-widgets/commit/d402aa2))
+* **widget-message:** Add roomId to activity event payload ([385bf17](https://github.com/webex/react-widgets/commit/385bf17))
+* **widget-message:** enable presence subscription ([79a095f](https://github.com/webex/react-widgets/commit/79a095f))
+* **widget-message:** implement activity retry feature ([07760df](https://github.com/webex/react-widgets/commit/07760df))
+* **widget-message:** implement buffer state watcher ([57f4585](https://github.com/webex/react-widgets/commit/57f4585))
+* **widget-message:** implement hoc-conversation-mercury ([2818a8a](https://github.com/webex/react-widgets/commit/2818a8a))
+* **widget-message:** Load conversation before websocket established ([57f9e9d](https://github.com/webex/react-widgets/commit/57f9e9d))
+* **widget-message:** mark conversation as read with mouse move ([b32c120](https://github.com/webex/react-widgets/commit/b32c120))
+* **widget-message:** Update events model ([a9e85c9](https://github.com/webex/react-widgets/commit/a9e85c9))
+* **widget-message:** use feature flag constants ([01eb2b5](https://github.com/webex/react-widgets/commit/01eb2b5))
+* **widget-message:** use fetchAvatars method ([14109c2](https://github.com/webex/react-widgets/commit/14109c2))
+* **widget-message-meet:** ability to start call via data props ([e21b143](https://github.com/webex/react-widgets/commit/e21b143))
+* **widget-message-meet:** Add ability to pass event names ([1ba8342](https://github.com/webex/react-widgets/commit/1ba8342))
+* **widget-message-meet:** add accessibility label to main menu ([7d1fc2f](https://github.com/webex/react-widgets/commit/7d1fc2f))
+* **widget-message-meet:** add accessibility label to main menu ([3d82113](https://github.com/webex/react-widgets/commit/3d82113))
+* **widget-message-meet:** add action for widget menu ([7b7efd7](https://github.com/webex/react-widgets/commit/7b7efd7))
+* **widget-message-meet:** Add browser global, additional props ([6e8b718](https://github.com/webex/react-widgets/commit/6e8b718))
+* **widget-message-meet:** Add call duration to title bar ([9889b45](https://github.com/webex/react-widgets/commit/9889b45))
+* **widget-message-meet:** Add callback and event support ([c980ea3](https://github.com/webex/react-widgets/commit/c980ea3))
+* **widget-message-meet:** Add intl support ([759ff03](https://github.com/webex/react-widgets/commit/759ff03))
+* **widget-message-meet:** Allow multiple widgets and removal ([ba2878c](https://github.com/webex/react-widgets/commit/ba2878c))
+* **widget-message-meet:** do not remove meet widget from dom ([fe2b3e5](https://github.com/webex/react-widgets/commit/fe2b3e5))
+* **widget-message-meet:** Go to message view after call ends ([ea36cf4](https://github.com/webex/react-widgets/commit/ea36cf4))
+* **widget-message-meet:** hangup active call on unload ([914c80f](https://github.com/webex/react-widgets/commit/914c80f))
+* **widget-message-meet:** implement activity menu ([1842c5d](https://github.com/webex/react-widgets/commit/1842c5d))
+* **widget-message-meet:** implement initial activity feature ([31486c6](https://github.com/webex/react-widgets/commit/31486c6))
+* **widget-message-meet:** in flight message preview ([d08dd8f](https://github.com/webex/react-widgets/commit/d08dd8f))
+* **widget-message-meet:** move activity menu from title bar to top ([62b428c](https://github.com/webex/react-widgets/commit/62b428c))
+* **widget-message-meet:** Move all widgets to new widget-base ([37e3592](https://github.com/webex/react-widgets/commit/37e3592))
+* **widget-message-meet:** properly define imports and exports of widgets ([10ee466](https://github.com/webex/react-widgets/commit/10ee466))
+* **widget-message-meet:** properly define imports and exports of widgets ([964a7af](https://github.com/webex/react-widgets/commit/964a7af))
+* **widget-message-meet:** toggle between message and meet ([cc8342b](https://github.com/webex/react-widgets/commit/cc8342b))
+* **widget-message-meet-demo:** initial implementation ([e38c130](https://github.com/webex/react-widgets/commit/e38c130))
+* **widget-recent:** Add incoming call event ([7f5ba02](https://github.com/webex/react-widgets/commit/7f5ba02))
+* **widget-recents:** Add ability to load spaces in increments ([af349e0](https://github.com/webex/react-widgets/commit/af349e0))
+* **widget-recents:** add accessibility label to call button ([f93d9b6](https://github.com/webex/react-widgets/commit/f93d9b6))
+* **widget-recents:** Add activity sender name to preview ([682e6f9](https://github.com/webex/react-widgets/commit/682e6f9))
+* **widget-recents:** Add all styles and UI fixes ([f9c439e](https://github.com/webex/react-widgets/commit/f9c439e))
+* **widget-recents:** Add direct call button ([b505846](https://github.com/webex/react-widgets/commit/b505846))
+* **widget-recents:** add features module ([703e193](https://github.com/webex/react-widgets/commit/703e193))
+* **widget-recents:** add fetch space when delete event arrives ([a63db43](https://github.com/webex/react-widgets/commit/a63db43))
+* **widget-recents:** Add filter for hidden spaces and move listeners ([84a3796](https://github.com/webex/react-widgets/commit/84a3796))
+* **widget-recents:** add group calling feature check ([9f6224d](https://github.com/webex/react-widgets/commit/9f6224d))
+* **widget-recents:** Add incoming call view into widgets ([6a81412](https://github.com/webex/react-widgets/commit/6a81412))
+* **widget-recents:** Add list constructors ([6d09d5d](https://github.com/webex/react-widgets/commit/6d09d5d))
+* **widget-recents:** Add listeners and events for moderation and shares ([5bd448a](https://github.com/webex/react-widgets/commit/5bd448a))
+* **widget-recents:** Add listeners for new messages and acknowledges ([b608dc7](https://github.com/webex/react-widgets/commit/b608dc7))
+* **widget-recents:** Add membership events ([b12ffbf](https://github.com/webex/react-widgets/commit/b12ffbf))
+* **widget-recents:** Add progressive avatar loading ([f1c2e1f](https://github.com/webex/react-widgets/commit/f1c2e1f))
+* **widget-recents:** Add rooms:unread and messages:created events ([8f4763b](https://github.com/webex/react-widgets/commit/8f4763b))
+* **widget-recents:** Add smaller initial spaces fetch ([0895a1a](https://github.com/webex/react-widgets/commit/0895a1a))
+* **widget-recents:** Add spaces fetching ([80b149d](https://github.com/webex/react-widgets/commit/80b149d))
+* **widget-recents:** add toPersonEmail to event data ([6ea08ed](https://github.com/webex/react-widgets/commit/6ea08ed))
+* **widget-recents:** Add unread indicator ([c0c7880](https://github.com/webex/react-widgets/commit/c0c7880))
+* **widget-recents:** Add view for pending space and decrypt support ([775d8bf](https://github.com/webex/react-widgets/commit/775d8bf))
+* **widget-recents:** Added initial avatars to direct spaces ([02298da](https://github.com/webex/react-widgets/commit/02298da))
+* **widget-recents:** Added non-text messages to list ([ce853cf](https://github.com/webex/react-widgets/commit/ce853cf))
+* **widget-recents:** display call button for group spaces ([29503b6](https://github.com/webex/react-widgets/commit/29503b6))
+* **widget-recents:** Hide incoming call ui when webrtc is not available ([3a70073](https://github.com/webex/react-widgets/commit/3a70073))
+* **widget-recents:** Initial reducers and containers ([07c3959](https://github.com/webex/react-widgets/commit/07c3959))
+* **widget-recents:** Progressive fetch rooms if unfetched ([0cffe9e](https://github.com/webex/react-widgets/commit/0cffe9e))
+* **widget-recents:** update incoming call listener for group calls ([78c557d](https://github.com/webex/react-widgets/commit/78c557d))
+* **widget-recents:** Update to use teams redux module ([0352175](https://github.com/webex/react-widgets/commit/0352175))
+* **widget-recents:** use avatar module for direct space avatars ([dc0c13d](https://github.com/webex/react-widgets/commit/dc0c13d))
+* **widget-recents:** use avatars module for space avatars ([2c84534](https://github.com/webex/react-widgets/commit/2c84534))
+* **widget-recents:** use bright spinner ([c21b20e](https://github.com/webex/react-widgets/commit/c21b20e))
+* **widget-recents:** use CallDataActivityMessage in space-item ([ac53694](https://github.com/webex/react-widgets/commit/ac53694))
+* **widget-recents:** use space read method ([d249015](https://github.com/webex/react-widgets/commit/d249015))
+* **widget-recents:** utilize errors module for display of errors ([c8384af](https://github.com/webex/react-widgets/commit/c8384af))
+* **widget-recents-demo:** add aria labels ([729d54d](https://github.com/webex/react-widgets/commit/729d54d))
+* **widget-recents-demo:** add support for events array ([a1e976b](https://github.com/webex/react-widgets/commit/a1e976b))
+* **widget-recents-demo:** change to basic input ([cf5aaaf](https://github.com/webex/react-widgets/commit/cf5aaaf))
+* **widget-recents-demo:** initial implementation ([afafb0e](https://github.com/webex/react-widgets/commit/afafb0e))
+* **widget-recents-demo:** use browser global method for widget creation ([b7f8eff](https://github.com/webex/react-widgets/commit/b7f8eff))
+* **widget-roster:** Add active call state tracking ([737b613](https://github.com/webex/react-widgets/commit/737b613))
+* **widget-roster:** add avatar component to list item ([9077a2d](https://github.com/webex/react-widgets/commit/9077a2d))
+* **widget-roster:** add avatar support ([0476511](https://github.com/webex/react-widgets/commit/0476511))
+* **widget-roster:** add edit button to roster items ([3bd5cd3](https://github.com/webex/react-widgets/commit/3bd5cd3))
+* **widget-roster:** add editingParticipant store data ([833fa2e](https://github.com/webex/react-widgets/commit/833fa2e))
+* **widget-roster:** add header bar ([7173b81](https://github.com/webex/react-widgets/commit/7173b81))
+* **widget-roster:** add invite email user ([4d11892](https://github.com/webex/react-widgets/commit/4d11892))
+* **widget-roster:** add keyboard interaction to add-participant ([81e9a05](https://github.com/webex/react-widgets/commit/81e9a05))
+* **widget-roster:** add moderators section to list ([5ee9c2c](https://github.com/webex/react-widgets/commit/5ee9c2c))
+* **widget-roster:** add participant details modal ([6cd7132](https://github.com/webex/react-widgets/commit/6cd7132))
+* **widget-roster:** add participant settings to redux state ([062f945](https://github.com/webex/react-widgets/commit/062f945))
+* **widget-roster:** add PersonListItem display to add participant ([fd7a040](https://github.com/webex/react-widgets/commit/fd7a040))
+* **widget-roster:** add roster header component ([3567cdf](https://github.com/webex/react-widgets/commit/3567cdf))
+* **widget-roster:** add scroll support for roster list ([af6b927](https://github.com/webex/react-widgets/commit/af6b927))
+* **widget-roster:** add search input ([f9c3d30](https://github.com/webex/react-widgets/commit/f9c3d30))
+* **widget-roster:** add search module capabilities ([1f577c6](https://github.com/webex/react-widgets/commit/1f577c6))
+* **widget-roster:** add user avatars to search results ([6697e9d](https://github.com/webex/react-widgets/commit/6697e9d))
+* **widget-roster:** create initial implementation ([58896af](https://github.com/webex/react-widgets/commit/58896af))
+* **widget-roster:** display add people button ([c4bf8b7](https://github.com/webex/react-widgets/commit/c4bf8b7))
+* **widget-roster:** display external status of users ([fc6cefc](https://github.com/webex/react-widgets/commit/fc6cefc))
+* **widget-roster:** display in flight participants ([166a516](https://github.com/webex/react-widgets/commit/166a516))
+* **widget-roster:** implement addParticipantToConversation ([f74aed0](https://github.com/webex/react-widgets/commit/f74aed0))
+* **widget-roster:** limit consumer org members to email only search ([71edce1](https://github.com/webex/react-widgets/commit/71edce1))
+* **widget-roster:** move external message to component ([63ce2f4](https://github.com/webex/react-widgets/commit/63ce2f4))
+* **widget-roster:** remove avatar from selector ([4f15360](https://github.com/webex/react-widgets/commit/4f15360))
+* **widget-roster:** separate list between current user and others ([4f36a70](https://github.com/webex/react-widgets/commit/4f36a70))
+* **widget-roster:** update accessibility label ([ca6176d](https://github.com/webex/react-widgets/commit/ca6176d))
+* **widget-roster:** use components to display roster list ([219aa7b](https://github.com/webex/react-widgets/commit/219aa7b))
+* **widget-roster:** use react-intl messages for text display ([808eebf](https://github.com/webex/react-widgets/commit/808eebf))
+* **widget-space:** add ability to pass props to activities ([915995a](https://github.com/webex/react-widgets/commit/915995a))
+* **widget-space:** add ability to update widget status ([17290e5](https://github.com/webex/react-widgets/commit/17290e5))
+* **widget-space:** Add Activity Imports for widgets ([bf16319](https://github.com/webex/react-widgets/commit/bf16319))
+* **widget-space:** Add activity menu ([6d07c84](https://github.com/webex/react-widgets/commit/6d07c84))
+* **widget-space:** Add actorName to calling and rooms events ([d402f82](https://github.com/webex/react-widgets/commit/d402f82))
+* **widget-space:** Add call start time ([6adc061](https://github.com/webex/react-widgets/commit/6adc061))
+* **widget-space:** add feature ability to activity menu ([96a203f](https://github.com/webex/react-widgets/commit/96a203f))
+* **widget-space:** add features module ([771c1d4](https://github.com/webex/react-widgets/commit/771c1d4))
+* **widget-space:** add group calling activity menu icon ([43d3e92](https://github.com/webex/react-widgets/commit/43d3e92))
+* **widget-space:** add id validation to getSpaceDetails ([981d13b](https://github.com/webex/react-widgets/commit/981d13b))
+* **widget-space:** add secondary activity to store ([8e3ded2](https://github.com/webex/react-widgets/commit/8e3ded2))
+* **widget-space:** add support for conversation errors ([4a4ff0f](https://github.com/webex/react-widgets/commit/4a4ff0f))
+* **widget-space:** add support for feature hide activities ([3f66f78](https://github.com/webex/react-widgets/commit/3f66f78))
+* **widget-space:** Add title bar data. Fix eslint errors ([5ab077a](https://github.com/webex/react-widgets/commit/5ab077a))
+* **widget-space:** change activity menu to return activity object ([fb4d56a](https://github.com/webex/react-widgets/commit/fb4d56a))
+* **widget-space:** change roster feature flag type to developer ([90443e7](https://github.com/webex/react-widgets/commit/90443e7))
+* **widget-space:** check error message if error name not matched ([a6dd9ff](https://github.com/webex/react-widgets/commit/a6dd9ff))
+* **widget-space:** Create initial container and component ([d84655f](https://github.com/webex/react-widgets/commit/d84655f))
+* **widget-space:** display error if to user is self ([7befc72](https://github.com/webex/react-widgets/commit/7befc72))
+* **widget-space:** display error on mercury disconnect ([999b2e0](https://github.com/webex/react-widgets/commit/999b2e0))
+* **widget-space:** display error on mercury disconnect ([8ba8eb8](https://github.com/webex/react-widgets/commit/8ba8eb8))
+* **widget-space:** display secondary widget when chosen ([b22bfbb](https://github.com/webex/react-widgets/commit/b22bfbb))
+* **widget-space:** display space errors on load ([27ebf63](https://github.com/webex/react-widgets/commit/27ebf63))
+* **widget-space:** Initial frame for widget ([bcce56d](https://github.com/webex/react-widgets/commit/bcce56d))
+* **widget-space:** Initial working widgets with message and calling ([d9acb33](https://github.com/webex/react-widgets/commit/d9acb33))
+* **widget-space:** move menu button to passed child of title bar ([0873b22](https://github.com/webex/react-widgets/commit/0873b22))
+* **widget-space:** remove avatar lookup ([ad18f34](https://github.com/webex/react-widgets/commit/ad18f34))
+* **widget-space:** remove call state watcher to switch modes ([d3f138a](https://github.com/webex/react-widgets/commit/d3f138a))
+* **widget-space:** Retrieve space details from public api ([4e9ca8e](https://github.com/webex/react-widgets/commit/4e9ca8e))
+* **widget-space:** store space details failures ([a52b5f1](https://github.com/webex/react-widgets/commit/a52b5f1))
+* **widget-space:** support for error actions ([bcacf75](https://github.com/webex/react-widgets/commit/bcacf75))
+* **widget-space:** update space not found message ([d8f2a72](https://github.com/webex/react-widgets/commit/d8f2a72))
+* **widget-space:** use errors module to display errors ([0d7806f](https://github.com/webex/react-widgets/commit/0d7806f))
+* **widget-space:** use errors module to display errors ([93d8d26](https://github.com/webex/react-widgets/commit/93d8d26))
+* **widget-space:** use feature flag constants ([dfc921a](https://github.com/webex/react-widgets/commit/dfc921a))
+* **widget-space:** use instanceof for error interpreting ([3709d41](https://github.com/webex/react-widgets/commit/3709d41))
+* **widget-space:** widget error object added to selector ([02b29ff](https://github.com/webex/react-widgets/commit/02b29ff))
+* **widget-space-demo:** add aria labels to inputs ([6301afd](https://github.com/webex/react-widgets/commit/6301afd))
+* **widget-space-demo:** add remove widget button ([df79074](https://github.com/webex/react-widgets/commit/df79074))
+* **widget-space-demo:** add support for events array ([da5ef34](https://github.com/webex/react-widgets/commit/da5ef34))
+* **widget-space-demo:** add toggle to show token in example code ([c88424e](https://github.com/webex/react-widgets/commit/c88424e))
+* **widget-space-demo:** add widget-space to bundle for dev builds ([be95d36](https://github.com/webex/react-widgets/commit/be95d36))
+* **widget-space-demo:** change to basic input ([7e61311](https://github.com/webex/react-widgets/commit/7e61311))
+* **widget-space-demo:** convert widget creation to global method ([4d5f9d7](https://github.com/webex/react-widgets/commit/4d5f9d7))
+* **widget-space-demo:** display global code demo option ([d5ccf11](https://github.com/webex/react-widgets/commit/d5ccf11))
+* **widget-space-demo:** initial implementation ([a946852](https://github.com/webex/react-widgets/commit/a946852))
+* **widget-space-demo:** revamped look with material cards ([5ae183c](https://github.com/webex/react-widgets/commit/5ae183c))
+* **widget-space-demo:** use injected bundle paths ([13e1517](https://github.com/webex/react-widgets/commit/13e1517))
+* **wiget-meet:** remove call.joined references ([c6d9f20](https://github.com/webex/react-widgets/commit/c6d9f20))
 
 
 ### Reverts
 
-* **widget-space:** revert index.html change ([edc403e](https://github.com/webex/react-ciscospark/commit/edc403e))
+* **widget-space:** revert index.html change ([edc403e](https://github.com/webex/react-widgets/commit/edc403e))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ ansiColor('xterm') {
 
             sshagent(['d8533977-c4c5-4e2b-938d-ae7fcbe27aac']) {
               // return the exit code because we don't care about failures
-              sh script: 'git remote add upstream git@github.com:webex/react-ciscospark.git', returnStatus: true
+              sh script: 'git remote add upstream git@github.com:webex/react-widgets.git', returnStatus: true
               // Make sure local tags don't include failed releases
               sh 'git tag -l | xargs git tag -d'
               sh 'git gc'

--- a/Jenkinsfile.jssdk
+++ b/Jenkinsfile.jssdk
@@ -11,7 +11,7 @@ ansiColor('xterm') {
 
           sshagent(['6c8a75fb-5e5f-4803-9b6d-1933a3111a34']) {
             // return the exit code because we don't care about failures
-            sh script: 'git remote add upstream git@github.com:webex/react-ciscospark.git', returnStatus: true
+            sh script: 'git remote add upstream git@github.com:webex/react-widgets.git', returnStatus: true
 
             sh 'git fetch upstream'
           }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# react-ciscospark
+# react-widgets
 
-[![CircleCI](https://img.shields.io/circleci/project/github/webex/react-ciscospark/master.svg)](https://circleci.com/gh/webex/react-ciscospark)
-[![license](https://img.shields.io/github/license/webex/react-ciscospark.svg)](https://github.com/webex/react-ciscospark/blob/master/LICENSE)
+[![CircleCI](https://img.shields.io/circleci/project/github/webex/react-widgets/master.svg)](https://circleci.com/gh/webex/react-widgets)
+[![license](https://img.shields.io/github/license/webex/react-widgets.svg)](https://github.com/webex/react-widgets/blob/master/LICENSE)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
-> Cisco Spark for React
+> Webex Widgets for React
 
-The Cisco Spark for React library allows developers to easily incorporate Spark functionality into an application.
+The Webex Widgets for React library allows developers to easily incorporate Spark functionality into an application.
 
 ## Table of Contents
 
@@ -24,13 +24,13 @@ The Cisco Spark for React library allows developers to easily incorporate Spark 
 
 ## Background
 
-This library allows React developers to quickly and easily create a Cisco Spark experience within their apps. Here we provide basic components (e.g. buttons, text fields, icons) that reflect the styles and aesthetics of Spark, along with more complex, complete widgets, such as the Spark Space Widget.
+This library allows React developers to quickly and easily create a Webex experience within their apps. Here we provide basic components (e.g. buttons, text fields, icons) that reflect the styles and aesthetics of Spark, along with more complex, complete widgets, such as the Spark Space Widget.
 
 The basic components are just presentational React <https://github.com/facebook/react> components, while our widgets leverage Redux <https://github.com/reactjs/redux> and the Spark Javascript SDK <https://github.com/webex/spark-js-sdk>.
 
 ## Widgets
 
-While many of our components are purely presentational, some have extended functionality that provide a piece of the full Cisco Spark experience. These fully self contained elements are called `Widgets` and are available here:
+While many of our components are purely presentational, some have extended functionality that provide a piece of the full Webex experience. These fully self contained elements are called `Widgets` and are available here:
 
 - [Space Widget](./packages/node_modules/@ciscospark/widget-space)
 - [Recents Widget](./packages/node_modules/@ciscospark/widget-recents)
@@ -48,7 +48,7 @@ $ npm start
 
 ### Build From Source
 
-1. Clone this repo using a git client (e.g. `git clone https://github.com/webex/react-ciscospark.git`)
+1. Clone this repo using a git client (e.g. `git clone https://github.com/webex/react-widgets.git`)
 1. Run `npm install` from the root of the repo. You will want to run this every time you pull down any new updates.
 1. From the root of the repo, run the following to build the widget:
     ```sh
@@ -70,7 +70,7 @@ Once a widget is bundled, the version number is available in the following ways:
 
 ## Coding Style
 
-We follow our [Cisco Spark Web Styleguide](https://github.com/webex/web-styleguide) when developing any web based libraries and tools. Please check it out and do your best to follow our norms when contributing to this codebase.
+We follow our [Webex Web Styleguide](https://github.com/webex/web-styleguide) when developing any web based libraries and tools. Please check it out and do your best to follow our norms when contributing to this codebase.
 
 ## Code Verification
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ciscospark/react-ciscospark",
+  "name": "@ciscospark/react-widgets",
   "version": "0.2.29",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ciscospark/react-ciscospark",
+  "name": "@ciscospark/react-widgets",
   "version": "0.2.29",
   "description": "The Cisco Spark for React library allows developers to easily incorporate Webex Teams functionality into an application.",
   "scripts": {
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/webex/react-ciscospark.git"
+    "url": "git+https://github.com/webex/react-widgets.git"
   },
   "contributors": [
     "Arash Koushkebaghi <akoushke@cisco.com>",
@@ -58,9 +58,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/webex/react-ciscospark/issues"
+    "url": "https://github.com/webex/react-widgets/issues"
   },
-  "homepage": "https://github.com/webex/react-ciscospark#readme",
+  "homepage": "https://github.com/webex/react-widgets#readme",
   "dependencies": {
     "@momentum-ui/core": "15.2.1",
     "@momentum-ui/icons": "6.2.1",

--- a/packages/node_modules/@ciscospark/react-component-activity-item-base/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-item-base/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-item/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-item/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-list/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-list/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-menu-header/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-menu-header/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-menu/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-menu/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-post-action/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-post-action/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-post/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-post/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-share-file/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-file/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-share-files/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-files/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-share-thumbnail/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-thumbnail/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-system-message/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-system-message/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-activity-text/package.json
+++ b/packages/node_modules/@ciscospark/react-component-activity-text/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-add-file-button/package.json
+++ b/packages/node_modules/@ciscospark/react-component-add-file-button/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-audio/package.json
+++ b/packages/node_modules/@ciscospark/react-component-audio/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-avatar/package.json
+++ b/packages/node_modules/@ciscospark/react-component-avatar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-badge/package.json
+++ b/packages/node_modules/@ciscospark/react-component-badge/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-button-controls/package.json
+++ b/packages/node_modules/@ciscospark/react-component-button-controls/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-button/package.json
+++ b/packages/node_modules/@ciscospark/react-component-button/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-call-data-activity/package.json
+++ b/packages/node_modules/@ciscospark/react-component-call-data-activity/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-chip-base/package.json
+++ b/packages/node_modules/@ciscospark/react-component-chip-base/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-chip-file/package.json
+++ b/packages/node_modules/@ciscospark/react-component-chip-file/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-confirmation-modal/package.json
+++ b/packages/node_modules/@ciscospark/react-component-confirmation-modal/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-cover/package.json
+++ b/packages/node_modules/@ciscospark/react-component-cover/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-day-separator/package.json
+++ b/packages/node_modules/@ciscospark/react-component-day-separator/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-error-display/package.json
+++ b/packages/node_modules/@ciscospark/react-component-error-display/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-file-share-display/package.json
+++ b/packages/node_modules/@ciscospark/react-component-file-share-display/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-file-staging-area/package.json
+++ b/packages/node_modules/@ciscospark/react-component-file-staging-area/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-icon/package.json
+++ b/packages/node_modules/@ciscospark/react-component-icon/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-incoming-call/package.json
+++ b/packages/node_modules/@ciscospark/react-component-incoming-call/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-join-call-button/package.json
+++ b/packages/node_modules/@ciscospark/react-component-join-call-button/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-list-separator/package.json
+++ b/packages/node_modules/@ciscospark/react-component-list-separator/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-loading-screen/package.json
+++ b/packages/node_modules/@ciscospark/react-component-loading-screen/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-new-messages-separator/package.json
+++ b/packages/node_modules/@ciscospark/react-component-new-messages-separator/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-people-list/package.json
+++ b/packages/node_modules/@ciscospark/react-component-people-list/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-presence-avatar/package.json
+++ b/packages/node_modules/@ciscospark/react-component-presence-avatar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-ringtone/package.json
+++ b/packages/node_modules/@ciscospark/react-component-ringtone/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-scroll-to-bottom-button/package.json
+++ b/packages/node_modules/@ciscospark/react-component-scroll-to-bottom-button/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-space-item/package.json
+++ b/packages/node_modules/@ciscospark/react-component-space-item/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-spaces-list/package.json
+++ b/packages/node_modules/@ciscospark/react-component-spaces-list/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-spark-fonts/package.json
+++ b/packages/node_modules/@ciscospark/react-component-spark-fonts/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-spark-logo/package.json
+++ b/packages/node_modules/@ciscospark/react-component-spark-logo/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-spark-oauth/package.json
+++ b/packages/node_modules/@ciscospark/react-component-spark-oauth/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-spinner/package.json
+++ b/packages/node_modules/@ciscospark/react-component-spinner/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-textarea/package.json
+++ b/packages/node_modules/@ciscospark/react-component-textarea/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-timer/package.json
+++ b/packages/node_modules/@ciscospark/react-component-timer/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-title-bar/package.json
+++ b/packages/node_modules/@ciscospark/react-component-title-bar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-typing-avatar/package.json
+++ b/packages/node_modules/@ciscospark/react-component-typing-avatar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-typing-indicator/package.json
+++ b/packages/node_modules/@ciscospark/react-component-typing-indicator/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-utils/package.json
+++ b/packages/node_modules/@ciscospark/react-component-utils/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-component-video/package.json
+++ b/packages/node_modules/@ciscospark/react-component-video/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-activity-list/package.json
+++ b/packages/node_modules/@ciscospark/react-container-activity-list/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-file-downloader/package.json
+++ b/packages/node_modules/@ciscospark/react-container-file-downloader/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-message-composer/package.json
+++ b/packages/node_modules/@ciscospark/react-container-message-composer/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-notifications/package.json
+++ b/packages/node_modules/@ciscospark/react-container-notifications/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-presence-avatar/package.json
+++ b/packages/node_modules/@ciscospark/react-container-presence-avatar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-read-receipts/package.json
+++ b/packages/node_modules/@ciscospark/react-container-read-receipts/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-container-scrolling-activity/package.json
+++ b/packages/node_modules/@ciscospark/react-container-scrolling-activity/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-hoc-conversation-mercury/package.json
+++ b/packages/node_modules/@ciscospark/react-hoc-conversation-mercury/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-hoc-scrollable/package.json
+++ b/packages/node_modules/@ciscospark/react-hoc-scrollable/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-redux-spark-fixtures/package.json
+++ b/packages/node_modules/@ciscospark/react-redux-spark-fixtures/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-redux-spark-metrics/package.json
+++ b/packages/node_modules/@ciscospark/react-redux-spark-metrics/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-redux-spark/package.json
+++ b/packages/node_modules/@ciscospark/react-redux-spark/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/react-test-utils/package.json
+++ b/packages/node_modules/@ciscospark/react-test-utils/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-activities/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-activities/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-activity/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-activity/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-avatar/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-conversation/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-errors/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-errors/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-features/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-features/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-flags/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-flags/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-indicators/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-indicators/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-media/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-media/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-mercury/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-mercury/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-presence/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-presence/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-search/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-search/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-share/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-share/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-spaces/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-teams/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-teams/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/redux-module-users/package.json
+++ b/packages/node_modules/@ciscospark/redux-module-users/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/spark-widget-base/README.md
+++ b/packages/node_modules/@ciscospark/spark-widget-base/README.md
@@ -77,8 +77,8 @@ When your widget instantiates, it will get receive props from our main store. So
 This package also provides some additional enhancers to make your widget setup a bit easier:
 
 - `withInitialState` (_default_): Establishes widget initial states with Redux and injects the React-Redux store `Provider` component
-- `withBrowserGlobals` (_default_): Enables widgets to be instantiated globally using `window.ciscospark.widget(el).widgetName` ([usage example](https://github.com/webex/react-ciscospark/tree/master/packages/node_modules/@ciscospark/widget-space#browser-globals))
-- `withDataAPI` (_default_): Enables widgets to be instantiated using a data API ([usage example](https://github.com/webex/react-ciscospark/tree/master/packages/node_modules/@ciscospark/widget-space#data-api))
+- `withBrowserGlobals` (_default_): Enables widgets to be instantiated globally using `window.ciscospark.widget(el).widgetName` ([usage example](https://github.com/webex/react-widgets/tree/master/packages/node_modules/@ciscospark/widget-space#browser-globals))
+- `withDataAPI` (_default_): Enables widgets to be instantiated using a data API ([usage example](https://github.com/webex/react-widgets/tree/master/packages/node_modules/@ciscospark/widget-space#data-api))
 - `withIntl`: A helper for enabling [react-intl](https://github.com/yahoo/react-intl) in your widget. You can pass a config object that will make intl available to you: `{locale: 'en', messages}`
 
 To use any of these enhancers you can apply them directly to a Component: `withIntl(MyComponent)`.

--- a/packages/node_modules/@ciscospark/spark-widget-base/package.json
+++ b/packages/node_modules/@ciscospark/spark-widget-base/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-demo/package.json
+++ b/packages/node_modules/@ciscospark/widget-demo/package.json
@@ -11,7 +11,7 @@
   ],
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-files/package.json
+++ b/packages/node_modules/@ciscospark/widget-files/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-meet/package.json
+++ b/packages/node_modules/@ciscospark/widget-meet/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-message/package.json
+++ b/packages/node_modules/@ciscospark/widget-message/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-recents-demo/package.json
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/package.json
@@ -11,7 +11,7 @@
   ],
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-recents/README.md
+++ b/packages/node_modules/@ciscospark/widget-recents/README.md
@@ -68,7 +68,7 @@ For the latest builds that are pulled from the head of the master branch:
 
 ### Build from Source
 
-1. Follow these instructions to checkout and build the `react-ciscospark` repo <https://github.com/webex/react-ciscospark/blob/master/README.md>
+1. Follow these instructions to checkout and build the `react-widgets` repo <https://github.com/webex/react-widgets/blob/master/README.md>
 
 1. To build the Recents Widget, run the following from the root directory:
 

--- a/packages/node_modules/@ciscospark/widget-recents/package.json
+++ b/packages/node_modules/@ciscospark/widget-recents/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-roster/package.json
+++ b/packages/node_modules/@ciscospark/widget-roster/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-space-demo/package.json
+++ b/packages/node_modules/@ciscospark/widget-space-demo/package.json
@@ -11,7 +11,7 @@
   ],
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@ciscospark/widget-space/README.md
+++ b/packages/node_modules/@ciscospark/widget-space/README.md
@@ -73,7 +73,7 @@ For the latest builds that are pulled from the head of the master branch:
 
 ### Build from Source
 
-1. Follow these instructions to checkout and build the `react-ciscospark` repo <https://github.com/webex/react-ciscospark/blob/master/README.md>
+1. Follow these instructions to checkout and build the `react-widgets` repo <https://github.com/webex/react-widgets/blob/master/README.md>
 
 1. To build the Space Widget, run the following from the root directory:
 

--- a/packages/node_modules/@ciscospark/widget-space/create-space-widget-with-server.md
+++ b/packages/node_modules/@ciscospark/widget-space/create-space-widget-with-server.md
@@ -72,7 +72,7 @@ Type a message and send it to the space. You should see it reflected in both you
 
 ## References
 
-1. Bender, Brian, et al. Spark Space Widget (@Ciscospark/Widget-Space). GitHub, 11 Apr. 2017, github.com/ciscospark/react-ciscospark/blob/master/packages/node_modules/@ciscospark/widget-space/README.md.
+1. Bender, Brian, et al. Spark Space Widget (@Ciscospark/Widget-Space). GitHub, 11 Apr. 2017, github.com/ciscospark/react-widgets/blob/master/packages/node_modules/@ciscospark/widget-space/README.md.
 
 ## External links
 

--- a/packages/node_modules/@ciscospark/widget-space/package.json
+++ b/packages/node_modules/@ciscospark/widget-space/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/private-react-component-example-code/package.json
+++ b/packages/node_modules/@webex/private-react-component-example-code/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "private": true,
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/private-react-component-space-destination/package.json
+++ b/packages/node_modules/@webex/private-react-component-space-destination/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "private": true,
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/private-react-component-token-input/package.json
+++ b/packages/node_modules/@webex/private-react-component-token-input/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "private": true,
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/react-component-loading-screen/package.json
+++ b/packages/node_modules/@webex/react-component-loading-screen/package.json
@@ -10,7 +10,7 @@
     "Bernie Zang <nzang@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/react-component-space-item/package.json
+++ b/packages/node_modules/@webex/react-component-space-item/package.json
@@ -11,7 +11,7 @@
     "Moriah Maney <momaney@cisco.com"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/react-component-spaces-list/package.json
+++ b/packages/node_modules/@webex/react-component-spaces-list/package.json
@@ -11,7 +11,7 @@
     "Moriah Maney <momaney@cisco.com"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/packages/node_modules/@webex/react-component-title-bar/package.json
+++ b/packages/node_modules/@webex/react-component-title-bar/package.json
@@ -10,7 +10,7 @@
     "Moriah Maney <momaney@cisco.com>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/webex/react-ciscospark",
+  "repository": "https://github.com/webex/react-widgets",
   "files": [
     "src",
     "dist",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,7 +37,7 @@ if [ -z $DRY_RUN ]; then
  if [ -z $BETA ]; then
     # Tag and push
     git tag $VERSION
-    git push --tags git@github.com:webex/react-ciscospark.git $VERSION
+    git push --tags git@github.com:webex/react-widgets.git $VERSION
 
     # Cleanup
     git checkout $SOURCE_DIR

--- a/scripts/webpack/webpack.base.babel.js
+++ b/scripts/webpack/webpack.base.babel.js
@@ -26,7 +26,7 @@ export default (options, env) => {
     ]),
     new MiniCssExtractPlugin({filename: '[name].css'}),
     // Adds use strict to prevent catch global namespace issues outside of chunks.
-    new webpack.BannerPlugin(`react-ciscospark v${packageJson.version}`)
+    new webpack.BannerPlugin(`react-widgets v${packageJson.version}`)
   ];
 
   return {

--- a/test/journeys/specs/recents/global/basic.js
+++ b/test/journeys/specs/recents/global/basic.js
@@ -156,7 +156,7 @@ describe('Widget Recents', () => {
   });
 
   describe('events', () => {
-    // https://github.com/webex/react-ciscospark/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
+    // https://github.com/webex/react-widgets/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
     it('messages:created - group space', () => {
       clearEventLog(browserLocal);
       const lorraineText = 'Don\'t be such a square';

--- a/test/journeys/specs/smoke/widget-recents/index.js
+++ b/test/journeys/specs/smoke/widget-recents/index.js
@@ -119,7 +119,7 @@ describe('Smoke Tests - Recents Widget', () => {
     });
 
     describe('events', () => {
-      // https://github.com/webex/react-ciscospark/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
+      // https://github.com/webex/react-widgets/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
       it('messages:created - group space', () => {
         clearEventLog(browserLocal);
         const lorraineText = 'Don\'t be such a square';

--- a/test/journeys/specs/tap/widget-recents/index.js
+++ b/test/journeys/specs/tap/widget-recents/index.js
@@ -128,7 +128,7 @@ describe('Widget Recents', () => {
     });
 
     describe('events', () => {
-      // https://github.com/webex/react-ciscospark/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
+      // https://github.com/webex/react-widgets/blob/master/packages/node_modules/%40ciscospark/widget-recents/events.md
       it('messages:created', () => {
         clearEventLog(browserLocal);
         const lorraineText = 'Don\'t be such a square';


### PR DESCRIPTION
Goodbye `react-ciscospark`. Hello `react-widgets`.