### PR TITLE
Fixing tap tests for stability and hydra support

### DIFF
--- a/test/journeys/lib/test-helpers/space-widget/main.js
+++ b/test/journeys/lib/test-helpers/space-widget/main.js
@@ -29,6 +29,9 @@ export function switchToMessage(aBrowser) {
   }
   aBrowser.waitForVisible(elements.messageActivityButton);
   aBrowser.click(elements.messageActivityButton);
+
+  // Activity menu animates the hide, wait for it to be gone
+  aBrowser.waitForVisible(elements.activityMenu, 1500, true);
 }
 
 /**

--- a/test/journeys/specs/tap/widget-space/oneOnOne.js
+++ b/test/journeys/specs/tap/widget-space/oneOnOne.js
@@ -10,7 +10,7 @@ import {setupOneOnOneUsers} from '../../../lib/test-users';
 describe('Widget Space: One on One: TAP', () => {
   const browserLocal = browser.select('browserLocal');
   const browserRemote = browser.select('browserRemote');
-  let local, mccoy, remote, spock;
+  let local, localUser, remote, remoteUser;
 
   before('load browsers', () => {
     browser
@@ -21,18 +21,18 @@ describe('Widget Space: One on One: TAP', () => {
   });
 
   before('create test users', () => {
-    [mccoy, spock] = setupOneOnOneUsers();
-    local = {browser: browserLocal, user: mccoy, displayName: mccoy.displayName};
-    remote = {browser: browserRemote, user: spock, displayName: spock.displayName};
+    [localUser, remoteUser] = setupOneOnOneUsers();
+    local = {browser: browserLocal, user: localUser, displayName: localUser.displayName};
+    remote = {browser: browserRemote, user: remoteUser, displayName: remoteUser.displayName};
   });
 
-  before('inject token for spock', () => {
-    loginAndOpenWidget(local.browser, spock.token.access_token, true, mccoy.email);
+  before('inject token for local user', () => {
+    loginAndOpenWidget(local.browser, local.user.token.access_token, true, remote.user.email);
     local.browser.waitForExist(`[placeholder="Send a message to ${remote.displayName}"]`, 30000);
   });
 
-  before('open remote widget for mccoy', () => {
-    loginAndOpenWidget(remote.browser, mccoy.token.access_token, true, spock.email);
+  before('open remote widget for remote user', () => {
+    loginAndOpenWidget(remote.browser, remote.user.token.access_token, true, local.user.email);
     remote.browser.waitForExist(`[placeholder="Send a message to ${local.displayName}"]`, 30000);
   });
 
@@ -63,6 +63,7 @@ describe('Widget Space: One on One: TAP', () => {
 
     it('closes the menu with the exit button', () => {
       local.browser.click(basicElements.exitButton);
+      // Activity menu animates the hide, wait for it to be gone
       local.browser.waitForVisible(basicElements.activityMenu, 1500, true);
     });
 
@@ -76,6 +77,8 @@ describe('Widget Space: One on One: TAP', () => {
 
     it('switches to message widget', () => {
       local.browser.element(basicElements.controlsContainer).element(basicElements.messageActivityButton).click();
+      // Activity menu animates the hide, wait for it to be gone
+      local.browser.waitForVisible(basicElements.activityMenu, 1500, true);
       assert.isTrue(local.browser.isVisible(basicElements.messageWidget));
       assert.isFalse(local.browser.isVisible(basicElements.meetWidget));
     });
@@ -87,6 +90,8 @@ describe('Widget Space: One on One: TAP', () => {
 
     it('switches to meet widget', () => {
       local.browser.element(basicElements.controlsContainer).element(basicElements.meetActivityButton).click();
+      // Activity menu animates the hide, wait for it to be gone
+      local.browser.waitForVisible(basicElements.activityMenu, 1500, true);
       assert.isTrue(local.browser.isVisible(basicElements.meetWidget));
       assert.isFalse(local.browser.isVisible(basicElements.messageWidget));
     });

--- a/test/journeys/specs/tap/widget-space/oneOnOne.js
+++ b/test/journeys/specs/tap/widget-space/oneOnOne.js
@@ -1,12 +1,11 @@
 import {assert} from 'chai';
 
-import testUsers from '@webex/test-helper-test-users';
-
 import {elements as basicElements, switchToMeet, switchToMessage} from '../../../lib/test-helpers/space-widget/main';
 import {clearEventLog, getEventLog} from '../../../lib/events';
 import {sendMessage, verifyMessageReceipt} from '../../../lib/test-helpers/space-widget/messaging';
 import {elements, declineIncomingCallTest, hangupDuringCallTest} from '../../../lib/test-helpers/space-widget/meet';
 import loginAndOpenWidget from '../../../lib/test-helpers/tap/space';
+import {setupOneOnOneUsers} from '../../../lib/test-users';
 
 describe('Widget Space: One on One: TAP', () => {
   const browserLocal = browser.select('browserLocal');
@@ -21,19 +20,11 @@ describe('Widget Space: One on One: TAP', () => {
       });
   });
 
-  before('create spock', () => testUsers.create({count: 1, config: {displayName: 'Mr Spock TAP'}})
-    .then((users) => {
-      [spock] = users;
-      local = {browser: browserLocal, user: spock, displayName: spock.displayName};
-    }));
-
-  before('create mccoy', () => testUsers.create({count: 1, config: {displayName: 'Bones Mccoy TAP'}})
-    .then((users) => {
-      [mccoy] = users;
-      remote = {browser: browserRemote, user: mccoy, displayName: mccoy.displayName};
-    }));
-
-  before('pause to let test users establish', () => browser.pause(5000));
+  before('create test users', () => {
+    [mccoy, spock] = setupOneOnOneUsers();
+    local = {browser: browserLocal, user: mccoy, displayName: mccoy.displayName};
+    remote = {browser: browserRemote, user: spock, displayName: spock.displayName};
+  });
 
   before('inject token for spock', () => {
     loginAndOpenWidget(local.browser, spock.token.access_token, true, mccoy.email);

--- a/test/journeys/specs/tap/widget-space/space.js
+++ b/test/journeys/specs/tap/widget-space/space.js
@@ -50,6 +50,13 @@ describe('Widget Space: Group Space: TAP', () => {
     remote.browser.waitForExist(`[placeholder="Send a message to ${conversation.displayName}"]`, 30000);
   });
 
+  before('stick widgets to bottom of viewport', () => {
+    local.browser.waitForVisible(elements.stickyButton);
+    local.browser.click(elements.stickyButton);
+    remote.browser.waitForVisible(elements.stickyButton);
+    remote.browser.click(elements.stickyButton);
+  });
+
   after('disconnect', () => Promise.all([
     disconnectDevices(participants),
     // Demos use cookies to save state, clear before moving on
@@ -80,29 +87,42 @@ describe('Widget Space: Group Space: TAP', () => {
 
     it('has a message button', () => {
       local.browser.click(elements.menuButton);
-      local.browser.element(elements.controlsContainer).element(elements.messageButton).waitForVisible();
+      local.browser
+        .element(elements.controlsContainer)
+        .element(elements.messageActivityButton)
+        .waitForVisible();
     });
 
     it('switches to message widget', () => {
-      local.browser.element(elements.controlsContainer).element(elements.messageButton).click();
+      local.browser.element(elements.controlsContainer).element(elements.messageActivityButton).click();
       // Activity menu animates the hide, wait for it to be gone
       local.browser.waitForVisible(elements.activityMenu, 1500, true);
       assert.isTrue(local.browser.isVisible(elements.messageWidget));
+      assert.isFalse(local.browser.isVisible(elements.meetWidget));
+    });
+
+    it('has a meet button', () => {
+      local.browser.click(elements.menuButton);
+      local.browser.element(elements.controlsContainer).element(elements.meetActivityButton).waitForVisible();
+    });
+
+    it('switches to meet widget', () => {
+      local.browser.element(elements.controlsContainer).element(elements.meetActivityButton).click();
+      // Activity menu animates the hide, wait for it to be gone
+      local.browser.waitForVisible(elements.activityMenu, 1500, true);
+      assert.isTrue(local.browser.isVisible(elements.meetWidget));
+      assert.isFalse(local.browser.isVisible(elements.messageWidget));
     });
   });
 
   describe('messaging', () => {
-    before('widget switches to message', () => {
-      switchToMessage(local.browser);
-      switchToMessage(remote.browser);
-    });
-
     it('sends and receives messages', () => {
       const martyText = 'Wait a minute. Wait a minute, Doc. Ah... Are you telling me that you built a time machine... out of a DeLorean?';
       const docText = 'The way I see it, if you\'re gonna build a time machine into a car, why not do it with some style?';
       const lorraineText = 'Marty, will we ever see you again?';
       const martyText2 = 'I guarantee it.';
 
+      switchToMessage(local.browser);
       sendMessage(local, remote, martyText);
       verifyMessageReceipt(remote, local, martyText);
       clearEventLog(local.browser);

--- a/test/journeys/specs/tap/widget-space/space.js
+++ b/test/journeys/specs/tap/widget-space/space.js
@@ -74,6 +74,7 @@ describe('Widget Space: Group Space: TAP', () => {
 
     it('closes the menu with the exit button', () => {
       local.browser.click(elements.exitButton);
+      // Activity menu animates the hide, wait for it to be gone
       local.browser.waitForVisible(elements.activityMenu, 1500, true);
     });
 
@@ -84,6 +85,8 @@ describe('Widget Space: Group Space: TAP', () => {
 
     it('switches to message widget', () => {
       local.browser.element(elements.controlsContainer).element(elements.messageButton).click();
+      // Activity menu animates the hide, wait for it to be gone
+      local.browser.waitForVisible(elements.activityMenu, 1500, true);
       assert.isTrue(local.browser.isVisible(elements.messageWidget));
     });
   });


### PR DESCRIPTION
Tap tests were failing due to them not being updated with the hydraid support for space destination. This PR converts the TAP tests to using the test user helper methods for space and user creation.

There are also some optimizations added due to animations not being disabled on the production server. This was causing click events to not register properly because the activity menu was not fully animated away before the click was attempted.