### PR TITLE
fix(video): use proper react property naming

### DIFF
--- a/packages/node_modules/@webex/react-component-video/src/index.js
+++ b/packages/node_modules/@webex/react-component-video/src/index.js
@@ -35,7 +35,7 @@ function Video({srcObject, audioMuted}) {
     // eslint-disable-next-line jsx-a11y/media-has-caption
     <video
       autoPlay
-      playsinline
+      playsInline
       className={classNames(styles.video)}
       muted={audioMuted}
       ref={getEl}


### PR DESCRIPTION
React prints an error message with using the non-camel-cased version of `playsInline`.