### PR TITLE
fix(adaptive-card): use proper momentum library

### DIFF
--- a/packages/node_modules/@webex/react-component-adaptive-card/src/adaptiveCard.scss
+++ b/packages/node_modules/@webex/react-component-adaptive-card/src/adaptiveCard.scss
@@ -1,5 +1,5 @@
-@import '@momentum-ui/core/scss/momentum-ui';
-@import "@webex/react-component-activity-text/src/styles";
+@import '~@momentum-ui/core/scss/momentum-ui-components';
+@import '~@webex/react-component-activity-text/src/styles';
 
 .activity-item--adaptive-card {
   @extend .activityText ;
@@ -44,7 +44,7 @@
             margin: auto 0px auto 6px;
           }
           &.expanded {
-            @extend .md-button:active; 
+            @extend .md-button:active;
             color: #FFFFFF;
             background-color: #196323;
             &:after {


### PR DESCRIPTION
Due to an issue caused by [this change](https://github.com/webex/react-widgets/blob/7974b2ba141ea1ef38180218a1730ad094866866/packages/node_modules/%40ciscospark/react-component-adaptive-card/src/adaptiveCard.scss#L1), the non-componentized momentum library was being pulled in and causing global styles to be overridden.

