### PR TITLE
Meetings widget initial framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,6 +1907,47 @@
         }
       }
     },
+    "@webex/plugin-meetings": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.79.0.tgz",
+      "integrity": "sha512-tXZvb3xrLka8l+XJC/77z01O+1IgoOEQfKoqTOJFzy05fF7oEqcnUfj8d6Vr8pak5aQSGtctX1H0ge3cPVK9rg==",
+      "requires": {
+        "@webex/common": "1.79.0",
+        "@webex/common-timers": "1.79.0",
+        "@webex/internal-plugin-mercury": "1.79.0",
+        "@webex/webex-core": "1.79.0",
+        "babel-runtime": "^6.26.0",
+        "bowser": "1.9.4",
+        "btoa": "^1.2.1",
+        "envify": "^4.1.0",
+        "global": "^4.4.0",
+        "javascript-state-machine": "^3.1.0",
+        "lodash": "^4.17.15",
+        "sdp-transform": "^2.12.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+          "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "^0.11.10"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        }
+      }
+    },
     "@webex/plugin-people": {
       "version": "1.79.0",
       "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.79.0.tgz",
@@ -5374,8 +5415,7 @@
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "dev": true
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "5.2.0",
@@ -14925,6 +14965,11 @@
       "requires": {
         "handlebars": "^4.0.3"
       }
+    },
+    "javascript-state-machine": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
+      "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
     },
     "jest": {
       "version": "23.6.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@webex/internal-plugin-wdm": "1.79.0",
     "@webex/plugin-authorization": "1.79.0",
     "@webex/plugin-logger": "1.79.0",
+    "@webex/plugin-meetings": "^1.79.0",
     "@webex/plugin-people": "1.79.0",
     "@webex/plugin-phone": "1.79.0",
     "@webex/plugin-rooms": "1.79.0",

--- a/packages/node_modules/@ciscospark/react-redux-spark/src/spark.js
+++ b/packages/node_modules/@ciscospark/react-redux-spark/src/spark.js
@@ -5,6 +5,7 @@ import '@webex/plugin-people';
 import '@webex/internal-plugin-conversation';
 import '@webex/plugin-phone';
 import '@webex/plugin-rooms';
+import '@webex/plugin-meetings';
 import '@webex/internal-plugin-flag';
 import '@webex/internal-plugin-feature';
 import '@webex/internal-plugin-presence';
@@ -94,6 +95,9 @@ function defaultConfig(options = {}) {
     // Added to help load blocking during decryption
     encryption: {
       kmsInitialTimeout: 10000
+    },
+    meetings: {
+      deviceType: 'WEB'
     },
     phone: {
       enableExperimentalGroupCallingSupport: true

--- a/packages/node_modules/@webex/redux-module-meetings/package.json
+++ b/packages/node_modules/@webex/redux-module-meetings/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@webex/redux-module-meetings",
+  "description": "Webex Redux Module Meetings",
+  "main": "./cjs/index.js",
+  "src": "./src/index.js",
+  "module": "./es/index.js",
+  "keywords": [],
+  "license": "MIT",
+  "repository": "https://github.com/webex/react-widgets",
+  "files": [
+    "src",
+    "dist",
+    "cjs",
+    "es"
+  ]
+}

--- a/packages/node_modules/@webex/redux-module-meetings/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/actions.js
@@ -1,0 +1,20 @@
+export const STORE_MEETING = 'meetings/CREATE_MEETING';
+
+function storeMeeting({destinationType, destinationId, meeting}) {
+  return {
+    type: STORE_MEETING,
+    payload: {
+      destinationType,
+      destinationId,
+      meeting
+    }
+  };
+}
+
+export function createMeeting({destinationType, destinationId}, sdkInstance) {
+  return (dispatch) => sdkInstance.meetings.create(destinationId).then((meeting) => {
+    dispatch(storeMeeting({destinationId, destinationType, meeting}));
+
+    return meeting;
+  });
+}

--- a/packages/node_modules/@webex/redux-module-meetings/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/actions.js
@@ -1,4 +1,5 @@
-export const STORE_MEETING = 'meetings/CREATE_MEETING';
+export const JOIN_MEETING = 'meetings/JOIN_MEETING';
+export const STORE_MEETING = 'meetings/STORE_MEETING';
 
 function storeMeeting({destinationType, destinationId, meeting}) {
   return {
@@ -11,10 +12,28 @@ function storeMeeting({destinationType, destinationId, meeting}) {
   };
 }
 
-export function createMeeting({destinationType, destinationId}, sdkInstance) {
-  return (dispatch) => sdkInstance.meetings.create(destinationId).then((meeting) => {
-    dispatch(storeMeeting({destinationId, destinationType, meeting}));
+function joinMeeting(meeting) {
+  return {
+    type: JOIN_MEETING,
+    payload: {
+      meeting
+    }
+  };
+}
 
-    return meeting;
-  });
+export function createAndJoinMeeting({destinationType, destinationId}, sdkInstance) {
+  return (dispatch) => sdkInstance.meetings.create(destinationId)
+    .then((meeting) => {
+      dispatch(storeMeeting({destinationId, destinationType, meeting}));
+
+      // TODO: handle meeting destroyed event
+
+      return meeting.join().then(() => {
+        dispatch(joinMeeting(meeting));
+
+        // TODO: Bind Events and add media
+
+        return meeting;
+      });
+    });
 }

--- a/packages/node_modules/@webex/redux-module-meetings/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/actions.js
@@ -1,5 +1,6 @@
 export const JOIN_MEETING = 'meetings/JOIN_MEETING';
 export const STORE_MEETING = 'meetings/STORE_MEETING';
+export const UPDATE_MEETING_STATE = 'meetings/UPDATE_MEETING_STATE';
 
 function storeMeeting({destinationType, destinationId, meeting}) {
   return {
@@ -21,19 +22,84 @@ function joinMeeting(meeting) {
   };
 }
 
+function updateMeetingState(meeting, meetingState) {
+  return {
+    type: UPDATE_MEETING_STATE,
+    payload: {
+      meeting,
+      meetingState
+    }
+  };
+}
+
+function bindMeetingEvents(meeting, dispatch) {
+  // Handle media streams changes to ready state
+  meeting.on('media:ready', (media) => {
+    if (!media) {
+      return;
+    }
+    if (media.type === 'local') {
+      dispatch(updateMeetingState(meeting, {hasLocalMedia: true}));
+    }
+    if (media.type === 'remoteVideo') {
+      dispatch(updateMeetingState(meeting, {hasRemoteVideo: true}));
+    }
+    if (media.type === 'remoteAudio') {
+      dispatch(updateMeetingState(meeting, {hasRemoteAudio: true}));
+    }
+  });
+}
+
 export function createAndJoinMeeting({destinationType, destinationId}, sdkInstance) {
   return (dispatch) => sdkInstance.meetings.create(destinationId)
     .then((meeting) => {
       dispatch(storeMeeting({destinationId, destinationType, meeting}));
 
-      // TODO: handle meeting destroyed event
+      bindMeetingEvents(meeting, dispatch);
 
       return meeting.join().then(() => {
         dispatch(joinMeeting(meeting));
 
-        // TODO: Bind Events and add media
-
         return meeting;
       });
     });
+}
+
+export function addMediaToMeeting({
+  meetingId,
+  receiveVideo,
+  receiveAudio,
+  receiveShare,
+  sendVideo,
+  sendAudio,
+  sendShare
+}, sdkInstance) {
+  return () => {
+    // Get meeting instance from the SDK
+    const meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
+
+    if (!meeting) {
+      throw new Error('#addMediaToMeeting - unable to locate meeting with id: ', meetingId);
+    }
+
+    const mediaSettings = {
+      receiveVideo,
+      receiveAudio,
+      receiveShare,
+      sendVideo,
+      sendAudio,
+      sendShare
+    };
+
+    // Get our local media stream and add it to the meeting
+    return meeting.getMediaStreams(mediaSettings).then((mediaStreams) => {
+      const [localStream, localShare] = mediaStreams;
+
+      meeting.addMedia({
+        localShare,
+        localStream,
+        mediaSettings
+      });
+    });
+  };
 }

--- a/packages/node_modules/@webex/redux-module-meetings/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/actions.js
@@ -64,8 +64,23 @@ function bindMeetingEvents(meeting, dispatch) {
       dispatch(updateMeetingState(meeting, {hasRemoteAudio: true}));
     }
   });
+
+  // TODO: Add media:stopped handlers
+
+  // TODO: Add meeting stopped & destroyed handlers
 }
 
+/**
+ * Gets the meeting instance from the SDK plugin
+ *
+ * @param {Object} config
+ * @param {String} config.destinationId
+ * @param {String} config.destinationType
+ * @param {String} config.meetingId
+ * @param {Object} config.meetings Redux state object from the store
+ * @param {Object} sdkInstance
+ * @returns {Object} meeting instance
+ */
 function getMeetingFromSDK({
   destinationId,
   destinationType,
@@ -95,6 +110,15 @@ function getMeetingFromSDK({
 
 // Exported Action Creators (Should return thunks)
 
+/**
+ * Creates a meeting and joins it via the SDK
+ *
+ * @param {Object} config
+ * @param {String} config.destinationId
+ * @param {String} config.destinationType
+ * @param {Object} sdkInstance
+ * @returns {Thunk}
+ */
 export function createAndJoinMeeting({destinationType, destinationId}, sdkInstance) {
   return (dispatch) => sdkInstance.meetings.create(destinationId)
     .then((meeting) => {
@@ -110,6 +134,20 @@ export function createAndJoinMeeting({destinationType, destinationId}, sdkInstan
     });
 }
 
+/**
+ * Gets local media and adds it to the meeting
+ *
+ * @param {Object} config
+ * @param {String} config.meetingId
+ * @param {boolean} config.receiveVideo
+ * @param {boolean} config.receiveAudio
+ * @param {boolean} config.receiveShare
+ * @param {boolean} config.sendAudio
+ * @param {boolean} config.sendVideo
+ * @param {boolean} config.sendShare
+ * @param {Object} sdkInstance
+ * @returns {Thunk}
+ */
 export function addMediaToMeeting({
   meetingId,
   receiveVideo,
@@ -145,6 +183,15 @@ export function addMediaToMeeting({
   };
 }
 
+/**
+ * Leaves a meeting via the SDK
+ *
+ * @param {Object} config
+ * @param {String} config.destinationId
+ * @param {String} config.destinationType
+ * @param {Object} sdkInstance
+ * @returns {Thunk}
+  */
 export function leaveMeeting({destinationType, destinationId}, sdkInstance) {
   return (dispatch, getState) => {
     const {meetings} = getState();

--- a/packages/node_modules/@webex/redux-module-meetings/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/actions.js
@@ -1,6 +1,29 @@
+import {buildDestinationLookup} from './reducer';
+
 export const JOIN_MEETING = 'meetings/JOIN_MEETING';
+export const LEAVE_MEETING = 'meetings/LEAVE_MEETING';
 export const STORE_MEETING = 'meetings/STORE_MEETING';
 export const UPDATE_MEETING_STATE = 'meetings/UPDATE_MEETING_STATE';
+
+// Redux Actions
+
+function joinMeeting(meeting) {
+  return {
+    type: JOIN_MEETING,
+    payload: {
+      meeting
+    }
+  };
+}
+
+function leaveMeetingAction(meeting) {
+  return {
+    type: LEAVE_MEETING,
+    payload: {
+      meeting
+    }
+  };
+}
 
 function storeMeeting({destinationType, destinationId, meeting}) {
   return {
@@ -8,15 +31,6 @@ function storeMeeting({destinationType, destinationId, meeting}) {
     payload: {
       destinationType,
       destinationId,
-      meeting
-    }
-  };
-}
-
-function joinMeeting(meeting) {
-  return {
-    type: JOIN_MEETING,
-    payload: {
       meeting
     }
   };
@@ -31,6 +45,8 @@ function updateMeetingState(meeting, meetingState) {
     }
   };
 }
+
+// Helper Methods
 
 function bindMeetingEvents(meeting, dispatch) {
   // Handle media streams changes to ready state
@@ -49,6 +65,35 @@ function bindMeetingEvents(meeting, dispatch) {
     }
   });
 }
+
+function getMeetingFromSDK({
+  destinationId,
+  destinationType,
+  meetingId,
+  meetings
+}, sdkInstance) {
+  let calculatedMeetingId = meetingId;
+
+  if (!meetingId) {
+    if (!destinationId || !destinationType || !meetings) {
+      throw new Error('#getMeetingFromSDK - unable to lookup meeting');
+    }
+
+    const destination = buildDestinationLookup({destinationId, destinationType});
+
+    calculatedMeetingId = meetings.getIn(['byDestination', destination]);
+  }
+
+  const meeting = sdkInstance.meetings.meetingCollection.meetings[calculatedMeetingId];
+
+  if (!meeting) {
+    throw new Error('#getMeetingFromSDK - unable to locate meeting with id: ', calculatedMeetingId);
+  }
+
+  return meeting;
+}
+
+// Exported Action Creators (Should return thunks)
 
 export function createAndJoinMeeting({destinationType, destinationId}, sdkInstance) {
   return (dispatch) => sdkInstance.meetings.create(destinationId)
@@ -76,11 +121,7 @@ export function addMediaToMeeting({
 }, sdkInstance) {
   return () => {
     // Get meeting instance from the SDK
-    const meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
-
-    if (!meeting) {
-      throw new Error('#addMediaToMeeting - unable to locate meeting with id: ', meetingId);
-    }
+    const meeting = getMeetingFromSDK({meetingId}, sdkInstance);
 
     const mediaSettings = {
       receiveVideo,
@@ -100,6 +141,21 @@ export function addMediaToMeeting({
         localStream,
         mediaSettings
       });
+    });
+  };
+}
+
+export function leaveMeeting({destinationType, destinationId}, sdkInstance) {
+  return (dispatch, getState) => {
+    const {meetings} = getState();
+
+    // Get meeting instance from the SDK
+    const meeting = getMeetingFromSDK({destinationId, destinationType, meetings}, sdkInstance);
+
+    return meeting.leave().then(() => {
+      dispatch(leaveMeetingAction(meeting));
+
+      return meeting;
     });
   };
 }

--- a/packages/node_modules/@webex/redux-module-meetings/src/index.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/index.js
@@ -1,0 +1,2 @@
+export * from './actions';
+export {default, initialState} from './reducer';

--- a/packages/node_modules/@webex/redux-module-meetings/src/index.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/index.js
@@ -1,2 +1,2 @@
 export * from './actions';
-export {default, initialState} from './reducer';
+export {default, initialState, buildDestinationLookup} from './reducer';

--- a/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
@@ -61,18 +61,21 @@ export default function reducer(state = initialState, action) {
       return updatedState;
     }
 
+    // Update the meeting state to show it has been joined
     case JOIN_MEETING: {
       const {meeting} = action.payload;
 
       return state.setIn(['byId', meeting.id, 'joined'], true);
     }
 
+    // Update the meeting state to show it was left and not joined
     case LEAVE_MEETING: {
       const {meeting} = action.payload;
 
       return state.setIn(['byId', meeting.id, 'joined'], false);
     }
 
+    // Update the meeting state
     case UPDATE_MEETING_STATE: {
       const {meeting, meetingState} = action.payload;
 

--- a/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
@@ -3,7 +3,14 @@ import {
   Map
 } from 'immutable';
 
-import {STORE_MEETING} from './actions';
+import {
+  JOIN_MEETING,
+  STORE_MEETING
+} from './actions';
+
+const MeetingState = Record({
+  joined: false
+});
 
 const InitialState = Record({
   byDestination: Map(),
@@ -13,8 +20,19 @@ const InitialState = Record({
 
 export const initialState = new InitialState();
 
+export function buildDestinationLookup({destinationId, destinationType}) {
+  if (!destinationId || !destinationType) {
+    throw new Error('#buildDestinationLookup - requires destinationID and destinationType');
+  }
+
+  return `${destinationType}-${destinationId}`;
+}
+
 export default function reducer(state = initialState, action) {
   switch (action.type) {
+    // The source of truth for the meetings objects is the meetings collection
+    // within the SDK. Instead of storing the meeting object in the redux store,
+    // we will just be storing IDs and meeting state in order to do the collection lookup.
     case STORE_MEETING: {
       const {
         meeting,
@@ -23,13 +41,12 @@ export default function reducer(state = initialState, action) {
       } = action.payload;
 
       const {locusUrl, id} = meeting;
+      const destination = buildDestinationLookup({destinationId, destinationType});
 
-      // Store the meeting object by id
-      let updatedState = state
-        .setIn(['byId', id], meeting);
+      let updatedState = state.setIn(['byId', id], new MeetingState());
 
       // Store a link to the meeting's ID by destination
-      updatedState = updatedState.setIn(['byDestination', `${destinationType}-${destinationId}`], id);
+      updatedState = updatedState.setIn(['byDestination', destination], id);
 
       // Store a link to the meeting's ID by locus
       if (locusUrl) {
@@ -37,6 +54,11 @@ export default function reducer(state = initialState, action) {
       }
 
       return updatedState;
+    }
+    case JOIN_MEETING: {
+      const {meeting} = action.payload;
+
+      return state.setIn(['byId', meeting.id, 'joined'], true);
     }
 
     default:

--- a/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
@@ -5,11 +5,15 @@ import {
 
 import {
   JOIN_MEETING,
-  STORE_MEETING
+  STORE_MEETING,
+  UPDATE_MEETING_STATE
 } from './actions';
 
 const MeetingState = Record({
-  joined: false
+  joined: false,
+  hasLocalMedia: false,
+  hasRemoteVideo: false,
+  hasRemoteAudio: false
 });
 
 const InitialState = Record({
@@ -59,6 +63,12 @@ export default function reducer(state = initialState, action) {
       const {meeting} = action.payload;
 
       return state.setIn(['byId', meeting.id, 'joined'], true);
+    }
+
+    case UPDATE_MEETING_STATE: {
+      const {meeting, meetingState} = action.payload;
+
+      return state.mergeIn(['byId', meeting.id], meetingState);
     }
 
     default:

--- a/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
@@ -5,6 +5,7 @@ import {
 
 import {
   JOIN_MEETING,
+  LEAVE_MEETING,
   STORE_MEETING,
   UPDATE_MEETING_STATE
 } from './actions';
@@ -59,10 +60,17 @@ export default function reducer(state = initialState, action) {
 
       return updatedState;
     }
+
     case JOIN_MEETING: {
       const {meeting} = action.payload;
 
       return state.setIn(['byId', meeting.id, 'joined'], true);
+    }
+
+    case LEAVE_MEETING: {
+      const {meeting} = action.payload;
+
+      return state.setIn(['byId', meeting.id, 'joined'], false);
     }
 
     case UPDATE_MEETING_STATE: {

--- a/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-meetings/src/reducer.js
@@ -1,0 +1,45 @@
+import {
+  Record,
+  Map
+} from 'immutable';
+
+import {STORE_MEETING} from './actions';
+
+const InitialState = Record({
+  byDestination: Map(),
+  byLocusUrl: Map(),
+  byId: Map()
+});
+
+export const initialState = new InitialState();
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    case STORE_MEETING: {
+      const {
+        meeting,
+        destinationId,
+        destinationType
+      } = action.payload;
+
+      const {locusUrl, id} = meeting;
+
+      // Store the meeting object by id
+      let updatedState = state
+        .setIn(['byId', id], meeting);
+
+      // Store a link to the meeting's ID by destination
+      updatedState = updatedState.setIn(['byDestination', `${destinationType}-${destinationId}`], id);
+
+      // Store a link to the meeting's ID by locus
+      if (locusUrl) {
+        updatedState = updatedState.setIn(['byLocusUrl', locusUrl], id);
+      }
+
+      return updatedState;
+    }
+
+    default:
+      return state;
+  }
+}

--- a/packages/node_modules/@webex/widget-meetings/package.json
+++ b/packages/node_modules/@webex/widget-meetings/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@webex/widget-meetings",
+  "description": "Webex React Meetings Widget",
+  "main": "./cjs/index.js",
+  "src": "./src/index.js",
+  "module": "./es/index.js",
+  "keywords": [],
+  "license": "MIT",
+  "repository": "https://github.com/webex/react-widgets",
+  "files": [
+    "src",
+    "dist",
+    "cjs",
+    "es"
+  ]
+}

--- a/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.css
+++ b/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.css
@@ -1,0 +1,10 @@
+.localVideo {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 150px;
+  height: 84px;
+  padding: 10px;
+  cursor: pointer;
+  transition: transform 160ms linear;
+}

--- a/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.css
+++ b/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.css
@@ -8,3 +8,14 @@
   cursor: pointer;
   transition: transform 160ms linear;
 }
+
+.meetingControls {
+  position: absolute;
+  bottom: 24px;
+  left: 0;
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  transition: all 160ms linear;
+  box-sizing: border-box;
+}

--- a/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Video from '@ciscospark/react-component-video';
+
+import styles from './ActiveMeeting.css';
+
+const propTypes = {
+  localVideoStream: PropTypes.object,
+  remoteVideoStream: PropTypes.object
+};
+
+const defaultProps = {
+  localVideoStream: undefined,
+  remoteVideoStream: undefined
+};
+
+function ActiveMeeting({localVideoStream, remoteVideoStream}) {
+  return (
+    <div>
+      {
+        localVideoStream &&
+        <div className={classNames(styles.localVideo, 'webex-meeting-active-local-video')}>
+          <Video audioMuted srcObject={localVideoStream} />
+        </div>
+      }
+      {
+        remoteVideoStream && remoteVideoStream.active &&
+        <Video srcObject={remoteVideoStream} />
+      }
+    </div>
+  );
+}
+
+ActiveMeeting.propTypes = propTypes;
+ActiveMeeting.defaultProps = defaultProps;
+
+export default ActiveMeeting;
+

--- a/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Video from '@ciscospark/react-component-video';
+import ButtonControls from '@ciscospark/react-component-button-controls';
 
 import styles from './ActiveMeeting.css';
 
 const propTypes = {
   localVideoStream: PropTypes.object,
+  onLeaveClick: PropTypes.func.isRequired,
   remoteVideoStream: PropTypes.object
 };
 
@@ -16,7 +18,22 @@ const defaultProps = {
   remoteVideoStream: undefined
 };
 
-function ActiveMeeting({localVideoStream, remoteVideoStream}) {
+function ActiveMeeting(
+  {
+    localVideoStream,
+    remoteVideoStream,
+    onLeaveClick
+  }
+) {
+  const controls = [];
+
+  controls.push({
+    accessibilityLabel: 'Hangup',
+    buttonType: 'cancel',
+    callControl: true,
+    onClick: onLeaveClick
+  });
+
   return (
     <div>
       {
@@ -29,6 +46,9 @@ function ActiveMeeting({localVideoStream, remoteVideoStream}) {
         remoteVideoStream && remoteVideoStream.active &&
         <Video srcObject={remoteVideoStream} />
       }
+      <div className={classNames(styles.meetingControls, 'webex-meeting-active-controls')}>
+        <ButtonControls buttons={controls} showLabels={false} />
+      </div>
     </div>
   );
 }

--- a/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.test.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/ActiveMeeting.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+import ActiveMeeting from './ActiveMeeting';
+
+const renderer = new ShallowRenderer();
+
+describe('ActiveMeeting component', () => {
+  it('renders properly with all props', () => {
+    renderer.render(
+      <ActiveMeeting
+        localVideoStream={{localVideoStream: 'mock'}}
+        onLeaveClick={jest.fn()}
+        remoteVideoStream={{removeVideoStream: 'mock', active: true}}
+      />
+    );
+
+    const component = renderer.getRenderOutput();
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders properly with inactive remote video', () => {
+    renderer.render(
+      <ActiveMeeting
+        localVideoStream={{localVideoStream: 'mock'}}
+        onLeaveClick={jest.fn()}
+        remoteVideoStream={{removeVideoStream: 'mock', active: false}}
+      />
+    );
+
+    const component = renderer.getRenderOutput();
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders properly with no remote video', () => {
+    renderer.render(
+      <ActiveMeeting
+        localVideoStream={{localVideoStream: 'mock'}}
+        onLeaveClick={jest.fn()}
+      />
+    );
+
+    const component = renderer.getRenderOutput();
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders properly with no local video', () => {
+    renderer.render(
+      <ActiveMeeting
+        onLeaveClick={jest.fn()}
+        remoteVideoStream={{removeVideoStream: 'mock', active: false}}
+      />
+    );
+
+    const component = renderer.getRenderOutput();
+
+    expect(component).toMatchSnapshot();
+  });
+});
+

--- a/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.css
+++ b/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.css
@@ -1,0 +1,33 @@
+.meetingInactiveContainer {
+  position: relative;
+  display: flex;
+  width: 100%;
+  margin: auto;
+  text-align: center;
+  flex: 1 1 auto;
+  align-items: center;
+  flex-direction: column;
+}
+
+.personName {
+  width: 100%;
+  margin: 10px;
+  overflow: hidden;
+  font-size: 32px;
+  color: #707071;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meetingControls {
+  z-index: 100;
+  text-align: center;
+}
+
+.meetingControls .meetingButton {
+  background-color: #30d557;
+}
+
+.meetingControls .meetingButton:hover {
+  background-color: #2ac44f;
+}

--- a/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import PresenceAvatar from '@ciscospark/react-container-presence-avatar';
+import ButtonControls from '@ciscospark/react-component-button-controls';
+
+import styles from './InactiveMeeting.css';
+
+const propTypes = {
+  avatarId: PropTypes.string,
+  avatarImage: PropTypes.string,
+  joinButtonAriaLabel: PropTypes.string,
+  joinButtonLabel: PropTypes.string,
+  displayName: PropTypes.string,
+  onJoinClick: PropTypes.func
+};
+
+const defaultProps = {
+  avatarId: '',
+  avatarImage: '',
+  joinButtonAriaLabel: 'Join Meeting',
+  joinButtonLabel: 'Join',
+  displayName: 'Unknown',
+  onJoinClick: () => {}
+};
+
+
+function InactiveMeeting({
+  avatarId,
+  avatarImage,
+  onJoinClick,
+  joinButtonAriaLabel,
+  joinButtonLabel,
+  displayName
+}) {
+  const buttons = [
+    {
+      label: joinButtonLabel,
+      accessibilityLabel: joinButtonAriaLabel,
+      buttonClassName: styles.meetingButton,
+      buttonType: 'camera',
+      onClick: onJoinClick
+    }
+  ];
+
+  return (
+    <div className={classNames(styles.meetingInactiveContainer, 'meeting-inactive-container')}>
+      <PresenceAvatar
+        avatarId={avatarId}
+        image={avatarImage}
+        name={displayName}
+        size={84}
+      />
+      <div className={classNames(styles.personName, 'meeting-person-name')}>
+        {displayName}
+      </div>
+      <div className={classNames(styles.meetingControls, 'meeting-controls-container')}>
+        <ButtonControls buttons={buttons} showLabels />
+      </div>
+    </div>
+  );
+}
+
+InactiveMeeting.propTypes = propTypes;
+InactiveMeeting.defaultProps = defaultProps;
+
+export default InactiveMeeting;

--- a/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.js
@@ -44,17 +44,17 @@ function InactiveMeeting({
   ];
 
   return (
-    <div className={classNames(styles.meetingInactiveContainer, 'meeting-inactive-container')}>
+    <div className={classNames(styles.meetingInactiveContainer, 'webex-meeting-inactive-container')}>
       <PresenceAvatar
         avatarId={avatarId}
         image={avatarImage}
         name={displayName}
         size={84}
       />
-      <div className={classNames(styles.personName, 'meeting-person-name')}>
+      <div className={classNames(styles.personName, 'webex-meeting-person-name')}>
         {displayName}
       </div>
-      <div className={classNames(styles.meetingControls, 'meeting-controls-container')}>
+      <div className={classNames(styles.meetingControls, 'webex-meeting-controls-container')}>
         <ButtonControls buttons={buttons} showLabels />
       </div>
     </div>

--- a/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.test.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/InactiveMeeting.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+import InactiveMeeting from './InactiveMeeting';
+
+const renderer = new ShallowRenderer();
+
+describe('InactiveMeeting component', () => {
+  it('renders properly with all props', () => {
+    renderer.render(
+      <InactiveMeeting
+        avatarId="avatarId"
+        avatarImage="http://newurl/pic.png"
+        onJoinClick={jest.fn()}
+        joinButtonAriaLabel="Join Meeting"
+        joinButtonLabel="Join"
+        displayName="Display Name"
+      />
+    );
+
+    const component = renderer.getRenderOutput();
+
+    expect(component).toMatchSnapshot();
+  });
+});
+

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.css
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.css
@@ -1,0 +1,12 @@
+.meetingsWidget {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+.errorWrapper {
+  position: absolute;
+  z-index: 1000;
+  width: 100%;
+  height: 100%;
+}

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import LoadingScreen from '@webex/react-component-loading-screen';
+
+function MeetingsWidget(props) {
+  const {isReady} = props;
+
+  let main;
+
+  if (!isReady) {
+    main = (
+      <LoadingScreen />
+    );
+  }
+  else {
+    main = (
+      <div>IS READY</div>
+    );
+  }
+
+  return (
+    <div>
+      { main }
+    </div>
+  );
+}
+
+MeetingsWidget.propTypes = {
+  isReady: PropTypes.bool.isRequired
+};
+
+export default MeetingsWidget;

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
@@ -1,33 +1,105 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import LoadingScreen from '@webex/react-component-loading-screen';
+import ErrorDisplay from '@ciscospark/react-component-error-display';
+
+import InactiveMeeting from './InactiveMeeting';
+
+// Momentum-UI base styling
+import './momentum.scss';
+import styles from './MeetingsWidget.css';
+
+const propTypes = {
+  destination: PropTypes.shape({
+    avatarId: PropTypes.string,
+    avatarImage: PropTypes.string,
+    callButtonAriaLabel: PropTypes.string,
+    callButtonLabel: PropTypes.string,
+    displayName: PropTypes.string
+  }),
+  error: PropTypes.shape({
+    displayTitle: PropTypes.string,
+    displaySubtitle: PropTypes.string,
+    temporary: PropTypes.bool
+  }),
+  isReady: PropTypes.bool,
+  meeting: PropTypes.object,
+  meetingStatus: PropTypes.object,
+  onJoinClick: PropTypes.func.isRequired
+};
+
+const defaultProps = {
+  destination: {},
+  error: undefined,
+  isReady: false,
+  meeting: undefined,
+  meetingStatus: {}
+};
 
 function MeetingsWidget(props) {
-  const {isReady} = props;
+  const {
+    destination,
+    error,
+    isReady,
+    meeting,
+    meetingStatus,
+    onJoinClick
+  } = props;
 
   let main;
 
-  if (!isReady) {
+  if (error) {
+    const {
+      displayTitle,
+      displaySubtitle,
+      temporary
+    } = error;
+
+    main = (
+      <div className={classNames(['webex-meetings-widget-error', styles.errorWrapper])}>
+        <ErrorDisplay
+          secondaryTitle={displaySubtitle}
+          title={displayTitle}
+          transparent={temporary}
+        />
+      </div>
+    );
+  }
+  else if (isReady) {
+    if (meeting && meetingStatus.joined) {
+      main = (
+        <div>MEETING JOINED</div>
+      );
+    }
+    else {
+      main = (
+        <InactiveMeeting
+          avatarId={destination.avatarId}
+          onJoinClick={onJoinClick}
+          avatarImage={destination.avatarImage}
+          joinButtonAriaLabel={destination.joinButtonAriaLabel}
+          joinButtonLabel={destination.joinButtonLabel}
+          displayName={destination.displayName}
+        />
+      );
+    }
+  }
+  else {
     main = (
       <LoadingScreen />
     );
   }
-  else {
-    main = (
-      <div>IS READY</div>
-    );
-  }
 
   return (
-    <div>
+    <div className={classNames(['webex-meetings-widget', 'md', styles.meetingsWidget])}>
       { main }
     </div>
   );
 }
 
-MeetingsWidget.propTypes = {
-  isReady: PropTypes.bool.isRequired
-};
+MeetingsWidget.propTypes = propTypes;
+MeetingsWidget.defaultProps = defaultProps;
 
 export default MeetingsWidget;

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import LoadingScreen from '@webex/react-component-loading-screen';
 import ErrorDisplay from '@ciscospark/react-component-error-display';
 
+import ActiveMeeting from './ActiveMeeting';
 import InactiveMeeting from './InactiveMeeting';
 
 // Momentum-UI base styling
@@ -26,6 +27,10 @@ const propTypes = {
   }),
   isReady: PropTypes.bool,
   meeting: PropTypes.object,
+  meetingMedia: PropTypes.shape({
+    localVideoStream: PropTypes.object,
+    remoteVideoStream: PropTypes.object
+  }),
   meetingStatus: PropTypes.object,
   onJoinClick: PropTypes.func.isRequired
 };
@@ -35,6 +40,7 @@ const defaultProps = {
   error: undefined,
   isReady: false,
   meeting: undefined,
+  meetingMedia: {},
   meetingStatus: {}
 };
 
@@ -44,6 +50,7 @@ function MeetingsWidget(props) {
     error,
     isReady,
     meeting,
+    meetingMedia,
     meetingStatus,
     onJoinClick
   } = props;
@@ -70,7 +77,10 @@ function MeetingsWidget(props) {
   else if (isReady) {
     if (meeting && meetingStatus.joined) {
       main = (
-        <div>MEETING JOINED</div>
+        <ActiveMeeting
+          localVideoStream={meetingMedia.localVideoStream}
+          remoteVideoStream={meetingMedia.remoteVideoStream}
+        />
       );
     }
     else {

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.js
@@ -32,7 +32,8 @@ const propTypes = {
     remoteVideoStream: PropTypes.object
   }),
   meetingStatus: PropTypes.object,
-  onJoinClick: PropTypes.func.isRequired
+  onJoinClick: PropTypes.func.isRequired,
+  onLeaveClick: PropTypes.func.isRequired
 };
 
 const defaultProps = {
@@ -52,7 +53,8 @@ function MeetingsWidget(props) {
     meeting,
     meetingMedia,
     meetingStatus,
-    onJoinClick
+    onJoinClick,
+    onLeaveClick
   } = props;
 
   let main;
@@ -79,6 +81,7 @@ function MeetingsWidget(props) {
       main = (
         <ActiveMeeting
           localVideoStream={meetingMedia.localVideoStream}
+          onLeaveClick={onLeaveClick}
           remoteVideoStream={meetingMedia.remoteVideoStream}
         />
       );

--- a/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.test.js
+++ b/packages/node_modules/@webex/widget-meetings/src/components/MeetingsWidget.test.js
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+import MeetingsWidget from './MeetingsWidget';
+
+const renderer = new ShallowRenderer();
+
+describe('MeetingsWidget component', () => {
+  describe('when it has an error', () => {
+    it('renders properly', () => {
+      const error = {
+        displayTitle: 'error title',
+        displaySubtitle: 'error subtitle',
+        temporary: false
+      };
+
+      renderer.render(
+        <MeetingsWidget
+          error={error}
+        />
+      );
+
+      const component = renderer.getRenderOutput();
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('when it is loading', () => {
+    it('renders properly', () => {
+      renderer.render(
+        <MeetingsWidget
+          isReady={false}
+        />
+      );
+
+      const component = renderer.getRenderOutput();
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('when the widget is ready', () => {
+    const isReady = true;
+
+    describe('when the meeting does not exist', () => {
+      it('renders properly', () => {
+        const destination = {
+          avatarId: 'avatarId',
+          avatarImage: 'avatarImage',
+          joinButtonAriaLabel: 'joinButtonArialLabel',
+          joinButtonLabel: 'joinButtonLabel',
+          displayName: 'displayName'
+        };
+
+        renderer.render(
+          <MeetingsWidget
+            destination={destination}
+            isReady={isReady}
+            onJoinClick={jest.fn()}
+          />
+        );
+
+        const component = renderer.getRenderOutput();
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('when the meeting exists but not joined', () => {
+      it('renders properly', () => {
+        const destination = {
+          avatarId: 'avatarId',
+          avatarImage: 'avatarImage',
+          joinButtonAriaLabel: 'joinButtonArialLabel',
+          joinButtonLabel: 'joinButtonLabel',
+          displayName: 'displayName'
+        };
+
+        renderer.render(
+          <MeetingsWidget
+            destination={destination}
+            isReady={isReady}
+            meetingStatus={{joined: false}}
+            onJoinClick={jest.fn()}
+          />
+        );
+
+        const component = renderer.getRenderOutput();
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+
+    describe('when the meeting is active', () => {
+      it('renders properly', () => {
+        renderer.render(
+          <MeetingsWidget
+            isReady={isReady}
+            meeting={{}}
+            meetingMedia={{localVideoStream: {mock: true}, remoteVideoStream: {mock: true}}}
+            meetingStatus={{joined: true}}
+            onLeaveClick={jest.fn()}
+          />
+        );
+
+        const component = renderer.getRenderOutput();
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+});
+

--- a/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/ActiveMeeting.test.js.snap
+++ b/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/ActiveMeeting.test.js.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActiveMeeting component renders properly with all props 1`] = `
+<div>
+  <div
+    className="localVideo webex-meeting-active-local-video"
+  >
+    <Video
+      audioMuted={true}
+      srcObject={
+        Object {
+          "localVideoStream": "mock",
+        }
+      }
+    />
+  </div>
+  <Video
+    audioMuted={false}
+    srcObject={
+      Object {
+        "active": true,
+        "removeVideoStream": "mock",
+      }
+    }
+  />
+  <div
+    className="meetingControls webex-meeting-active-controls"
+  >
+    <ButtonControls
+      buttons={
+        Array [
+          Object {
+            "accessibilityLabel": "Hangup",
+            "buttonType": "cancel",
+            "callControl": true,
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      showLabels={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`ActiveMeeting component renders properly with inactive remote video 1`] = `
+<div>
+  <div
+    className="localVideo webex-meeting-active-local-video"
+  >
+    <Video
+      audioMuted={true}
+      srcObject={
+        Object {
+          "localVideoStream": "mock",
+        }
+      }
+    />
+  </div>
+  <div
+    className="meetingControls webex-meeting-active-controls"
+  >
+    <ButtonControls
+      buttons={
+        Array [
+          Object {
+            "accessibilityLabel": "Hangup",
+            "buttonType": "cancel",
+            "callControl": true,
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      showLabels={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`ActiveMeeting component renders properly with no local video 1`] = `
+<div>
+  <div
+    className="meetingControls webex-meeting-active-controls"
+  >
+    <ButtonControls
+      buttons={
+        Array [
+          Object {
+            "accessibilityLabel": "Hangup",
+            "buttonType": "cancel",
+            "callControl": true,
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      showLabels={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`ActiveMeeting component renders properly with no remote video 1`] = `
+<div>
+  <div
+    className="localVideo webex-meeting-active-local-video"
+  >
+    <Video
+      audioMuted={true}
+      srcObject={
+        Object {
+          "localVideoStream": "mock",
+        }
+      }
+    />
+  </div>
+  <div
+    className="meetingControls webex-meeting-active-controls"
+  >
+    <ButtonControls
+      buttons={
+        Array [
+          Object {
+            "accessibilityLabel": "Hangup",
+            "buttonType": "cancel",
+            "callControl": true,
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      showLabels={false}
+    />
+  </div>
+</div>
+`;

--- a/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/InactiveMeeting.test.js.snap
+++ b/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/InactiveMeeting.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InactiveMeeting component renders properly with all props 1`] = `
+<div
+  className="meetingInactiveContainer webex-meeting-inactive-container"
+>
+  <Connect(PresenceAvatar)
+    avatarId="avatarId"
+    image="http://newurl/pic.png"
+    name="Display Name"
+    size={84}
+  />
+  <div
+    className="personName webex-meeting-person-name"
+  >
+    Display Name
+  </div>
+  <div
+    className="meetingControls webex-meeting-controls-container"
+  >
+    <ButtonControls
+      buttons={
+        Array [
+          Object {
+            "accessibilityLabel": "Join Meeting",
+            "buttonClassName": "meetingButton",
+            "buttonType": "camera",
+            "label": "Join",
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      showLabels={true}
+    />
+  </div>
+</div>
+`;

--- a/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/MeetingsWidget.test.js.snap
+++ b/packages/node_modules/@webex/widget-meetings/src/components/__snapshots__/MeetingsWidget.test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MeetingsWidget component when it has an error renders properly 1`] = `
+<div
+  className="webex-meetings-widget md meetingsWidget"
+>
+  <div
+    className="webex-meetings-widget-error errorWrapper"
+  >
+    <ErrorDisplay
+      actionTitle=""
+      onAction={[Function]}
+      secondaryTitle="error subtitle"
+      title="error title"
+      transparent={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`MeetingsWidget component when it is loading renders properly 1`] = `
+<div
+  className="webex-meetings-widget md meetingsWidget"
+>
+  <LoadingScreen
+    loadingMessage=""
+  />
+</div>
+`;
+
+exports[`MeetingsWidget component when the widget is ready when the meeting does not exist renders properly 1`] = `
+<div
+  className="webex-meetings-widget md meetingsWidget"
+>
+  <InactiveMeeting
+    avatarId="avatarId"
+    avatarImage="avatarImage"
+    displayName="displayName"
+    joinButtonAriaLabel="joinButtonArialLabel"
+    joinButtonLabel="joinButtonLabel"
+    onJoinClick={[MockFunction]}
+  />
+</div>
+`;
+
+exports[`MeetingsWidget component when the widget is ready when the meeting exists but not joined renders properly 1`] = `
+<div
+  className="webex-meetings-widget md meetingsWidget"
+>
+  <InactiveMeeting
+    avatarId="avatarId"
+    avatarImage="avatarImage"
+    displayName="displayName"
+    joinButtonAriaLabel="joinButtonArialLabel"
+    joinButtonLabel="joinButtonLabel"
+    onJoinClick={[MockFunction]}
+  />
+</div>
+`;
+
+exports[`MeetingsWidget component when the widget is ready when the meeting is active renders properly 1`] = `
+<div
+  className="webex-meetings-widget md meetingsWidget"
+>
+  <ActiveMeeting
+    localVideoStream={
+      Object {
+        "mock": true,
+      }
+    }
+    onLeaveClick={[MockFunction]}
+    remoteVideoStream={
+      Object {
+        "mock": true,
+      }
+    }
+  />
+</div>
+`;

--- a/packages/node_modules/@webex/widget-meetings/src/components/momentum.scss
+++ b/packages/node_modules/@webex/widget-meetings/src/components/momentum.scss
@@ -1,0 +1,4 @@
+$brand-font-folder: "~@momentum-ui/core/fonts";
+$icon-font-path: "~@momentum-ui/icons/fonts";
+
+@import '~@momentum-ui/core/scss/momentum-ui-components';

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -23,7 +23,9 @@ const injectedPropTypes = {
     displaySubtitle: PropTypes.string,
     temporary: PropTypes.bool
   }),
-  isReady: PropTypes.bool
+  isReady: PropTypes.bool,
+  meeting: PropTypes.object,
+  meetingStatus: PropTypes.object
 };
 
 // Action props from handlers.js
@@ -50,14 +52,22 @@ export class ConnectedMeetingsWidget extends Component {
   }
 
   render() {
-    const {destination, error, isReady} = this.props;
+    const {
+      destination,
+      error,
+      isReady,
+      meeting,
+      meetingStatus
+    } = this.props;
 
     return (
       <MeetingsWidget
         destination={destination}
         error={error}
         isReady={isReady}
-        onCallClick={this.props.onStartMeeting}
+        meeting={meeting}
+        meetingStatus={meetingStatus}
+        onJoinClick={this.props.onStartMeeting}
       />
     );
   }

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -10,6 +10,13 @@ import MeetingsWidget from './components/MeetingsWidget';
 
 // Props injected via selector.js
 const injectedPropTypes = {
+  destination: PropTypes.shape({
+    avatarId: PropTypes.string,
+    avatarImage: PropTypes.string,
+    callButtonAriaLabel: PropTypes.string,
+    callButtonLabel: PropTypes.string,
+    displayName: PropTypes.string
+  }),
   isReady: PropTypes.bool.isRequired
 };
 
@@ -31,9 +38,14 @@ export class ConnectedMeetingsWidget extends Component {
   }
 
   render() {
-    const {isReady} = this.props;
+    const {destination, isReady} = this.props;
 
-    return <MeetingsWidget isReady={isReady} />;
+    return (
+      <MeetingsWidget
+        destination={destination}
+        isReady={isReady}
+      />
+    );
   }
 }
 

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -5,6 +5,7 @@ import {compose} from 'recompose';
 
 import getMeetingsWidgetProps from './selector';
 import enhancers from './enhancers';
+import handlers from './handlers';
 
 import MeetingsWidget from './components/MeetingsWidget';
 
@@ -17,9 +18,20 @@ const injectedPropTypes = {
     callButtonLabel: PropTypes.string,
     displayName: PropTypes.string
   }),
-  isReady: PropTypes.bool.isRequired
+  error: PropTypes.shape({
+    displayTitle: PropTypes.string,
+    displaySubtitle: PropTypes.string,
+    temporary: PropTypes.bool
+  }),
+  isReady: PropTypes.bool
 };
 
+// Action props from handlers.js
+const handlerPropTypes = {
+  onStartMeeting: PropTypes.func
+};
+
+// Props via the main react component
 export const ownPropTypes = {
   destinationId: PropTypes.string.isRequired,
   destinationType: PropTypes.oneOf(['email', 'spaceId', 'userId', 'sip', 'pstn']).isRequired
@@ -38,12 +50,14 @@ export class ConnectedMeetingsWidget extends Component {
   }
 
   render() {
-    const {destination, isReady} = this.props;
+    const {destination, error, isReady} = this.props;
 
     return (
       <MeetingsWidget
         destination={destination}
+        error={error}
         isReady={isReady}
+        onCallClick={this.props.onStartMeeting}
       />
     );
   }
@@ -51,6 +65,7 @@ export class ConnectedMeetingsWidget extends Component {
 
 ConnectedMeetingsWidget.propTypes = {
   ...injectedPropTypes,
+  ...handlerPropTypes,
   ...ownPropTypes
 };
 
@@ -59,5 +74,6 @@ export default compose(
   connect(
     getMeetingsWidgetProps
   ),
-  ...enhancers
+  ...enhancers,
+  handlers
 )(ConnectedMeetingsWidget);

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -34,6 +34,7 @@ const injectedPropTypes = {
 
 // Action props from handlers.js
 const handlerPropTypes = {
+  onLeaveMeeting: PropTypes.func,
   onStartMeeting: PropTypes.func
 };
 
@@ -74,6 +75,7 @@ export class ConnectedMeetingsWidget extends Component {
         meetingMedia={meetingMedia}
         meetingStatus={meetingStatus}
         onJoinClick={this.props.onStartMeeting}
+        onLeaveClick={this.props.onLeaveMeeting}
       />
     );
   }

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -3,28 +3,49 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {compose} from 'recompose';
 
-import LoadingScreen from '@webex/react-component-loading-screen';
+import getMeetingsWidgetProps from './selector';
+import enhancers from './enhancers';
+
+import MeetingsWidget from './components/MeetingsWidget';
+
+// Props injected via selector.js
+const injectedPropTypes = {
+  isReady: PropTypes.bool.isRequired
+};
 
 export const ownPropTypes = {
   destinationId: PropTypes.string.isRequired,
   destinationType: PropTypes.oneOf(['email', 'spaceId', 'userId', 'sip', 'pstn']).isRequired
 };
 
-export class MeetingsWidget extends Component {
+export class ConnectedMeetingsWidget extends Component {
+  // Component missing functionality?
+  // We are utilizing the "lifecycle" methods from recompose to reduce the
+  // amount of code in the main component.
+  // These files live in the "enhancers" folder.
+  // Note: these could be eventually replaced by react hooks,
+  // but are enhancers for consistency with the other widgets.
+
   shouldComponentUpdate(nextProps) {
     return nextProps !== this.props;
   }
 
   render() {
-    return <LoadingScreen />;
+    const {isReady} = this.props;
+
+    return <MeetingsWidget isReady={isReady} />;
   }
 }
 
-MeetingsWidget.propTypes = {
+ConnectedMeetingsWidget.propTypes = {
+  ...injectedPropTypes,
   ...ownPropTypes
 };
 
 
 export default compose(
-  connect()
-)(MeetingsWidget);
+  connect(
+    getMeetingsWidgetProps
+  ),
+  ...enhancers
+)(ConnectedMeetingsWidget);

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -25,6 +25,10 @@ const injectedPropTypes = {
   }),
   isReady: PropTypes.bool,
   meeting: PropTypes.object,
+  meetingMedia: PropTypes.shape({
+    localVideoStream: PropTypes.object,
+    remoteVideoStream: PropTypes.object
+  }),
   meetingStatus: PropTypes.object
 };
 
@@ -57,6 +61,7 @@ export class ConnectedMeetingsWidget extends Component {
       error,
       isReady,
       meeting,
+      meetingMedia,
       meetingStatus
     } = this.props;
 
@@ -66,6 +71,7 @@ export class ConnectedMeetingsWidget extends Component {
         error={error}
         isReady={isReady}
         meeting={meeting}
+        meetingMedia={meetingMedia}
         meetingStatus={meetingStatus}
         onJoinClick={this.props.onStartMeeting}
       />

--- a/packages/node_modules/@webex/widget-meetings/src/container.js
+++ b/packages/node_modules/@webex/widget-meetings/src/container.js
@@ -1,0 +1,30 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {compose} from 'recompose';
+
+import LoadingScreen from '@webex/react-component-loading-screen';
+
+export const ownPropTypes = {
+  destinationId: PropTypes.string.isRequired,
+  destinationType: PropTypes.oneOf(['email', 'spaceId', 'userId', 'sip', 'pstn']).isRequired
+};
+
+export class MeetingsWidget extends Component {
+  shouldComponentUpdate(nextProps) {
+    return nextProps !== this.props;
+  }
+
+  render() {
+    return <LoadingScreen />;
+  }
+}
+
+MeetingsWidget.propTypes = {
+  ...ownPropTypes
+};
+
+
+export default compose(
+  connect()
+)(MeetingsWidget);

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/errors.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/errors.js
@@ -1,0 +1,71 @@
+import {connect} from 'react-redux';
+import {compose, lifecycle} from 'recompose';
+import {bindActionCreators} from 'redux';
+import {addError, removeError} from '@ciscospark/redux-module-errors';
+
+import messages from '../messages';
+
+function checkForSDKErrors(props) {
+  const {
+    errors,
+    sdkState,
+    sdkInstance
+  } = props;
+  const {formatMessage} = props.intl;
+  const registerErrorId = 'sdk.register';
+
+  if (sdkState.registerError && (!errors.get('hasError') || !errors.get('errors').has(registerErrorId))) {
+    const error = sdkInstance.get('error');
+    let displaySubtitle = formatMessage(messages.unknownError);
+
+    if (error.statusCode === 401) {
+      displaySubtitle = formatMessage(messages.errorBadToken);
+    }
+    props.addError({
+      id: registerErrorId,
+      displayTitle: formatMessage(messages.unableToLoad),
+      displaySubtitle,
+      temporary: false,
+      code: error.statusCode
+    });
+  }
+}
+
+function checkForPropsErrors(props) {
+  const {
+    destinationId,
+    destinationType,
+    errors
+  } = props;
+  const {formatMessage} = props.intl;
+  const missingDestinationErrorId = 'meetings.missingDestination';
+
+  if ((!destinationId || !destinationType) && (!errors.get('hasError')
+      || !errors.get('errors').has(missingDestinationErrorId))) {
+    props.addError({
+      id: missingDestinationErrorId,
+      displayTitle: formatMessage(messages.missingDestination),
+      temporary: false
+    });
+  }
+}
+
+export default compose(
+  connect(
+    (state) => state,
+    (dispatch) => bindActionCreators({
+      addError,
+      removeError
+    }, dispatch)
+  ),
+  lifecycle({
+    componentWillMount() {
+      checkForSDKErrors(this.props);
+      checkForPropsErrors(this.props);
+    },
+    componentWillReceiveProps: (nextProps) => {
+      checkForSDKErrors(nextProps);
+      checkForPropsErrors(nextProps);
+    }
+  })
+);

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/index.js
@@ -1,0 +1,5 @@
+import setup from './setup';
+
+export default [
+  setup
+];

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/index.js
@@ -1,5 +1,7 @@
+import errors from './errors';
 import setup from './setup';
 
 export default [
+  errors,
   setup
 ];

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
@@ -12,6 +12,11 @@ import getMeetingsWidgetProps from '../selector';
 function fetchDestinationDetails(props) {
   const {sdkInstance, users} = props;
 
+  if (!props.destinationId || !props.destinationType) {
+    // This situation handled in errors.js
+    return;
+  }
+
   if (props.destinationType === destinationTypes.EMAIL) {
     // Get User ID
     const userID = users.getIn(['byEmail', props.destinationId]);

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
@@ -1,0 +1,74 @@
+import {compose, lifecycle} from 'recompose';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {connectToMercury} from '@ciscospark/redux-module-mercury';
+
+import getMeetingsWidgetProps from '../selector';
+
+
+/**
+ * Connects to the websocket server (mercury)
+ * @param {object} props
+ */
+function connectWebsocket(props) {
+  const {
+    sdkInstance,
+    mercuryStatus
+  } = props;
+
+
+  if (!mercuryStatus.hasConnected
+      && !mercuryStatus.connecting
+      && !mercuryStatus.connected
+      && sdkInstance.internal.device.registered) {
+    props.connectToMercury(sdkInstance);
+  }
+}
+
+
+/**
+ * The main setup process that proceeds through a series of events
+ * based on the state of the application.
+ *
+ * @export
+ * @param {*} props
+ */
+export function setup(props) {
+  const {
+    mercuryStatus,
+    sdkInstance,
+    sdkState
+  } = props;
+
+  // We cannot do anything until the sdk is ready
+  if (sdkInstance
+    && sdkState.authenticated
+    && sdkState.registered
+    && !sdkState.hasError
+  ) {
+    if (!mercuryStatus.connected) {
+      connectWebsocket(props);
+    }
+  }
+}
+
+export default compose(
+  connect(
+    getMeetingsWidgetProps,
+    (dispatch) => bindActionCreators({
+      connectToMercury
+    }, dispatch)
+  ),
+  lifecycle({
+    componentWillMount() {
+      setup(this.props);
+    },
+    shouldComponentUpdate(nextProps) {
+      return nextProps !== this.props;
+    },
+    componentWillReceiveProps(nextProps) {
+      setup(nextProps, this.props);
+    }
+  })
+);

--- a/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
+++ b/packages/node_modules/@webex/widget-meetings/src/enhancers/setup.js
@@ -3,9 +3,25 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {connectToMercury} from '@ciscospark/redux-module-mercury';
+import {getUser} from '@ciscospark/redux-module-users';
 
+import {destinationTypes} from '../index';
 import getMeetingsWidgetProps from '../selector';
 
+
+function fetchDestinationDetails(props) {
+  const {sdkInstance, users} = props;
+
+  if (props.destinationType === destinationTypes.EMAIL) {
+    // Get User ID
+    const userID = users.getIn(['byEmail', props.destinationId]);
+
+    // If it doesn't have a user id, start the request to get it
+    if (!userID) {
+      props.getUser({email: props.destinationId}, sdkInstance);
+    }
+  }
+}
 
 /**
  * Connects to the websocket server (mercury)
@@ -50,6 +66,9 @@ export function setup(props) {
     if (!mercuryStatus.connected) {
       connectWebsocket(props);
     }
+    else {
+      fetchDestinationDetails(props);
+    }
   }
 }
 
@@ -57,7 +76,8 @@ export default compose(
   connect(
     getMeetingsWidgetProps,
     (dispatch) => bindActionCreators({
-      connectToMercury
+      connectToMercury,
+      getUser
     }, dispatch)
   ),
   lifecycle({

--- a/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
@@ -2,7 +2,7 @@ import {compose, withHandlers} from 'recompose';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {addMediaToMeeting, createAndJoinMeeting} from '@webex/redux-module-meetings';
+import {addMediaToMeeting, createAndJoinMeeting, leaveMeeting} from '@webex/redux-module-meetings';
 
 function handleStartMeeting(props) {
   return () => {
@@ -33,15 +33,25 @@ function handleStartMeeting(props) {
   };
 }
 
+function handleLeaveMeeting(props) {
+  return () => {
+    const {destinationId, destinationType, sdkInstance} = props;
+
+    props.leaveMeeting({destinationId, destinationType}, sdkInstance);
+  };
+}
+
 export default compose(
   connect(
     null,
     (dispatch) => bindActionCreators({
       addMediaToMeeting,
-      createAndJoinMeeting
+      createAndJoinMeeting,
+      leaveMeeting
     }, dispatch)
   ),
   withHandlers({
+    onLeaveMeeting: handleLeaveMeeting,
     onStartMeeting: handleStartMeeting
   })
 );

--- a/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
@@ -2,13 +2,34 @@ import {compose, withHandlers} from 'recompose';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {createAndJoinMeeting} from '@webex/redux-module-meetings';
+import {addMediaToMeeting, createAndJoinMeeting} from '@webex/redux-module-meetings';
 
 function handleStartMeeting(props) {
   return () => {
     const {destinationId, destinationType, sdkInstance} = props;
 
-    props.createAndJoinMeeting({destinationId, destinationType}, sdkInstance);
+    props.createAndJoinMeeting({destinationId, destinationType}, sdkInstance)
+      .then((meeting) => {
+        // The store will get our meeting object from the sdk
+        const meetingId = meeting.id;
+
+        const receiveVideo = true;
+        const receiveAudio = true;
+        const receiveShare = true;
+        const sendVideo = true;
+        const sendAudio = true;
+        const sendShare = false;
+
+        props.addMediaToMeeting({
+          meetingId,
+          receiveVideo,
+          receiveAudio,
+          receiveShare,
+          sendVideo,
+          sendAudio,
+          sendShare
+        }, sdkInstance);
+      });
   };
 }
 
@@ -16,6 +37,7 @@ export default compose(
   connect(
     null,
     (dispatch) => bindActionCreators({
+      addMediaToMeeting,
       createAndJoinMeeting
     }, dispatch)
   ),

--- a/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
@@ -1,0 +1,25 @@
+import {compose, withHandlers} from 'recompose';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {createMeeting} from '@webex/redux-module-meetings';
+
+function handleStartMeeting(props) {
+  return () => {
+    const {destinationId, destinationType, sdkInstance} = props;
+
+    props.createMeeting({destinationId, destinationType}, sdkInstance);
+  };
+}
+
+export default compose(
+  connect(
+    null,
+    (dispatch) => bindActionCreators({
+      createMeeting
+    }, dispatch)
+  ),
+  withHandlers({
+    onStartMeeting: handleStartMeeting
+  })
+);

--- a/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/handlers/index.js
@@ -2,13 +2,13 @@ import {compose, withHandlers} from 'recompose';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {createMeeting} from '@webex/redux-module-meetings';
+import {createAndJoinMeeting} from '@webex/redux-module-meetings';
 
 function handleStartMeeting(props) {
   return () => {
     const {destinationId, destinationType, sdkInstance} = props;
 
-    props.createMeeting({destinationId, destinationType}, sdkInstance);
+    props.createAndJoinMeeting({destinationId, destinationType}, sdkInstance);
   };
 }
 
@@ -16,7 +16,7 @@ export default compose(
   connect(
     null,
     (dispatch) => bindActionCreators({
-      createMeeting
+      createAndJoinMeeting
     }, dispatch)
   ),
   withHandlers({

--- a/packages/node_modules/@webex/widget-meetings/src/index.html
+++ b/packages/node_modules/@webex/widget-meetings/src/index.html
@@ -1,0 +1,67 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Meetings Widget Demo</title>
+  <meta charset="utf8"/>
+</head>
+<body>
+<div style="float: left;">
+  <h2>Meetings Widget</h2>
+  <p>
+    <label for="accessTokenInput">Access Token</label>
+    <input type="password" placeholder="access token" id="accessTokenInput" value="<%= process.env.WEBEX_ACCESS_TOKEN %>" />
+  </p>
+  <p>
+    <label for="destinationInput">Destination ID</label>
+    <input id="destinationInput"/>
+  </p>
+  <p>
+    <label for="destinationTypeInput">Destination Type</label>
+    <select id="destinationTypeInput">
+        <option value="">--Please choose an option--</option>
+        <option value="email">email</option>
+        <option value="userId">userId</option>
+        <option value="spaceId">spaceId</option>
+        <option value="sip">sip</option>
+        <option value="pstn">pstn</option>
+    </select>
+  </p>
+  <button onClick="createWidget()">Create Widget</button>
+  <button onClick="removeWidget()">Remove Widget</button>
+  <div style="width: 500px; height: 500px;">
+    <div id="webex-widget-global"></div>
+  </div>
+  <div>Event: <span id="widget-events"></span></div>
+</div>
+
+<script type="text/javascript">
+var widgetEl = document.getElementById('webex-widget-global');
+var widgetEventsEl = document.getElementById('widget-events');
+var accessTokenInput = document.getElementById('accessTokenInput');
+var destinationInput = document.getElementById('destinationInput');
+var destinationTypeInput = document.getElementById('destinationTypeInput');
+function createWidget() {
+  var widget = window.ciscospark.widget(widgetEl);
+  widget.meetingsWidget({
+    accessToken: accessTokenInput.value,
+    destinationId: destinationInput.value,
+    destinationType: destinationTypeInput.value,
+    onEvent: function(name, data) {
+      widgetEventsEl.innerText = name+'\n'+JSON.stringify(data, null, 2);
+      console.log(data);
+    }
+  });
+}
+
+function removeWidget() {
+  var widget = ciscospark.widget(widgetEl);
+  if (widget.remove) {
+    widget.remove();
+  }
+}
+
+</script>
+
+</body>
+</html>

--- a/packages/node_modules/@webex/widget-meetings/src/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/index.js
@@ -1,0 +1,23 @@
+import {compose} from 'recompose';
+import {constructSparkEnhancer, withIntl} from '@ciscospark/spark-widget-base';
+import {enhancer as mercuryEnhancer} from '@ciscospark/redux-module-mercury';
+
+import ConnectedMeetings from './container';
+
+import messages from './translations/en';
+
+export const destinationTypes = {
+  SIP: 'sip',
+  EMAIL: 'email',
+  USERID: 'userId',
+  SPACEID: 'spaceId',
+  PSTN: 'pstn'
+};
+
+export default compose(
+  constructSparkEnhancer({
+    name: 'meetings'
+  }),
+  withIntl({locale: 'en', messages}),
+  mercuryEnhancer
+)(ConnectedMeetings);

--- a/packages/node_modules/@webex/widget-meetings/src/index.js
+++ b/packages/node_modules/@webex/widget-meetings/src/index.js
@@ -1,10 +1,13 @@
 import {compose} from 'recompose';
 import {constructSparkEnhancer, withIntl} from '@ciscospark/spark-widget-base';
-import {enhancer as mercuryEnhancer} from '@ciscospark/redux-module-mercury';
 
-import ConnectedMeetings from './container';
+import ConnectedMeetingsWidget from './container';
+
+import reducers from './reducer';
 
 import messages from './translations/en';
+
+export {reducers};
 
 export const destinationTypes = {
   SIP: 'sip',
@@ -16,8 +19,8 @@ export const destinationTypes = {
 
 export default compose(
   constructSparkEnhancer({
-    name: 'meetings'
+    name: 'meetings',
+    reducers
   }),
-  withIntl({locale: 'en', messages}),
-  mercuryEnhancer
-)(ConnectedMeetings);
+  withIntl({locale: 'en', messages})
+)(ConnectedMeetingsWidget);

--- a/packages/node_modules/@webex/widget-meetings/src/messages.js
+++ b/packages/node_modules/@webex/widget-meetings/src/messages.js
@@ -1,0 +1,25 @@
+/*
+ * WidgetRecents Messages
+ *
+ * This contains all the text for the FeaturePage component.
+ */
+import {defineMessages} from 'react-intl';
+
+export default defineMessages({
+  errorBadToken: {
+    id: 'webex.container.meetings.error.badtoken',
+    defaultMessage: 'Error: Bad or Invalid Access Token'
+  },
+  missingDestination: {
+    id: 'webex.container.meetings.error.missingDestination',
+    defaultMessage: 'Error: Destination ID and Type Required'
+  },
+  unableToLoad: {
+    id: 'webex.container.meetings.error.unabletoload',
+    defaultMessage: 'Unable to Load Meeting'
+  },
+  unknownError: {
+    id: 'webex.container.meetings.error.unknown',
+    defaultMessage: 'There was a problem loading meeting'
+  }
+});

--- a/packages/node_modules/@webex/widget-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/widget-meetings/src/reducer.js
@@ -1,10 +1,12 @@
 import avatar from '@ciscospark/redux-module-avatar';
+import errors from '@ciscospark/redux-module-errors';
 import mercury from '@ciscospark/redux-module-mercury';
-import users from '@ciscospark/redux-module-users';
 import presence from '@ciscospark/redux-module-presence';
+import users from '@ciscospark/redux-module-users';
 
 export const reducers = {
   avatar,
+  errors,
   mercury,
   presence,
   users

--- a/packages/node_modules/@webex/widget-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/widget-meetings/src/reducer.js
@@ -1,12 +1,15 @@
 import avatar from '@ciscospark/redux-module-avatar';
 import errors from '@ciscospark/redux-module-errors';
+import meetings from '@webex/redux-module-meetings';
 import mercury from '@ciscospark/redux-module-mercury';
 import presence from '@ciscospark/redux-module-presence';
 import users from '@ciscospark/redux-module-users';
 
+
 export const reducers = {
   avatar,
   errors,
+  meetings,
   mercury,
   presence,
   users

--- a/packages/node_modules/@webex/widget-meetings/src/reducer.js
+++ b/packages/node_modules/@webex/widget-meetings/src/reducer.js
@@ -1,0 +1,14 @@
+import avatar from '@ciscospark/redux-module-avatar';
+import mercury from '@ciscospark/redux-module-mercury';
+import users from '@ciscospark/redux-module-users';
+import presence from '@ciscospark/redux-module-presence';
+
+export const reducers = {
+  avatar,
+  mercury,
+  presence,
+  users
+};
+
+export default reducers;
+

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -1,15 +1,40 @@
 import {createSelector} from 'reselect';
 
 import {PENDING_STATUS} from '@ciscospark/redux-module-users';
+import {buildDestinationLookup} from '@webex/redux-module-meetings';
 
 import {destinationTypes} from './index';
 
 const getErrors = (state) => state.errors;
+const getMeetings = (state) => state.meetings;
 const getSDKState = (state) => state.spark.get('status');
 const getSDKInstance = (state) => state.spark.get('spark');
 const getMercuryStatus = (state) => state.mercury.get('status');
 const getUsers = (state) => state.users;
 const getOwnProps = (state, ownProps) => ownProps;
+
+const getMeetingDetails = createSelector(
+  [getMeetings, getSDKInstance, getOwnProps],
+  (meetings, sdkInstance, props) => {
+    let meeting;
+    let meetingStatus = {};
+
+    const {destinationId, destinationType} = props;
+    const meetingId = meetings.getIn(['byDestination', buildDestinationLookup({destinationType, destinationId})]);
+
+    if (meetingId) {
+      // Get the meeting object from the SDK collection
+      meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
+      // Get the meeting status from the store
+      meetingStatus = meetings.getIn(['byId', meetingId]);
+    }
+
+    return {
+      meeting,
+      meetingStatus
+    };
+  }
+);
 
 const getDestinationDetails = createSelector(
   [getUsers, getOwnProps],
@@ -43,8 +68,8 @@ const getDestinationDetails = createSelector(
 );
 
 const getMeetingsWidgetProps = createSelector(
-  [getSDKState, getSDKInstance, getMercuryStatus, getDestinationDetails, getErrors],
-  (sdkState, sdkInstance, mercuryStatusRedux, destination, errors) => {
+  [getSDKState, getSDKInstance, getMercuryStatus, getDestinationDetails, getErrors, getMeetingDetails],
+  (sdkState, sdkInstance, mercuryStatusRedux, destination, errors, meetingDetails) => {
     let error;
 
     // Check error store for an error
@@ -59,10 +84,14 @@ const getMeetingsWidgetProps = createSelector(
     const isReady = sdkState.authenticated && sdkState.registered && !sdkState.hasError &&
       mercuryStatus.hasConnected && destination.displayName && !error;
 
+    const {meeting, meetingStatus} = meetingDetails;
+
     return {
       destination,
       error,
       isReady,
+      meeting,
+      meetingStatus,
       mercuryStatus,
       sdkState,
       sdkInstance

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -1,0 +1,26 @@
+import {createSelector} from 'reselect';
+
+const getSDKState = (state) => state.spark.get('status');
+const getSDKInstance = (state) => state.spark.get('spark');
+const getMercuryStatus = (state) => state.mercury.get('status');
+
+const getMeetingsWidgetProps = createSelector(
+  [getSDKState, getSDKInstance, getMercuryStatus],
+  (sdkState, sdkInstance, mercuryStatusRedux) => {
+    // Mercury Status isn't a Redux Record yet, convert to js
+    const mercuryStatus = mercuryStatusRedux.toJS();
+
+    // Meetings Widget is ready when SDK has device registered and websockets are connected
+    const isReady = sdkState.authenticated && sdkState.registered && !sdkState.hasError &&
+      mercuryStatus.hasConnected;
+
+    return {
+      isReady,
+      mercuryStatus,
+      sdkState,
+      sdkInstance
+    };
+  }
+);
+
+export default getMeetingsWidgetProps;

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -30,7 +30,7 @@ const getMeetingDetails = createSelector(
       // Get the meeting object from the SDK collection
       meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
 
-      if (meeting) {
+      if (meeting && meetingStatus.joined) {
         // Get the meeting media from the meeting instance
         let remoteVideoStream;
 

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -4,6 +4,7 @@ import {PENDING_STATUS} from '@ciscospark/redux-module-users';
 
 import {destinationTypes} from './index';
 
+const getErrors = (state) => state.errors;
 const getSDKState = (state) => state.spark.get('status');
 const getSDKInstance = (state) => state.spark.get('spark');
 const getMercuryStatus = (state) => state.mercury.get('status');
@@ -42,17 +43,25 @@ const getDestinationDetails = createSelector(
 );
 
 const getMeetingsWidgetProps = createSelector(
-  [getSDKState, getSDKInstance, getMercuryStatus, getDestinationDetails],
-  (sdkState, sdkInstance, mercuryStatusRedux, destination) => {
+  [getSDKState, getSDKInstance, getMercuryStatus, getDestinationDetails, getErrors],
+  (sdkState, sdkInstance, mercuryStatusRedux, destination, errors) => {
+    let error;
+
+    // Check error store for an error
+    if (errors.get('hasError')) {
+      error = errors.get('errors').first();
+    }
+
     // Mercury Status isn't a Redux Record yet, convert to js
     const mercuryStatus = mercuryStatusRedux.toJS();
 
     // Meetings Widget is ready when SDK has device registered and websockets are connected
     const isReady = sdkState.authenticated && sdkState.registered && !sdkState.hasError &&
-      mercuryStatus.hasConnected && destination.displayName;
+      mercuryStatus.hasConnected && destination.displayName && !error;
 
     return {
       destination,
+      error,
       isReady,
       mercuryStatus,
       sdkState,

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -1,20 +1,58 @@
 import {createSelector} from 'reselect';
 
+import {PENDING_STATUS} from '@ciscospark/redux-module-users';
+
+import {destinationTypes} from './index';
+
 const getSDKState = (state) => state.spark.get('status');
 const getSDKInstance = (state) => state.spark.get('spark');
 const getMercuryStatus = (state) => state.mercury.get('status');
+const getUsers = (state) => state.users;
+const getOwnProps = (state, ownProps) => ownProps;
+
+const getDestinationDetails = createSelector(
+  [getUsers, getOwnProps],
+  (users, props) => {
+    let avatarId, displayName;
+
+    if (props.destinationType === destinationTypes.EMAIL) {
+      // Get User ID from store
+      const userId = users.getIn(['byEmail', props.destinationId]);
+
+      if (userId && userId !== PENDING_STATUS) {
+        avatarId = userId;
+
+        // Get Display name from store
+        const user = users.getIn(['byId', userId]);
+
+        if (user) {
+          ({displayName} = user);
+        }
+      }
+    }
+
+    const destination = {
+      id: avatarId,
+      avatarImage: '',
+      displayName
+    };
+
+    return destination;
+  }
+);
 
 const getMeetingsWidgetProps = createSelector(
-  [getSDKState, getSDKInstance, getMercuryStatus],
-  (sdkState, sdkInstance, mercuryStatusRedux) => {
+  [getSDKState, getSDKInstance, getMercuryStatus, getDestinationDetails],
+  (sdkState, sdkInstance, mercuryStatusRedux, destination) => {
     // Mercury Status isn't a Redux Record yet, convert to js
     const mercuryStatus = mercuryStatusRedux.toJS();
 
     // Meetings Widget is ready when SDK has device registered and websockets are connected
     const isReady = sdkState.authenticated && sdkState.registered && !sdkState.hasError &&
-      mercuryStatus.hasConnected;
+      mercuryStatus.hasConnected && destination.displayName;
 
     return {
+      destination,
       isReady,
       mercuryStatus,
       sdkState,

--- a/packages/node_modules/@webex/widget-meetings/src/selector.js
+++ b/packages/node_modules/@webex/widget-meetings/src/selector.js
@@ -18,19 +18,37 @@ const getMeetingDetails = createSelector(
   (meetings, sdkInstance, props) => {
     let meeting;
     let meetingStatus = {};
+    let meetingMedia = {};
 
     const {destinationId, destinationType} = props;
     const meetingId = meetings.getIn(['byDestination', buildDestinationLookup({destinationType, destinationId})]);
 
     if (meetingId) {
-      // Get the meeting object from the SDK collection
-      meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
       // Get the meeting status from the store
       meetingStatus = meetings.getIn(['byId', meetingId]);
+
+      // Get the meeting object from the SDK collection
+      meeting = sdkInstance.meetings.meetingCollection.meetings[meetingId];
+
+      if (meeting) {
+        // Get the meeting media from the meeting instance
+        let remoteVideoStream;
+
+        if (meetingStatus.hasRemoteVideo || meetingStatus.hasRemoteAudio) {
+          remoteVideoStream = meeting.mediaProperties.remoteStream;
+        }
+
+        meetingMedia = {
+          // Only local tracks are in the SDK, so create a stream from it
+          localVideoStream: meetingStatus.hasLocalMedia && new MediaStream([meeting.mediaProperties.videoTrack]),
+          remoteVideoStream
+        };
+      }
     }
 
     return {
       meeting,
+      meetingMedia,
       meetingStatus
     };
   }
@@ -84,13 +102,14 @@ const getMeetingsWidgetProps = createSelector(
     const isReady = sdkState.authenticated && sdkState.registered && !sdkState.hasError &&
       mercuryStatus.hasConnected && destination.displayName && !error;
 
-    const {meeting, meetingStatus} = meetingDetails;
+    const {meeting, meetingMedia, meetingStatus} = meetingDetails;
 
     return {
       destination,
       error,
       isReady,
       meeting,
+      meetingMedia,
       meetingStatus,
       mercuryStatus,
       sdkState,

--- a/packages/node_modules/@webex/widget-meetings/src/translations/en.js
+++ b/packages/node_modules/@webex/widget-meetings/src/translations/en.js
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
# Initial framework for the meetings widget. 

This PR adds the new "meetings-widget" that utilizes the meetings plugin of the SDK. This PR is meant as a foundation for contributions for the meetings widget and should not be assumed to be ready for release.

The widget currently only supports email destinations.

## Things currently supported

* Creating a meeting with an email destination
* Joining the meeting and adding media
* Leaving the meeting

## Not supported

* Other destination types
* Local/remote media controls
* Screen sharing
* Journey testing

## How to run:
`npm run serve:package widget-meetings`

## Example
![image](https://user-images.githubusercontent.com/190647/64546915-8e717280-d2f9-11e9-9ea8-c6d904ad796a.png)

## Note

Commits have not been squashed in order to help external (web) team to better understand the development process for widgets. 

There are quite a few layers of abstraction in this widget in preparation for possible conversion to webex components system. 