### PR TITLE
fix(media): use proper webex object

### DIFF
--- a/packages/node_modules/@webex/redux-module-media/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-media/src/actions.js
@@ -347,7 +347,7 @@ function bindEvents({dispatch, call, id}) {
         dispatch(answeredIncomingCall(callId));
         // incomingCall.joinedOnThisDevice takes a few ticks so we have to
         // calculate it ourselves for now
-        if (call.locus.self.deviceUrl !== call.spark.internal.device.url) {
+        if (call.locus.self.deviceUrl !== call.webex.internal.device.url) {
           // We are not connected on this device, dismiss
           dispatch(dismissIncomingCall(callId));
         }


### PR DESCRIPTION
A missed object in the webex rename was found causing meeting issues with the widget.