### PR TITLE
Support notifications for adaptive cards

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-utils/src/constants.js
+++ b/packages/node_modules/@ciscospark/react-component-utils/src/constants.js
@@ -72,6 +72,7 @@ export const TAG_MUTED = 'MUTED';
 export const CARD_ATTACHMENT_TYPE = 'AdaptiveCard';
 export const CARD_CONTAINS_IMAGE = 'cardReference';
 export const ACTIVITY_CARDS = 'cards';
+export const MESSAGE_CONTAINS_IMAGES = 'images';
 
 export const FEATURES_DEVELOPER = 'developer';
 export const FEATURES_WIDGET_ADAPTIVE_CARD = 'WIDGET_ADAPTIVE_CARD';

--- a/packages/node_modules/@ciscospark/react-component-utils/src/constants.js
+++ b/packages/node_modules/@ciscospark/react-component-utils/src/constants.js
@@ -72,7 +72,7 @@ export const TAG_MUTED = 'MUTED';
 export const CARD_ATTACHMENT_TYPE = 'AdaptiveCard';
 export const CARD_CONTAINS_IMAGE = 'cardReference';
 export const ACTIVITY_CARDS = 'cards';
-export const MESSAGE_CONTAINS_IMAGES = 'images';
+export const ACTIVITY_OBJECT_CONTENT_CATEGORY_IMAGES = 'images';
 
 export const FEATURES_DEVELOPER = 'developer';
 export const FEATURES_WIDGET_ADAPTIVE_CARD = 'WIDGET_ADAPTIVE_CARD';

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -8,7 +8,7 @@ import {debounce, has, throttle, filter} from 'lodash';
 import {autobind} from 'core-decorators';
 import {compose} from 'recompose';
 
-import {constructFiles, API_ACTIVITY_VERB, CARD_CONTAINS_IMAGE, MESSAGE_CONTAINS_IMAGES} from '@ciscospark/react-component-utils';
+import {constructFiles, API_ACTIVITY_VERB, CARD_CONTAINS_IMAGE, ACTIVITY_OBJECT_CONTENT_CATEGORY_IMAGES} from '@ciscospark/react-component-utils';
 
 import {fetchAvatarsForUsers} from '@ciscospark/redux-module-avatar';
 
@@ -263,7 +263,7 @@ export class MessageWidget extends Component {
             }
             else if (lastActivityFromThis.verb === API_ACTIVITY_VERB.SHARE && lastActivityFromThis.object.files
               && lastActivityFromThis.object.files.items
-              && lastActivityFromThis.object.contentCategory === MESSAGE_CONTAINS_IMAGES) {
+              && lastActivityFromThis.object.contentCategory === ACTIVITY_OBJECT_CONTENT_CATEGORY_IMAGES) {
               const cardImagesLength
             = lastActivityFromThis.object.files.items.filter((item) => item.type === CARD_CONTAINS_IMAGE).length;
               const itemsLength = lastActivityFromThis.object.files.items.length;

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -8,7 +8,7 @@ import {debounce, has, throttle, filter} from 'lodash';
 import {autobind} from 'core-decorators';
 import {compose} from 'recompose';
 
-import {constructFiles} from '@ciscospark/react-component-utils';
+import {constructFiles, API_ACTIVITY_VERB, CARD_CONTAINS_IMAGE, MESSAGE_CONTAINS_IMAGES} from '@ciscospark/react-component-utils';
 
 import {fetchAvatarsForUsers} from '@ciscospark/redux-module-avatar';
 
@@ -249,27 +249,32 @@ export class MessageWidget extends Component {
         // Send notification of new message
         const avatars = props.avatar.get('items');
         let cardsLength = 0;
-        let message = lastActivityFromThis.object.displayName;
+        let message;
 
-        if (Object.prototype.hasOwnProperty.call(lastActivityFromThis, 'object')
-        && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object, 'cards') && lastActivityFromThis.object.cards.length > 0) {
-          cardsLength = lastActivityFromThis.object.cards.length;
-          const sharedCardsNotificationFormat = formatMessage(messages.sharedCards, {cardsLength});
+        if (lastActivityFromThis.object) {
+          message = lastActivityFromThis.object.displayName;
 
-          if (lastActivityFromThis.verb === 'post') {
-            message = sharedCardsNotificationFormat;
-          }
-          else if (lastActivityFromThis.verb === 'share' && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object, 'files') && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object.files, 'items')
-          && lastActivityFromThis.object.contentCategory === 'images') {
-            const cardImagesLength = lastActivityFromThis.object.files.items.filter((item) => item.type === 'cardReference').length;
-            const itemsLength = lastActivityFromThis.object.files.items.length;
-            const sharedPhotosNotificationFormat
+          if (lastActivityFromThis.object.cards && lastActivityFromThis.object.cards.length > 0) {
+            cardsLength = lastActivityFromThis.object.cards.length;
+            const sharedCardsNotificationMessage = formatMessage(messages.sharedCards, {cardsLength});
+
+            if (lastActivityFromThis.verb === API_ACTIVITY_VERB.POST) {
+              message = sharedCardsNotificationMessage;
+            }
+            else if (lastActivityFromThis.verb === API_ACTIVITY_VERB.SHARE && lastActivityFromThis.object.files
+              && lastActivityFromThis.object.files.items
+              && lastActivityFromThis.object.contentCategory === MESSAGE_CONTAINS_IMAGES) {
+              const cardImagesLength
+            = lastActivityFromThis.object.files.items.filter((item) => item.type === CARD_CONTAINS_IMAGE).length;
+              const itemsLength = lastActivityFromThis.object.files.items.length;
+              const sharedPhotosNotificationMessage
             = formatMessage(messages.sharedPhotos, {imagesLength: itemsLength - cardImagesLength});
 
-            message
+              message
             = cardImagesLength === itemsLength
-                ? sharedCardsNotificationFormat
-                : sharedPhotosNotificationFormat;
+                  ? sharedCardsNotificationMessage
+                  : sharedPhotosNotificationMessage;
+            }
           }
         }
         const details = {

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -221,6 +221,7 @@ export class MessageWidget extends Component {
       props,
       activityList
     } = this;
+    const {formatMessage} = this.props.intl;
 
     if (activityList) {
       const {
@@ -247,9 +248,33 @@ export class MessageWidget extends Component {
       ) {
         // Send notification of new message
         const avatars = props.avatar.get('items');
+        let cardsLength = 0;
+        let message = lastActivityFromThis.object.displayName;
+
+        if (Object.prototype.hasOwnProperty.call(lastActivityFromThis, 'object')
+        && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object, 'cards') && lastActivityFromThis.object.cards.length > 0) {
+          cardsLength = lastActivityFromThis.object.cards.length;
+          const sharedCardsNotificationFormat = formatMessage(messages.sharedCards, {cardsLength});
+
+          if (lastActivityFromThis.verb === 'post') {
+            message = sharedCardsNotificationFormat;
+          }
+          else if (lastActivityFromThis.verb === 'share' && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object, 'files') && Object.prototype.hasOwnProperty.call(lastActivityFromThis.object.files, 'items')
+          && lastActivityFromThis.object.contentCategory === 'images') {
+            const cardImagesLength = lastActivityFromThis.object.files.items.filter((item) => item.type === 'cardReference').length;
+            const itemsLength = lastActivityFromThis.object.files.items.length;
+            const sharedPhotosNotificationFormat
+            = formatMessage(messages.sharedPhotos, {imagesLength: itemsLength - cardImagesLength});
+
+            message
+            = cardImagesLength === itemsLength
+                ? sharedCardsNotificationFormat
+                : sharedPhotosNotificationFormat;
+          }
+        }
         const details = {
           username: lastActivityFromThis.actor.displayName,
-          message: lastActivityFromThis.object.displayName,
+          message,
           avatar: avatars.get(lastActivityFromThis.actor.id),
           alertType: lastActivityFromThis.alertType
         };

--- a/packages/node_modules/@ciscospark/widget-message/src/messages.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/messages.js
@@ -41,5 +41,13 @@ export default defineMessages({
   scrollToBottom: {
     id: 'ciscospark.container.message.scrollToBottom',
     defaultMessage: 'Click to scroll to latest messages'
+  },
+  sharedCards: {
+    id: 'ciscospark.container.message.sharedCards',
+    defaultMessage: '{cardsLength, plural, =1 {Responded with a card} other {Responded with # cards}}'
+  },
+  sharedPhotos: {
+    id: 'ciscospark.container.message.sharedPhotos',
+    defaultMessage: '{imagesLength, plural, =1 {Shared a photo} other {Shared # photos}}'
   }
 });

--- a/packages/node_modules/@ciscospark/widget-message/src/translations/en.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/translations/en.js
@@ -11,5 +11,7 @@ export default {
   'ciscospark.datetime.yesterday': 'Yesterday',
   'ciscospark.container.message.scrollToBottom': 'Click to scroll to latest messages',
   'ciscospark.container.message.newMessages.message': 'NEW MESSAGES',
-  'ciscospark.container.message.dropzone.coverMessage': 'Drag and drop your files here'
+  'ciscospark.container.message.dropzone.coverMessage': 'Drag and drop your files here',
+  'ciscospark.container.message.sharedCards': '{cardsLength, plural, =1 {Responded with a card} other {Responded with # cards}}',
+  'ciscospark.container.message.sharedPhotos': '{imagesLength, plural, =1 {Shared a photo} other {Shared # photos}}'
 };


### PR DESCRIPTION
Description of changes made (Required)
* Added code to get a notification same as 'web client' when the message contains an adaptive card

For example:
* When a message only contains an adaptive card  with /without an image in it (without normal images )then notification be 'Responded with a card /Responded with {number} cards'
* Message contains both adaptive card and normal images then the notification is 'Shared a photo /Shared {number} photos'

Associated issue number/tracking link (Required)
[94107](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-94107)

**The following criteria should be met (Required)**
- [X] [commit guidelines](https://sqbu-github.cisco.com/WebExSquared/web-client/blob/master/CONTRIBUTING.md#github-commit-guidelines) were followed
- [] Tests have been added for new functionality and all existing tests pass.
- [X] [pushing guidelines](https://sqbu-github.cisco.com/WebExSquared/web-client/blob/master/CONTRIBUTING.md#pushing-to-the-pipeline) are followed

Reviewers (Required)
@InteractiveTimmy @akoushke 