### PR TITLE
chore(circle): extend timeout for tap test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,7 +331,9 @@ jobs:
           git checkout tags/production
       - restore_node_modules
       - run: npm i
-      - run: npm run test:tap
+      - run:
+          command: npm run test:tap
+          no_output_timeout: 30m
       - store_test_results:
           path: reports/
       - store_test_results:


### PR DESCRIPTION
Tap tests are timing out. Extend the circle no output timeout.

Test result circle build: https://circleci.com/gh/webex/react-widgets/10484?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link