### PR TITLE
Fix broken build

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -74,11 +74,6 @@ Runs a webpack build and transpile on all packages that start with '@webex/widge
 * Executes [`webpackBuild`](#webpackBuild) command.
 * Executes [`transpile`](#transpile) command.
 
-### `npm run es5-check:dist`
-Verifies that the bundles are es5 compatible.
-
-### `npm run es6-check:esm`
-Verifies that the ES modules are es6 compatible.
 ## Publish
 
 Publishing the different packages to NPM.
@@ -90,7 +85,6 @@ Runs the commands necessary to publish all of the widgets and components to NPM
 * `build:components`
 * `build:widgets`
 * `build:packagejson`
-* `es6-check:esm`
 * `publish components`
 
 ### `npm run publish components`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5010,6 +5010,12 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "caniuse-lite": "^1.0.30000744",
     "chai": "^4.0.2",
     "child-process-promise": "^2.2.0",
+    "colors": "^1.4.0",
     "cross-env": "^5.0.0",
     "css-loader": "^2.1.1",
     "cssnano": "^4.1.10",


### PR DESCRIPTION
The "colors" package was being provided as a sub-dependency, but after removing the "es-check" package, "colors" was gone.
Adding it back in since it is a specific dependency.