### PR TITLE
Destination ID Hydra Requirements

### DIFF
--- a/packages/node_modules/@ciscospark/widget-space/README.md
+++ b/packages/node_modules/@ciscospark/widget-space/README.md
@@ -189,14 +189,6 @@ When loading the widgets there are some configuration options you can provide:
 | `secondaryActivitiesFullWidth` | N/A: global only feature | (default: `false`) When true, the widget's secondary activities will cover the entire main widget area. When false, only a portion of the widget will be covered.
 | `spaceActivities` | N/A: global only feature | (default: `spaceActivities: {files: true, meet: true, message: true, people: true}`). When present and a property is set to false, that activity will be disabled in the activities menu. Disabling the initial activity will result in an error.
 
-**These properties have been deprecated:**
-
-| Name | Data API | Description |
-|:--|:-------|---|
-| `spaceId` | `data-space-id` | ID of the space you want to open. |
-| `toPersonEmail` | `data-to-person-email` | Email of the message recipient |
-| `toPersonId` | `data-to-person-id` | User Id of the message recipient |
-
 ### External Control
 
 The space widget allows for developers to control actions and behaviors via properties. These properties, when set, will make the widget perform certain actions, like switching to different activities.

--- a/packages/node_modules/@ciscospark/widget-space/SETUP.md
+++ b/packages/node_modules/@ciscospark/widget-space/SETUP.md
@@ -21,7 +21,7 @@ Destination type determines what kind of space you are trying to open. It can be
 
 If destination type is "email", then simply pass a string containing the email of the user you would like to open the space with.
 
-If the destination type is either "userId" or "spaceId", you can pass the UUID or the Hydra ID (the ID provided by the developer portal).
+If the destination type is either "userId" or "spaceId", you can pass the encoded ID provided by the developer portal.
 
 If the destination type is "sip", you can pass a SIP URI.
 

--- a/packages/node_modules/@ciscospark/widget-space/SETUP.md
+++ b/packages/node_modules/@ciscospark/widget-space/SETUP.md
@@ -25,14 +25,6 @@ If the destination type is either "userId" or "spaceId", you can pass the UUID o
 
 If the destination type is "sip", you can pass a SIP URI.
 
-## Legacy Properties
-
-Previously, the space widget accepted different properties for different destination types, but in an attempt to consolidate, those properties are now deprecated and need to be migrated to the following:
-
-* "spaceId" should now be `destinationType: "spaceId"` and `destinationId: {spaceId}`
-* "toPersonId" should now be `destinationType: "userId"` and `destinationId: {toPersonId}`
-* "email" should now be `destinationType: "email"` and `destinationId: {email}`
-
 ## Processing
 
 When the widget initializes, it processes the destination to understand which "conversation" to load from the API.

--- a/packages/node_modules/@ciscospark/widget-space/SETUP.md
+++ b/packages/node_modules/@ciscospark/widget-space/SETUP.md
@@ -37,3 +37,17 @@ The "destinationId" is converted from a hydra ID to a UUID (if necessary), then 
 ### Email/User ID
 
 The "email" destination type allows a user to open a direct space to the account with the given email address. The space widget uses the conversation service to get space details for direct spaces. This is due to the fact that the `/rooms` endpoint doesn't currently have a way to look up space details without a room id.
+
+## Workflow
+
+The space widget follows a workflow of data fetching and processing in order to be fully setup.
+
+* The JS SDK is authenticated and registered as a device
+* Does something say the widget needs to reloaded?
+  * Reload the widget and start over
+* The JS SDK connects to web socket for real time data
+* Widget fetches space details about the destination
+  * Gets user details for 1:1 spaces
+  * Fetches space details via `/rooms` api endpoint
+
+Once all of these items are successful, the space widget is considered "ready" and the other widgets (message, meet, people, etc) will start their loading process.

--- a/packages/node_modules/@ciscospark/widget-space/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/container.js
@@ -50,13 +50,10 @@ export const ownPropTypes = {
     message: PropTypes.bool,
     people: PropTypes.bool
   }),
-  spaceId: PropTypes.string,
   startCall: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool
   ]),
-  toPersonEmail: PropTypes.string,
-  toPersonId: PropTypes.string,
   ...activityMenuPropTypes,
   ...injectedPropTypes
 };
@@ -77,10 +74,7 @@ const defaultProps = {
     message: true,
     people: true
   },
-  spaceId: '',
-  startCall: false,
-  toPersonEmail: '',
-  toPersonId: ''
+  startCall: false
 };
 
 export class SpaceWidget extends Component {

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
@@ -2,7 +2,7 @@ import {connect} from 'react-redux';
 import {compose, lifecycle} from 'recompose';
 import {bindActionCreators} from 'redux';
 import {addError, removeError} from '@ciscospark/redux-module-errors';
-import {validateAndDecodeId} from '@ciscospark/react-component-utils';
+import {validateAndDecodeId, isUuid} from '@ciscospark/react-component-utils';
 
 import messages from '../messages';
 
@@ -40,22 +40,19 @@ function checkForMercuryErrors(props) {
   }
 }
 
-function checkForErrors(props) {
+/**
+ * Checks for SDK device registration errors
+ * @param {Object} props
+ */
+function checkForRegistrationErrors(props) {
   const {
-    activityTypes,
-    currentUser,
-    destination,
-    destinationId,
-    destinationType,
     errors,
-    initialActivity,
-    spaceId,
     sparkState,
-    spark,
-    toPersonEmail,
-    toPersonId
+    spark
   } = props;
+
   const {formatMessage} = props.intl;
+
   const registerErrorId = 'spark.register';
 
   if (sparkState.get('registerError') && (!errors.get('hasError') || !errors.get('errors').has(registerErrorId))) {
@@ -73,11 +70,27 @@ function checkForErrors(props) {
       code: error.statusCode
     });
   }
+}
 
+/**
+ * Verifies the destination provided is valid
+ * @param {Object} props
+ */
+function checkForDestinationErrors(props) {
+  const {
+    currentUser,
+    destination,
+    destinationId,
+    destinationType,
+    errors
+  } = props;
+  const {formatMessage} = props.intl;
+
+  // Destination type and id are required
   const missingDestinationErrorId = 'space.error.missingDestination';
 
   if (
-    !destinationId && !destinationType && !toPersonEmail && !toPersonId && !spaceId &&
+    !destinationId && !destinationType &&
     (!errors.get('hasError') || !errors.get('errors').has(missingDestinationErrorId))
   ) {
     // No destination found
@@ -89,6 +102,7 @@ function checkForErrors(props) {
     });
   }
 
+  // Cannot start a space with yourself
   const toSelfErrorId = 'space.error.toSelf';
 
   if (
@@ -110,7 +124,36 @@ function checkForErrors(props) {
     }
   }
 
-  if (activityTypes) {
+  // Cannot start a space to a UUID destination ID
+  const invalidDestinationErrorId = 'space.error.invalidDestination';
+
+  if (
+    destinationId && isUuid(destinationId) &&
+    (!errors.get('hasError') || !errors.get('errors').has(invalidDestinationErrorId))
+  ) {
+    // No destination found
+    props.addError({
+      id: invalidDestinationErrorId,
+      displayTitle: formatMessage(messages.unableToLoad),
+      displaySubtitle: formatMessage(messages.invalidDestination),
+      temporary: false
+    });
+  }
+}
+
+/**
+ * Verifies the prop based activity types are valid
+ * @param {Object} props
+ */
+function checkActivityTypes(props) {
+  const {
+    activityTypes,
+    errors,
+    initialActivity
+  } = props;
+  const {formatMessage} = props.intl;
+
+  if (activityTypes && activityTypes.length > 0) {
     const invalidActivityId = 'ciscospark.container.space.error.invalidActivity';
     const defaultActivity = 'message';
     let validActivity = false;
@@ -134,6 +177,13 @@ function checkForErrors(props) {
   }
 }
 
+function checkForErrors(props) {
+  checkForMercuryErrors(props);
+  checkForRegistrationErrors(props);
+  checkForDestinationErrors(props);
+  checkActivityTypes(props);
+}
+
 export default compose(
   connect(
     (state) => state,
@@ -145,10 +195,8 @@ export default compose(
   lifecycle({
     componentWillMount() {
       checkForErrors(this.props);
-      checkForMercuryErrors(this.props);
     },
     componentWillReceiveProps: (nextProps) => {
-      checkForMercuryErrors(nextProps);
       checkForErrors(nextProps);
     }
   })

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
@@ -62,40 +62,11 @@ function normalizeDestinationId({id, type}) {
 function getDestinationFromProps(props) {
   const {
     destinationId,
-    destinationType,
-    spaceId,
-    sparkInstance,
-    toPersonEmail,
-    toPersonId
+    destinationType
   } = props;
 
   if (destinationType && destinationId) {
     return {type: destinationType, id: normalizeDestinationId({type: destinationType, id: destinationId})};
-  }
-  if (spaceId) {
-    sparkInstance.logger.warn();
-
-    return {
-      type: destinationTypes.SPACEID,
-      id: normalizeDestinationId({type: destinationTypes.SPACEID, id: spaceId}),
-      warning: 'The Space ID property is deprecated. Please use Destination ID and Type instead.'
-    };
-  }
-  if (toPersonEmail) {
-    return {
-      type: destinationTypes.EMAIL,
-      id: toPersonEmail,
-      warning: 'The To Person Email property is deprecated. Please use Destination ID and Type instead.'
-    };
-  }
-  if (toPersonId) {
-    sparkInstance.logger.warn('The To Person ID property is deprecated. Please use Destination ID and Type instead.');
-
-    return {
-      type: destinationTypes.USERID,
-      id: normalizeDestinationId({type: destinationTypes.USERID, id: toPersonId}),
-      warning: 'The To Person ID property is deprecated. Please use Destination ID and Type instead.'
-    };
   }
 
   return null;

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
@@ -7,7 +7,7 @@ import {resetErrors} from '@ciscospark/redux-module-errors';
 import {connectToMercury} from '@ciscospark/redux-module-mercury';
 import {fetchSpace} from '@ciscospark/redux-module-spaces';
 import {getUser} from '@ciscospark/redux-module-users';
-import {constructHydraId, hydraTypes, isUuid, validateAndDecodeId} from '@ciscospark/react-component-utils';
+import {validateAndDecodeId} from '@ciscospark/react-component-utils';
 
 import {
   getSpaceDetails,
@@ -19,58 +19,6 @@ import {
 import {getSpaceWidgetProps} from '../selector';
 
 import {destinationTypes} from '../';
-
-/**
- * Normalizes destination id to either email or hydra id
- *
- * @param {string} destination.id
- * @param {string} destination.type
- * @returns {string}
- */
-function normalizeDestinationId({id, type}) {
-  if (type === destinationTypes.USERID) {
-    let destinationId = id;
-
-    if (isUuid(id)) {
-      destinationId = constructHydraId(hydraTypes.PEOPLE, id);
-    }
-
-    return destinationId;
-  }
-  if (type === destinationTypes.SPACEID) {
-    let destinationId = id;
-
-    if (isUuid(id)) {
-      destinationId = constructHydraId(hydraTypes.ROOM, id);
-    }
-
-    return destinationId;
-  }
-
-  return id;
-}
-
-/**
- * Converts props into a destination object
- *
- * @param {*} props
- * @returns {Object} destination
- * @returns {string} destination.id
- * @returns {string} destination.type
- * @returns {string} destination.warning
- */
-function getDestinationFromProps(props) {
-  const {
-    destinationId,
-    destinationType
-  } = props;
-
-  if (destinationType && destinationId) {
-    return {type: destinationType, id: normalizeDestinationId({type: destinationType, id: destinationId})};
-  }
-
-  return null;
-}
 
 function setup(props, prevProps) {
   const {
@@ -99,12 +47,11 @@ function setup(props, prevProps) {
 
     // Check for destination Change
     if (destination && prevProps.destination) {
-      const calculatedDestination = getDestinationFromProps(props);
-      const calculatedPreviousDestination = getDestinationFromProps(prevProps);
+      const previousDestination = prevProps.destination;
 
       if (
-        calculatedPreviousDestination.id !== calculatedDestination.id
-        || calculatedPreviousDestination.type !== calculatedDestination.type
+        destination.id !== previousDestination.id
+        || destination.type !== previousDestination.type
       ) {
         sparkInstance.logger.info('Destination has changed, widget reloading...');
         props.updateWidgetStatus({
@@ -126,7 +73,6 @@ function setup(props, prevProps) {
       // If the selector isn't returning a destination object and we have props for them, store
       if (destination) {
         // Use destination object from store to fetch space details
-        // Instead of using props because of legacy prop support
         props.getSpaceDetails({
           sparkInstance,
           destinationId: destination.id,
@@ -145,12 +91,16 @@ function setup(props, prevProps) {
         }
       }
       else {
-        const calculatedDestination = getDestinationFromProps(props);
+        // Destination has not been stored yet, process and store.
+        const {
+          destinationId,
+          destinationType
+        } = props;
 
-        if (calculatedDestination.warning) {
-          sparkInstance.logger.warn(calculatedDestination.warning);
-        }
-        props.storeDestination(calculatedDestination);
+        props.storeDestination({
+          type: destinationType,
+          id: destinationId
+        });
       }
     }
 

--- a/packages/node_modules/@ciscospark/widget-space/src/messages.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/messages.js
@@ -38,6 +38,10 @@ export default defineMessages({
     id: 'ciscospark.container.space.error.unknownDestination',
     defaultMessage: 'Please provide a Space ID or To Person'
   },
+  invalidDestination: {
+    id: 'ciscospark.container.space.error.invalidDestination',
+    defaultMessage: 'Destination IDs must be fully encoded (not a UUID)'
+  },
   unknownError: {
     id: 'ciscospark.container.space.error.unknown',
     defaultMessage: 'There was a problem loading space'

--- a/test/journeys/lib/test-users.js
+++ b/test/journeys/lib/test-users.js
@@ -101,7 +101,11 @@ export function createTestUsers(count, config) {
     }
 
     return Promise.all(promises)
-      .then(() => storeUsers(createdUsers));
+      .then(() => storeUsers(createdUsers))
+      // Adding delay for test user creation propagation
+      .then(() => new Promise((resolve) => {
+        setTimeout(resolve, 3000);
+      }));
   }
 
   browser.call(createUsers);

--- a/test/journeys/lib/test-users.js
+++ b/test/journeys/lib/test-users.js
@@ -1,6 +1,7 @@
 import '@webex/plugin-authorization';
 import '@webex/plugin-logger';
 import '@webex/plugin-people';
+import '@webex/plugin-rooms';
 import '@webex/internal-plugin-conversation';
 
 import CiscoSpark from '@webex/webex-core';
@@ -135,7 +136,7 @@ export function setupOneOnOneUsers() {
  * Creates a space using the JS SDK
  * @param {Object} options
  * @param {Object} options.sparkInstance
- * @param {Object} options.participants
+ * @param {Array} options.participants
  * @param {Object} options.displayName
  * @returns {Object}
  */
@@ -148,18 +149,22 @@ export function createSpace({sparkInstance, participants, displayName}) {
   }).then((c) => {
     space = c;
 
-    return space;
-  }));
+    return sparkInstance.rooms.get(space);
+  })
+    .then((room) => {
+      // Get the hydra ID for created space
+      space.hydraId = room.id;
+    }));
 
   return space;
 }
 
 /**
- * Creates a space using the JS SDK
+ * Sends a message to a space using the JS SDK
  * @param {Object} options
  * @param {Object} options.sparkInstance
- * @param {Object} options.participants
- * @param {Object} options.displayName
+ * @param {Object} options.space
+ * @param {String} options.message
  * @returns {Object}
  */
 export function sendMessage({sparkInstance, space, message}) {

--- a/test/journeys/specs/recents/dataApi/basic.js
+++ b/test/journeys/specs/recents/dataApi/basic.js
@@ -59,7 +59,8 @@ describe('Widget Recents: Data API', () => {
         onEvent: (eventName, detail) => {
           window.ciscoSparkEvents.push({eventName, detail});
         },
-        toPersonEmail: localToUserEmail,
+        destinationType: 'email',
+        destinationId: localToUserEmail,
         initialActivity: 'meet'
       };
 

--- a/test/journeys/specs/smoke/multiple/index.js
+++ b/test/journeys/specs/smoke/multiple/index.js
@@ -62,7 +62,7 @@ describe('Multiple Widgets', () => {
       };
 
       window.openSpaceWidget(options);
-    }, marty.token.access_token, conversation.id);
+    }, marty.token.access_token, conversation.hydraId);
     browserLocal.waitForVisible(spaceElements.spaceWidget);
   });
 
@@ -91,7 +91,7 @@ describe('Multiple Widgets', () => {
       };
 
       window.openSpaceWidget(options);
-    }, docbrown.token.access_token, conversation.id);
+    }, docbrown.token.access_token, conversation.hydraId);
     browserRemote.waitForVisible(spaceElements.spaceWidget);
   });
 

--- a/test/journeys/specs/smoke/widget-recents/index.js
+++ b/test/journeys/specs/smoke/widget-recents/index.js
@@ -365,7 +365,8 @@ describe('Smoke Tests - Recents Widget', () => {
           onEvent: (eventName, detail) => {
             window.ciscoSparkEvents.push({eventName, detail});
           },
-          toPersonEmail: localToUserEmail,
+          destinationType: 'email',
+          destinationId: localToUserEmail,
           initialActivity: 'meet'
         };
 

--- a/test/journeys/specs/smoke/widget-space/index.js
+++ b/test/journeys/specs/smoke/widget-space/index.js
@@ -49,7 +49,7 @@ describe('Smoke Tests - Space Widget', () => {
       };
 
       window.openSpaceWidget(options);
-    }, marty.token.access_token, conversation.id);
+    }, marty.token.access_token, conversation.hydraId);
   });
 
   it('open widget for docbrown in browserRemote', () => {
@@ -65,7 +65,7 @@ describe('Smoke Tests - Space Widget', () => {
       };
 
       window.openSpaceWidget(options);
-    }, docbrown.token.access_token, conversation.id);
+    }, docbrown.token.access_token, conversation.hydraId);
     remote.browser.waitForVisible(`[placeholder="Send a message to ${local.displayName}"]`);
   });
 

--- a/test/journeys/specs/space/data-api.js
+++ b/test/journeys/specs/space/data-api.js
@@ -47,7 +47,7 @@ describe('Space Widget Data API Tests', () => {
       csmmDom.setAttribute('data-initial-activity', 'message');
       document.getElementById('ciscospark-widget').appendChild(csmmDom);
       window.loadBundle('/dist-space/bundle.js');
-    }, marty.token.access_token, conversation.id);
+    }, marty.token.access_token, conversation.hydraId);
     local.browser.waitForVisible(spaceWidget);
   });
 
@@ -64,7 +64,7 @@ describe('Space Widget Data API Tests', () => {
       csmmDom.setAttribute('data-initial-activity', 'message');
       document.getElementById('ciscospark-widget').appendChild(csmmDom);
       window.loadBundle('/dist-space/bundle.js');
-    }, docbrown.token.access_token, conversation.id);
+    }, docbrown.token.access_token, conversation.hydraId);
     remote.browser.waitForVisible(spaceWidget);
   });
 

--- a/test/journeys/specs/space/index.js
+++ b/test/journeys/specs/space/index.js
@@ -66,7 +66,7 @@ describe('Space Widget Primary Tests', () => {
       };
 
       window.openSpaceWidget(options);
-    }, marty.token.access_token, conversation.id);
+    }, marty.token.access_token, conversation.hydraId);
   });
 
   before('open widget for docbrown in browserRemote', () => {
@@ -82,7 +82,7 @@ describe('Space Widget Primary Tests', () => {
       };
 
       window.openSpaceWidget(options);
-    }, docbrown.token.access_token, conversation.id);
+    }, docbrown.token.access_token, conversation.hydraId);
     remote.browser.waitForVisible(`[placeholder="Send a message to ${local.displayName}"]`);
   });
 

--- a/test/journeys/specs/space/startup-settings.js
+++ b/test/journeys/specs/space/startup-settings.js
@@ -106,27 +106,6 @@ describe('Space Widget Startup Settings Tests', () => {
     });
   });
 
-  describe('legacy destination settings', () => {
-    it('opens message widget using legacy toPersonEmail', () => {
-      browserLocal.execute((localAccessToken, localToUserEmail) => {
-        const options = {
-          accessToken: localAccessToken,
-          onEvent: (eventName, detail) => {
-            window.ciscoSparkEvents.push({eventName, detail});
-          },
-          toPersonEmail: localToUserEmail,
-          initialActivity: 'message'
-        };
-
-        window.openSpaceWidget(options);
-      }, mccoy.token.access_token, spock.email);
-
-      browserLocal.waitForVisible(`[placeholder="Send a message to ${spock.displayName}"]`);
-      browserLocal.refresh();
-      browserRemote.refresh();
-    });
-  });
-
   /* eslint-disable-next-line func-names */
   afterEach(function () {
     allPassed = allPassed && (this.currentTest.state === 'passed');

--- a/test/journeys/specs/tap/widget-space/space.js
+++ b/test/journeys/specs/tap/widget-space/space.js
@@ -103,13 +103,13 @@ describe('Widget Space: Group Space: TAP', () => {
 
   before('inject marty token', () => {
     local = {browser: browserLocal, user: marty, displayName: conversation.displayName};
-    loginAndOpenWidget(local.browser, marty.token.access_token, false, conversation.id);
+    loginAndOpenWidget(local.browser, marty.token.access_token, false, conversation.hydraId);
     local.browser.waitForExist(`[placeholder="Send a message to ${conversation.displayName}"]`, 30000);
   });
 
   before('inject docbrown token', () => {
     remote = {browser: browserRemote, user: docbrown, displayName: conversation.displayName};
-    loginAndOpenWidget(remote.browser, docbrown.token.access_token, false, conversation.id);
+    loginAndOpenWidget(remote.browser, docbrown.token.access_token, false, conversation.hydraId);
     remote.browser.waitForExist(`[placeholder="Send a message to ${conversation.displayName}"]`, 30000);
   });
 

--- a/test/journeys/testplan.md
+++ b/test/journeys/testplan.md
@@ -181,8 +181,6 @@ The space widget suite tests the functionality of the space widget in a given sp
   - opens message widget
 - start call setting
   - starts call when set to true
-- legacy destination settings
-  - opens message widget using legacy toPersonEmail
 
 #### Space Widget Data API Instantiation Tests
 
@@ -201,7 +199,6 @@ The space widget suite tests the functionality of the space widget in a given sp
     - opens message widget
   - start call setting
     - starts call when set to true
-  - opens using legacy toPersonEmail
 
 ### Recents Suite
 


### PR DESCRIPTION
This PR introduces two breaking changes to the space widget:

* The previously deprecated legacy destination props of "toPersonEmail", "toSpace", "toPersonId" are no longer supported.
* Destination types of "SPACEID" and "USERID" require the fully encoded hydra ID to be able to look up these destinations via federation.