### PR TITLE
Merge pull request #1053 from taymoork2/npm-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,9 @@ jobs:
     executor: main-executor
     steps:
       - checkout
-      - restore_node_modules
       - run:
           name: 'Install dependencies'
-          command: npm i
+          command: npm ci
       # Cache node_modules across different internal jobs in the workflow and across different circleci runs
       - save_cache:
           key: node-modules-cache-node-dubnium-npm-6-v1-{{ checksum "package-lock.json" }}


### PR DESCRIPTION
On CircleCI we currently restore cache before running npm i on the install jobs. This has caused a weird issue where sometimes post merge npm install has caused package updates to not be reflected/installed correctly.
Moving to not restore cache and then using npm ci and then saving the cache should stop that from happening