### PR TITLE
chore(circle-ci): live demos missing script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,23 +181,12 @@ jobs:
           command: |
             export NODE_ENV=production
             export WEBEX_SCOPE="Identity:OAuthClient webexsquare:get_conversation webexsquare:admin spark:people_read spark:rooms_read spark:rooms_write spark:memberships_read spark:memberships_write spark:messages_read spark:messages_write spark:applications_read spark:applications_write spark:teams_read spark:teams_write spark:team_memberships_read spark:team_memberships_write spark:bots_read spark:bots_write spark:kms"
-
             BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/" npm run build:package widget-space
-
             BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/" npm run build sri widget-space
-
-            BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/"
-
-            BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/demo/" npm run build:package widget-space-demo
-
+            BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/" BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${VERSION}/demo/" npm run build:package widget-space-demo
             BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/" npm run build:package widget-recents
-
             BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/" npm run build sri widget-recents
-
-            BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/"
-
-            BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/demo/" npm run build:package widget-recents-demo
-
+            BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/" BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${VERSION}/demo/" npm run build:package widget-recents-demo
             BUILD_PUBLIC_PATH="https://code.s4d.io/widget-demo/archives/${VERSION}/" npm run build:package widget-demo
 
             npm run es5-check:dist


### PR DESCRIPTION
Fix the build path error that prevents the widgets
demo from running on the live sample.

# Pull Request

## Description

This pull request addresses the current issue with the public demos not containing the correct script to allow them to operate successfully.

Fixes # (issue)

SPARK-101841

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
