### PR TITLE
fix(widget-space): convert mercuryStatus to js object

### DIFF
--- a/packages/node_modules/@webex/widget-space/src/selector.js
+++ b/packages/node_modules/@webex/widget-space/src/selector.js
@@ -212,7 +212,7 @@ export const getSpaceWidgetProps = createSelector(
     activityTypes,
     destination: widget.get('destination'),
     media,
-    mercuryStatus,
+    mercuryStatus: mercuryStatus.toJS(),
     sparkInstance: spark.get('spark'),
     sparkState: spark.get('status'),
     spaceDetails,


### PR DESCRIPTION
Widget space was expecting the mercuryStatus object to be a regular javascript object and not an immutable object. 

It was caught in a loop that constantly was attempting to connect to mercury every time a store updated: https://github.com/adamweeks/react-widgets/blob/207c9c79c74c67f0661edef1f3b29d7c304c4b25/packages/node_modules/@webex/widget-space/src/enhancers/setup.js#L64-L69