### PR TITLE
'Webex' browser global namespace

### DIFF
--- a/packages/node_modules/@webex/spark-widget-base/README.md
+++ b/packages/node_modules/@webex/spark-widget-base/README.md
@@ -97,7 +97,7 @@ When your widget instantiates, it will get receive props from our main store. So
 This package also provides some additional enhancers to make your widget setup a bit easier:
 
 - `withInitialState` (_default_): Establishes widget initial states with Redux and injects the React-Redux store `Provider` component
-- `withBrowserGlobals` (_default_): Enables widgets to be instantiated globally using `window.ciscospark.widget(el).widgetName` ([usage example](https://github.com/webex/react-widgets/tree/master/packages/node_modules/@webex/widget-space#browser-globals))
+- `withBrowserGlobals` (_default_): Enables widgets to be instantiated globally using `window.webex.widget(el).widgetName` ([usage example](https://github.com/webex/react-widgets/tree/master/packages/node_modules/@webex/widget-space#browser-globals))
 - `withDataAPI` (_default_): Enables widgets to be instantiated using a data API ([usage example](https://github.com/webex/react-widgets/tree/master/packages/node_modules/@webex/widget-space#data-api))
 - `withIntl`: A helper for enabling [react-intl](https://github.com/yahoo/react-intl) in your widget. You can pass a config object that will make intl available to you: `{locale: 'en', messages}`
 

--- a/packages/node_modules/@webex/spark-widget-base/src/enhancers/withBrowserGlobals.js
+++ b/packages/node_modules/@webex/spark-widget-base/src/enhancers/withBrowserGlobals.js
@@ -30,7 +30,7 @@ function BrowserWidget(el) {
     const removed = ReactDOM.unmountComponentAtNode(el);
 
     // Remove from widgetStore
-    Reflect.deleteProperty(window.ciscospark.widgetStore, id);
+    Reflect.deleteProperty(window.webex.widgetStore, id);
 
     // Fire callback
     if (typeof callback === 'function') {
@@ -64,8 +64,8 @@ function BrowserWidget(el) {
   // Attach event handlers to each widget
   const widgetFn = {};
 
-  Object.keys(window.ciscospark.widgetFn).forEach((fn) => {
-    const func = window.ciscospark.widgetFn[fn];
+  Object.keys(window.webex.widgetFn).forEach((fn) => {
+    const func = window.webex.widgetFn[fn];
 
     widgetFn[fn] = (options) => {
       const onEvent = (name, data) => {
@@ -107,7 +107,7 @@ function getWidget(el) {
 
     // Store ID as attribute on dom element
     widgetEl.setAttribute('data-uuid', id);
-    window.ciscospark.widgetStore[id] = widgetObj;
+    window.webex.widgetStore[id] = widgetObj;
 
     return widgetObj;
   }
@@ -126,7 +126,7 @@ function getWidget(el) {
       // Add class
       widgetEl.classList.add('webex-widget');
       // Get widget from store if it exists
-      const widgetObj = window.ciscospark.widgetStore[id];
+      const widgetObj = window.webex.widgetStore[id];
 
       if (widgetObj) {
         return widgetObj;
@@ -135,7 +135,7 @@ function getWidget(el) {
       // Otherwise create new widget store
       return createNewWidget(widgetEl);
     }
-    console.warn('WARNING: ciscospark.widget: No HTML element provided.'); // eslint-disable-line no-console
+    console.warn('WARNING: webex.widget: No HTML element provided.'); // eslint-disable-line no-console
 
     return false;
   }
@@ -144,18 +144,22 @@ function getWidget(el) {
 }
 
 
-function setupSparkWidgetNamespace() {
+function setupWidgetNamespace() {
+  if (!window.webex) {
+    window.webex = {};
+  }
+  if (!window.webex.widgetStore) {
+    window.webex.widgetStore = {};
+  }
+  if (!window.webex.widgetFn) {
+    window.webex.widgetFn = {};
+  }
+  if (!window.webex.widget || typeof window.webex.widget !== 'function') {
+    window.webex.widget = getWidget;
+  }
+  // Legacy Support
   if (!window.ciscospark) {
-    window.ciscospark = {};
-  }
-  if (!window.ciscospark.widgetStore) {
-    window.ciscospark.widgetStore = {};
-  }
-  if (!window.ciscospark.widgetFn) {
-    window.ciscospark.widgetFn = {};
-  }
-  if (!window.ciscospark.widget || typeof window.ciscospark.widget !== 'function') {
-    window.ciscospark.widget = getWidget;
+    window.ciscospark = window.webex;
   }
 }
 
@@ -166,11 +170,11 @@ function setupSparkWidgetNamespace() {
  */
 export default function withBrowserGlobals({name}) {
   // Inject widget into browser globals
-  setupSparkWidgetNamespace();
+  setupWidgetNamespace();
   const fnName = `${name}Widget`;
 
   return (BaseComponent) => {
-    function renderSparkWidget(options) {
+    function renderWidget(options) {
       const {el} = this;
       const {onEvent, ...otherOptions} = options;
 
@@ -181,16 +185,16 @@ export default function withBrowserGlobals({name}) {
     }
 
     // Set up this widget's init process
-    // Allow dev to call window.ciscospark.widget(EL).WIDGETNAME({options});
-    if (typeof window.ciscospark.widgetFn[fnName] === 'function') {
+    // Allow dev to call window.webex.widget(EL).WIDGETNAME({options});
+    if (typeof window.webex.widgetFn[fnName] === 'function') {
       // eslint-disable-reason Need to log console warning when widget already registered
       // eslint-disable-next-line no-console
       console.warn(`${name} Widget is already registered.`);
     }
     else {
-      window.ciscospark.widgetFn[fnName] = renderSparkWidget;
+      window.webex.widgetFn[fnName] = renderWidget;
       // Attach version number statically. This will need to change when we publish widgets independently
-      window.ciscospark.widgetFn[fnName].version = process.env.REACT_CISCOSPARK_VERSION;
+      window.webex.widgetFn[fnName].version = process.env.REACT_CISCOSPARK_VERSION;
     }
 
     return BaseComponent;

--- a/packages/node_modules/@webex/spark-widget-base/src/enhancers/withDataAPI.js
+++ b/packages/node_modules/@webex/spark-widget-base/src/enhancers/withDataAPI.js
@@ -31,8 +31,8 @@ function loadWidgets({name}) {
     const props = getDataAttributes(widget);
 
     // Use browser globals to init widget if available
-    if (window.ciscospark.widget) {
-      const widgetObj = window.ciscospark.widget(widget);
+    if (window.webex.widget) {
+      const widgetObj = window.webex.widget(widget);
       const widgetName = `${name}Widget`;
 
       if (typeof widgetObj[widgetName] === 'function') {

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
@@ -352,7 +352,7 @@ class DemoWidget extends Component {
 <script>
   var widgetEl = document.getElementById('my-webex-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).recentsWidget({
+  webex.widget(widgetEl).recentsWidget({
     ${tokenString}
     ${spaceLoadCount}
     ${enableUserProfile}
@@ -374,7 +374,7 @@ class DemoWidget extends Component {
 <script>
   var widgetEl = document.getElementById('my-webex-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).spaceWidget({
+  webex.widget(widgetEl).spaceWidget({
     ${tokenString},
     ${destinationIdField},
     ${destinationTypeField},

--- a/packages/node_modules/@webex/widget-meet/src/index.html
+++ b/packages/node_modules/@webex/widget-meet/src/index.html
@@ -25,7 +25,7 @@ var widgetEventsEl = document.getElementById('widget-events');
 var tokenEl = document.getElementById('token');
 var toEl = document.getElementById('to');
 function createWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   widget.meetWidget({
     accessToken: tokenEl.value,
     to: toEl.value,
@@ -37,7 +37,7 @@ function createWidget() {
 }
 
 function removeWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   if (widget.remove) {
     widget.remove();
   }

--- a/packages/node_modules/@webex/widget-meetings/src/index.html
+++ b/packages/node_modules/@webex/widget-meetings/src/index.html
@@ -42,7 +42,7 @@ var accessTokenInput = document.getElementById('accessTokenInput');
 var destinationInput = document.getElementById('destinationInput');
 var destinationTypeInput = document.getElementById('destinationTypeInput');
 function createWidget() {
-  var widget = window.ciscospark.widget(widgetEl);
+  var widget = window.webex.widget(widgetEl);
   widget.meetingsWidget({
     accessToken: accessTokenInput.value,
     destinationId: destinationInput.value,
@@ -55,7 +55,7 @@ function createWidget() {
 }
 
 function removeWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   if (widget.remove) {
     widget.remove();
   }

--- a/packages/node_modules/@webex/widget-recents-demo/src/components/demo-widget-recents/index.js
+++ b/packages/node_modules/@webex/widget-recents-demo/src/components/demo-widget-recents/index.js
@@ -1,4 +1,4 @@
-/* global ciscospark */
+/* global webex */
 import React, {Component} from 'react';
 import {instanceOf} from 'prop-types';
 import classNames from 'classnames';
@@ -54,7 +54,7 @@ class DemoWidgetRecents extends Component {
     }
     const widgetEl = document.getElementById(widgetElementId);
 
-    ciscospark.widget(widgetEl).recentsWidget(widgetOptions);
+    webex.widget(widgetEl).recentsWidget(widgetOptions);
     this.setState({running: true});
   }
 
@@ -85,7 +85,7 @@ class DemoWidgetRecents extends Component {
 <script>
   var widgetEl = document.getElementById('my-webex-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).recentsWidget({
+  webex.widget(widgetEl).recentsWidget({
     ${globalToken}
   });
 </script>`;

--- a/packages/node_modules/@webex/widget-recents/README.md
+++ b/packages/node_modules/@webex/widget-recents/README.md
@@ -182,20 +182,20 @@ If you need additional behaviors or need to do additional work before the widget
 <script>
   var widgetEl = document.getElementById('my-webexteams-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).recentsWidget({
+  webex.widget(widgetEl).recentsWidget({
     accessToken: 'AN_ACCESS_TOKEN'
   });
 </script>
 ```
 
 > `my-webexteams-widget` is an arbitrary id to illustrate one way to select the DOM element.
-> But please ensure that the `widgetEl` that you pass to `ciscospark.widget()` is a DOM element.
+> But please ensure that the `widgetEl` that you pass to `webex.widget()` is a DOM element.
 
 You can also attach to an existing widget. Currently this gives you access to [events](#events). Other functionality will be added in future releases.
 
 ``` js
 var widgetEl = document.getElementById('webexteams-widget-id');
-var widgetObject = ciscospark.widget(widgetEl);
+var widgetObject = webex.widget(widgetEl);
 ```
 
 ##### Widget Teardown
@@ -206,17 +206,17 @@ The returned value, `removed`, is `true` if a matching widget has been removed, 
 
 ``` js
 // Basic remove
-ciscospark.widget(widgetEl).remove();
+webex.widget(widgetEl).remove();
 
 // With callback
-ciscospark.widget(widgetEl).remove(function(removed) {
+webex.widget(widgetEl).remove(function(removed) {
   if (removed) {
     console.log('removed!');
   }
 });
 
 // With Promise
-ciscospark.widget(widgetEl).remove().then(function(removed) {
+webex.widget(widgetEl).remove().then(function(removed) {
   if (removed) {
     console.log('removed!');
   }
@@ -251,7 +251,7 @@ If you are using *browser globals*, you can provide a callback parameter that wi
 ``` js
 var widgetEl = document.getElementById('my-webexteams-widget');
 // Init a new widget
-ciscospark.widget(widgetEl).recentsWidget({
+webex.widget(widgetEl).recentsWidget({
   accessToken: 'AN_ACCESS_TOKEN',
   onEvent: callback
 });
@@ -267,7 +267,7 @@ Or you can use the (`ampersand-events`)[https://github.com/AmpersandJS/ampersand
 
 ``` js
 var widgetEl = document.getElementById('webexteams-widget');
-ciscospark.widget(widgetEl).on('messages:created', function(e) {
+webex.widget(widgetEl).on('messages:created', function(e) {
   console.log(e.detail);
 });
 ```

--- a/packages/node_modules/@webex/widget-recents/src/index.html
+++ b/packages/node_modules/@webex/widget-recents/src/index.html
@@ -31,7 +31,7 @@ var widgetEventsEl = document.getElementById('widget-events');
 var accessTokenInput = document.getElementById('accessTokenInput');
 var basicModeInput = document.getElementById('basicModeInput');
 function createWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   widget.recentsWidget({
     accessToken: accessTokenInput.value,
     basicMode: basicModeInput.checked,
@@ -43,7 +43,7 @@ function createWidget() {
 }
 
 function removeWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   if (widget.remove) {
     widget.remove();
   }

--- a/packages/node_modules/@webex/widget-space-demo/src/components/demo-widget-space/index.js
+++ b/packages/node_modules/@webex/widget-space-demo/src/components/demo-widget-space/index.js
@@ -1,4 +1,4 @@
-/* global ciscospark */
+/* global webex */
 import React, {Component} from 'react';
 import classNames from 'classnames';
 import {Cookies, withCookies} from 'react-cookie';
@@ -85,7 +85,7 @@ class DemoWidgetSpace extends Component {
   handleRemove() {
     const widgetEl = document.getElementById(spaceWidgetElementId);
 
-    ciscospark.widget(widgetEl).remove();
+    webex.widget(widgetEl).remove();
     this.setState({spaceRunning: false});
   }
 
@@ -217,7 +217,7 @@ class DemoWidgetSpace extends Component {
 <script>
   var widgetEl = document.getElementById('my-webex-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).spaceWidget({
+  webex.widget(widgetEl).spaceWidget({
     ${globalToken}
     ${globalDestinationIdField},
     ${globalDestinationTypeField},

--- a/packages/node_modules/@webex/widget-space/README.md
+++ b/packages/node_modules/@webex/widget-space/README.md
@@ -229,7 +229,7 @@ If you need additional behaviors or need to do additional work before the widget
 <script>
   var widgetEl = document.getElementById('my-webexteams-widget');
   // Init a new widget
-  ciscospark.widget(widgetEl).spaceWidget({
+  webex.widget(widgetEl).spaceWidget({
     accessToken: 'AN_ACCESS_TOKEN',
     destinationType: 'spaceId',
     destinationId: 'XXXXXXXXXXXXXXX'
@@ -238,13 +238,13 @@ If you need additional behaviors or need to do additional work before the widget
 ```
 
 > `my-webexteams-widget` is an arbitrary id to illustrate one way to select the DOM element.
-> But please ensure that the `widgetEl` that you pass to `ciscospark.widget()` is a DOM element.
+> But please ensure that the `widgetEl` that you pass to `webex.widget()` is a DOM element.
 
 You can also attach to an existing widget. Currently this gives you access to [events](#events). Other functionality will be added in future releases.
 
 ``` js
 var widgetEl = document.getElementById('webexteams-widget-id');
-var widgetObject = ciscospark.widget(widgetEl);
+var widgetObject = webex.widget(widgetEl);
 ```
 
 ##### Widget Teardown
@@ -255,17 +255,17 @@ The returned value, `removed`, is `true` if a matching widget has been removed, 
 
 ``` js
 // Basic remove
-ciscospark.widget(widgetEl).remove();
+webex.widget(widgetEl).remove();
 
 // With callback
-ciscospark.widget(widgetEl).remove(function(removed) {
+webex.widget(widgetEl).remove(function(removed) {
   if (removed) {
     console.log('removed!');
   }
 });
 
 // With Promise
-ciscospark.widget(widgetEl).remove().then(function(removed) {
+webex.widget(widgetEl).remove().then(function(removed) {
   if (removed) {
     console.log('removed!');
   }
@@ -316,7 +316,7 @@ If you are using *browser globals*, you can provide a callback parameter that wi
 ``` js
 var widgetEl = document.getElementById('my-webexteams-widget');
 // Init a new widget
-ciscospark.widget(widgetEl).spaceWidget({
+webex.widget(widgetEl).spaceWidget({
   accessToken: 'AN_ACCESS_TOKEN',
   destinationId: 'XXXXXXXXXXXXXXX',
   destinationType: 'spaceId',
@@ -334,7 +334,7 @@ Or you can use the [`ampersand-events`](https://github.com/AmpersandJS/ampersand
 
 ``` js
 var widgetEl = document.getElementById('webexteams-widget');
-ciscospark.widget(widgetEl).on('messages:created', function(e) {
+webex.widget(widgetEl).on('messages:created', function(e) {
   console.log(e.detail);
 });
 ```
@@ -349,7 +349,7 @@ is available when answering the call:
 - if it is a space meeting, the `spaceId`
 
   ```js
-    ciscospark.widget(widgetEl).spaceWidget({
+    webex.widget(widgetEl).spaceWidget({
       accessToken: 'AN_ACCESS_TOKEN',
       destinationType: 'spaceId',
       destiationId: 'SPACE_ID'
@@ -359,7 +359,7 @@ is available when answering the call:
 - a `call` object provided by the `calls:created` event from the [`recents widget`](../widget-recents/events.md#callscreated) (use this for incoming pstn and sip calls):
 
   ```js
-    ciscospark.widget(widgetEl).spaceWidget({
+    webex.widget(widgetEl).spaceWidget({
       accessToken: 'AN_ACCESS_TOKEN',
       call: callObject
     });

--- a/packages/node_modules/@webex/widget-space/create-space-widget-with-server.md
+++ b/packages/node_modules/@webex/widget-space/create-space-widget-with-server.md
@@ -47,7 +47,7 @@ Replace the contents of *views/index.ejs* with the following:
     <script>
       var widgetEl = document.getElementById('my-webex-widget');
       // Init a new widget
-      ciscospark.widget(widgetEl).spaceWidget({
+      webex.widget(widgetEl).spaceWidget({
         accessToken: 'REPLACE WITH YOUR ACCESS TOKEN',
         spaceId: 'REPLACE WITH SPARK SPACE ID'
       });
@@ -56,9 +56,9 @@ Replace the contents of *views/index.ejs* with the following:
 </html>
 ```
 
-Your `accessToken` allows you to perform actions in Cisco Spark as yourself. Get your `accessToken` at https://developer.ciscospark.com/getting-started.html#authentication and replace the value of `accessToken` with it.  
+Your `accessToken` allows you to perform actions in Cisco Spark as yourself. Get your `accessToken` at https://developer.webex.com/docs/api/getting-started/accounts-and-authentication and replace the value of `accessToken` with it.  
 
-`spaceId` is the ID of the Spark space where you wish to read and send messages. Visit https://developer.ciscospark.com/endpoint-rooms-get.html to list the spaces (rooms) you have access to. Choose an ID from one of the spaces in the `items` array and replace the value of `spaceId` with it. 
+`spaceId` is the ID of the Spark space where you wish to read and send messages. Visit https://developer.webex.com/docs/api/v1/rooms/list-rooms to list the spaces (rooms) you have access to. Choose an ID from one of the spaces in the `items` array and replace the value of `spaceId` with it. 
 
 Start the application. 
 
@@ -72,7 +72,7 @@ Type a message and send it to the space. You should see it reflected in both you
 
 ## References
 
-1. Bender, Brian, et al. Spark Space Widget (@webex/Widget-Space). GitHub, 11 Apr. 2017, github.com/ciscospark/react-widgets/blob/master/packages/node_modules/@webex/widget-space/README.md.
+1. Bender, Brian, et al. Spark Space Widget (@webex/Widget-Space). GitHub, 11 Apr. 2017, github.com/webex/react-widgets/blob/master/packages/node_modules/@webex/widget-space/README.md.
 
 ## External links
 

--- a/packages/node_modules/@webex/widget-space/src/index.html
+++ b/packages/node_modules/@webex/widget-space/src/index.html
@@ -42,7 +42,7 @@ var accessTokenInput = document.getElementById('accessTokenInput');
 var destinationInput = document.getElementById('destinationInput');
 var destinationTypeInput = document.getElementById('destinationTypeInput');
 function createWidget() {
-  var widget = window.ciscospark.widget(widgetEl);
+  var widget = window.webex.widget(widgetEl);
   widget.spaceWidget({
     accessToken: accessTokenInput.value,
     destinationId: destinationInput.value,
@@ -55,7 +55,7 @@ function createWidget() {
 }
 
 function removeWidget() {
-  var widget = ciscospark.widget(widgetEl);
+  var widget = webex.widget(widgetEl);
   if (widget.remove) {
     widget.remove();
   }

--- a/test/journeys/server/multiple.html
+++ b/test/journeys/server/multiple.html
@@ -53,12 +53,12 @@
     window.openSpaceWidget = function(options) {
       var spaceWidgetEl = document.getElementById('webex-space-widget');
       // Init a new widget
-      ciscospark.widget(spaceWidgetEl).spaceWidget(options);
+      webex.widget(spaceWidgetEl).spaceWidget(options);
     };
     window.openRecentsWidget = function(options) {
       var recentsWidgetEl = document.getElementById('webex-recents-widget');
       // Init a new widget
-      ciscospark.widget(recentsWidgetEl).recentsWidget(options);
+      webex.widget(recentsWidgetEl).recentsWidget(options);
     };
     window.ciscoSparkEvents = [];
   </script>

--- a/test/journeys/server/production/recents.html
+++ b/test/journeys/server/production/recents.html
@@ -16,7 +16,7 @@
   window.openRecentsWidget = function(options) {
     var widgetEl = document.getElementById('webex-widget');
     // Init a new widget
-    ciscospark.widget(widgetEl).recentsWidget(options);
+    webex.widget(widgetEl).recentsWidget(options);
   };
   window.ciscoSparkEvents = [];
 </script>

--- a/test/journeys/server/production/space.html
+++ b/test/journeys/server/production/space.html
@@ -16,7 +16,7 @@
   window.openSpaceWidget = function(options) {
     var widgetEl = document.getElementById('webex-widget');
     // Init a new widget
-    ciscospark.widget(widgetEl).spaceWidget(options);
+    webex.widget(widgetEl).spaceWidget(options);
   };
 </script>
 </body>

--- a/test/journeys/server/recents.html
+++ b/test/journeys/server/recents.html
@@ -17,7 +17,7 @@
   window.openRecentsWidget = function(options) {
     var widgetEl = document.getElementById('webex-widget');
     // Init a new widget
-    ciscospark.widget(widgetEl).recentsWidget(options);
+    webex.widget(widgetEl).recentsWidget(options);
   };
   window.ciscoSparkEvents = [];
 </script>

--- a/test/journeys/server/space.html
+++ b/test/journeys/server/space.html
@@ -45,7 +45,7 @@
   window.openSpaceWidget = function(options) {
     var widgetEl = document.getElementById('webex-widget');
     // Init a new widget
-    ciscospark.widget(widgetEl).spaceWidget(options);
+    webex.widget(widgetEl).spaceWidget(options);
   };
   window.ciscoSparkEvents = [];
 </script>


### PR DESCRIPTION
Builds off of #1045 and should be rebased once merged in. 

Changes the `window.ciscospark` implementation to `window.webex`.