### PR TITLE
FIX: Widget Space Email Setup

### DIFF
--- a/packages/node_modules/@ciscospark/widget-space/src/actions.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/actions.js
@@ -3,7 +3,7 @@ import {addError} from '@ciscospark/redux-module-errors';
 
 import messages from './messages';
 
-import {destinationTypes} from './';
+import {destinationTypes} from './constants';
 
 export const FETCHING_SPACE_DETAILS = 'widget-space/FETCHING_SPACE_DETAILS';
 export const RELOAD_WIDGET = 'widget-space/RELOAD_WIDGET';

--- a/packages/node_modules/@ciscospark/widget-space/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/actions.test.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk';
 
 import * as actions from './actions';
 
-import {destinationTypes} from './';
+import {destinationTypes} from './constants';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/packages/node_modules/@ciscospark/widget-space/src/constants.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/constants.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
+export const destinationTypes = {
+  EMAIL: 'email',
+  USERID: 'userId',
+  SPACEID: 'spaceId',
+  SIP: 'sip',
+  PSTN: 'pstn'
+};

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
@@ -6,7 +6,7 @@ import {validateAndDecodeId, isUuid} from '@ciscospark/react-component-utils';
 
 import messages from '../messages';
 
-import {destinationTypes} from '../';
+import {destinationTypes} from '../constants';
 
 import {ACTIVITY_TYPE_PRIMARY} from './activity-menu';
 

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
@@ -96,10 +96,15 @@ function setup(props, prevProps) {
           destinationId,
           destinationType
         } = props;
+        let id = destinationId;
+
+        if (destinationType === destinationTypes.EMAIL && destinationId) {
+          id = destinationId.toLowerCase();
+        }
 
         props.storeDestination({
           type: destinationType,
-          id: destinationId
+          id
         });
       }
     }

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
@@ -18,9 +18,9 @@ import {
 
 import {getSpaceWidgetProps} from '../selector';
 
-import {destinationTypes} from '../';
+import {destinationTypes} from '../constants';
 
-function setup(props, prevProps) {
+export function setup(props, prevProps = {}) {
   const {
     conversation,
     destination,
@@ -35,9 +35,9 @@ function setup(props, prevProps) {
   } = props;
 
   if (sparkInstance
-    && sparkState.get('authenticated')
-    && sparkState.get('registered')
-    && !sparkState.get('hasError')
+      && sparkState.authenticated
+      && sparkState.registered
+      && !sparkState.hasError
   ) {
     // Check if we need to reload space
     if (widgetStatus.shouldReloadWidget && prevProps && !prevProps.widgetStatus.shouldReloadWidget) {
@@ -64,7 +64,7 @@ function setup(props, prevProps) {
     if (!mercuryStatus.hasConnected
       && !mercuryStatus.connecting
       && !mercuryStatus.connected
-      && sparkInstance.internal.device.registered) {
+      && sparkState.registered) {
       props.connectToMercury(sparkInstance);
     }
 

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.test.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.test.js
@@ -1,0 +1,145 @@
+import {destinationTypes} from '../constants';
+
+import {setup} from './setup';
+
+
+describe('widget-space: enhancers: setup', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      mercuryStatus: {
+        hasConnected: false,
+        connecting: false,
+        connected: false
+      },
+      sparkInstance: {
+        internal: {
+          device: {
+            registered: false
+          }
+        }
+      },
+      sparkState: {
+        authenticated: false,
+        registered: false,
+        hasError: false
+      },
+      conversation: {
+        get: () => false
+      },
+      errors: {
+        get: () => false
+      },
+      users: {
+        getIn: () => false
+      },
+      spaces: {
+        getIn: () => false
+      },
+      widgetStatus: {
+        isFetchingSpaceDetails: false,
+        shouldReloadWidget: false
+      },
+      // Mocked action creators
+      getSpaceDetails: jest.fn(),
+      reloadWidget: jest.fn(),
+      connectToMercury: jest.fn(),
+      storeDestination: jest.fn(),
+      resetErrors: jest.fn(),
+      getUser: jest.fn(),
+      fetchSpace: jest.fn()
+    };
+  });
+
+  it('does not do anything until spark registration', () => {
+    setup(props);
+
+    expect(props.connectToMercury).not.toHaveBeenCalled();
+    expect(props.getSpaceDetails).not.toHaveBeenCalled();
+  });
+
+  describe('after spark registration', () => {
+    beforeEach(() => {
+      props.sparkState = {
+        authenticated: true,
+        registered: true
+      };
+    });
+
+    it('reloads the widget when required', () => {
+      const prevProps = {
+        widgetStatus: {
+          shouldReloadWidget: false
+        }
+      };
+
+      props.widgetStatus.shouldReloadWidget = true;
+      setup(props, prevProps);
+      expect(props.reloadWidget).toHaveBeenCalled();
+    });
+
+    it('connects to mercury', () => {
+      setup(props);
+      expect(props.connectToMercury).toHaveBeenCalled();
+    });
+
+    it('does not connect to mercury when already connected', () => {
+      props.mercuryStatus.connected = true;
+      setup(props);
+      expect(props.connectToMercury).not.toHaveBeenCalled();
+    });
+
+    describe('when space details are empty', () => {
+      it('stores the destination', () => {
+        setup(props);
+        expect(props.storeDestination).toHaveBeenCalled();
+      });
+
+      it('lowercases the email destination', () => {
+        props.destinationId = 'UpperCase@email';
+        props.destinationType = destinationTypes.EMAIL;
+        setup(props);
+        expect(props.storeDestination).toHaveBeenCalledWith({
+          type: destinationTypes.EMAIL,
+          id: 'uppercase@email'
+        });
+      });
+
+      describe('when destination is populated', () => {
+        it('gets space details', () => {
+          props.destination = {};
+          setup(props);
+          expect(props.getSpaceDetails).toHaveBeenCalled();
+        });
+
+        it('gets user details for email type', () => {
+          props.destination = {
+            id: 'email@test.net',
+            type: destinationTypes.EMAIL
+          };
+          setup(props);
+          expect(props.getUser).toHaveBeenCalled();
+        });
+
+        it('gets user details for user id type', () => {
+          props.destination = {
+            id: 'abc123',
+            type: destinationTypes.USERID
+          };
+          setup(props);
+          expect(props.getUser).toHaveBeenCalled();
+        });
+
+        it('gets space details for space id type', () => {
+          props.destination = {
+            id: 'abc123',
+            type: destinationTypes.SPACEID
+          };
+          setup(props);
+          expect(props.fetchSpace).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/packages/node_modules/@ciscospark/widget-space/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/index.js
@@ -6,6 +6,7 @@ import reducers from './reducer';
 import ConnectedSpace from './container';
 import messages from './translations/en';
 import events from './events';
+import {destinationTypes} from './constants';
 
 const {eventNames} = events;
 
@@ -13,13 +14,7 @@ export {eventNames};
 
 export {reducers};
 
-export const destinationTypes = {
-  EMAIL: 'email',
-  USERID: 'userId',
-  SPACEID: 'spaceId',
-  SIP: 'sip',
-  PSTN: 'pstn'
-};
+export {destinationTypes};
 
 export default compose(
   constructSparkEnhancer({

--- a/packages/node_modules/@ciscospark/widget-space/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/selector.js
@@ -2,7 +2,7 @@ import {createSelector} from 'reselect';
 
 import {validateAndDecodeId} from '@ciscospark/react-component-utils';
 
-import {destinationTypes} from './';
+import {destinationTypes} from './constants';
 
 const getWidget = (state) => state.widgetSpace;
 const getSpark = (state) => state.spark;

--- a/packages/node_modules/@ciscospark/widget-space/src/selector.test.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/selector.test.js
@@ -4,7 +4,7 @@ import {CallRecord} from '@ciscospark/redux-module-media';
 
 import {getCall, getSpaceDetails} from './selector';
 
-import {destinationTypes} from './';
+import {destinationTypes} from './constants';
 
 describe('widget-space selectors', () => {
   describe('#getSpaceDetails selector', () => {


### PR DESCRIPTION
When using a destination type of email and the destination ID is mixed case, convert to lowercase to match the response from the server.

Also added a missing test suite around the `setup.js` file of the space widget. This caused me to have to move the constants into its own file due to jest trying to load reselect when doing `import X from './'`.

Commits should be separated and easy to follow.