### PR TITLE
feat(r-m-teams): add support for error handling

### DIFF
--- a/packages/node_modules/@webex/redux-module-teams/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@webex/redux-module-teams/src/__snapshots__/actions.test.js.snap
@@ -3,6 +3,9 @@
 exports[`redux-module-teams actions #fetchTeams can successfully fetch teams 1`] = `
 Array [
   Object {
+    "type": "teams/FETCH_TEAMS",
+  },
+  Object {
     "payload": Object {
       "teams": Array [
         Object {

--- a/packages/node_modules/@webex/redux-module-teams/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@webex/redux-module-teams/src/__snapshots__/reducer.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redux-module-teams reducer should handle FETCH_TEAMS 1`] = `
+Immutable.Map {
+  "byId": Immutable.Map {},
+  "status": Immutable.Record {
+    "isFetching": true,
+    "hasFetched": false,
+    "error": undefined,
+  },
+}
+`;
+
+exports[`redux-module-teams reducer should handle STORE_TEAMS 1`] = `
+Immutable.Map {
+  "byId": Immutable.Map {
+    "teamId": Immutable.Record {
+      "id": "teamId",
+      "color": "#abcabc",
+      "generalConversationId": "10000000-0000-0000-0000-000000000000",
+      "displayName": "test team!",
+      "description": "team that tests",
+      "status": Object {
+        "isArchived": false,
+      },
+    },
+  },
+  "status": Immutable.Record {
+    "isFetching": false,
+    "hasFetched": true,
+    "error": undefined,
+  },
+}
+`;
+
+exports[`redux-module-teams reducer should handle STORE_TEAMS_ERROR 1`] = `
+Immutable.Map {
+  "byId": Immutable.Map {},
+  "status": Immutable.Record {
+    "isFetching": false,
+    "hasFetched": false,
+    "error": [Error: 429 Retry],
+  },
+}
+`;
+
+exports[`redux-module-teams reducer should return initial state 1`] = `
+Immutable.Map {
+  "byId": Immutable.Map {},
+  "status": Immutable.Record {
+    "isFetching": false,
+    "hasFetched": false,
+    "error": undefined,
+  },
+}
+`;

--- a/packages/node_modules/@webex/redux-module-teams/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-teams/src/actions.js
@@ -1,10 +1,23 @@
-import {
-  constructTeam,
-  constructTeams
-} from './helpers';
+import {constructTeams} from './helpers';
 
+export const FETCH_TEAMS = 'teams/FETCH_TEAMS';
 export const STORE_TEAMS = 'teams/STORE_TEAMS';
-export const UPDATE_TEAM = 'teams/UPDATE_TEAM';
+export const STORE_TEAMS_ERROR = 'teams/STORE_TEAMS_ERROR';
+
+function startFetchTeams() {
+  return {
+    type: FETCH_TEAMS
+  };
+}
+
+function storeTeamError(error) {
+  return {
+    type: STORE_TEAMS_ERROR,
+    payload: {
+      error
+    }
+  };
+}
 
 function storeTeams(teams) {
   return {
@@ -15,19 +28,16 @@ function storeTeams(teams) {
   };
 }
 
-export function updateTeam(team) {
-  return {
-    type: UPDATE_TEAM,
-    payload: {
-      team: constructTeam(team)
-    }
-  };
-}
-
-
+/**
+ * Fetches teams from the conversation server
+ * @param {object} sparkInstance
+ * @returns {Thunk}
+ */
 export function fetchTeams(sparkInstance) {
-  return (dispatch) =>
-    sparkInstance.internal.team.list()
+  return (dispatch) => {
+    dispatch(startFetchTeams());
+
+    return sparkInstance.internal.team.list()
       .then((teams) => {
         if (teams && teams.length) {
           dispatch(storeTeams(teams));
@@ -37,5 +47,10 @@ export function fetchTeams(sparkInstance) {
 
         return Promise.resolve();
       })
-      .catch((e) => Promise.reject(new Error('Could not fetch teams', e)));
+      .catch((e) => {
+        dispatch(storeTeamError(e));
+
+        return Promise.reject(new Error('Could not fetch teams', e));
+      });
+  };
 }

--- a/packages/node_modules/@webex/redux-module-teams/src/actions.test.js
+++ b/packages/node_modules/@webex/redux-module-teams/src/actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import * as actions from '.';
+import * as actions from './actions';
 
 const {initialState} = actions;
 const middlewares = [thunk];

--- a/packages/node_modules/@webex/redux-module-teams/src/reducer.js
+++ b/packages/node_modules/@webex/redux-module-teams/src/reducer.js
@@ -1,7 +1,10 @@
 import {fromJS, Record} from 'immutable';
 
-export const STORE_TEAMS = 'teams/STORE_TEAMS';
-export const UPDATE_TEAM = 'teams/UPDATE_TEAM';
+import {
+  FETCH_TEAMS,
+  STORE_TEAMS,
+  STORE_TEAMS_ERROR
+} from './actions';
 
 const Team = Record({
   id: null,
@@ -16,7 +19,8 @@ const Team = Record({
 
 const Status = Record({
   isFetching: false,
-  hasFetched: false
+  hasFetched: false,
+  error: undefined
 });
 
 export const initialState = fromJS({
@@ -26,6 +30,9 @@ export const initialState = fromJS({
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {
+    case FETCH_TEAMS: {
+      return state.setIn(['status', 'isFetching'], true);
+    }
     case STORE_TEAMS: {
       const teams = {};
 
@@ -33,12 +40,21 @@ export default function reducer(state = initialState, action) {
         teams[t.id] = new Team(t);
       });
 
-      return state.mergeIn(['byId'], teams);
+      return state
+        .mergeIn(['byId'], teams)
+        .set('status', new Status({
+          isFetching: false,
+          hasFetched: true,
+          error: undefined
+        }));
     }
-    case UPDATE_TEAM: {
-      const {team} = action.payload;
-
-      return state.mergeDeepIn(['byId', team.id], team);
+    case STORE_TEAMS_ERROR: {
+      return state
+        .set('status', new Status({
+          isFetching: false,
+          hasFetched: false,
+          error: action.payload.error
+        }));
     }
     default:
       return state;

--- a/packages/node_modules/@webex/redux-module-teams/src/reducer.test.js
+++ b/packages/node_modules/@webex/redux-module-teams/src/reducer.test.js
@@ -1,0 +1,54 @@
+import reducer, {initialState} from './reducer';
+import {
+  FETCH_TEAMS,
+  STORE_TEAMS,
+  STORE_TEAMS_ERROR
+} from './actions';
+
+describe('redux-module-teams reducer', () => {
+  let teams;
+
+  beforeEach(() => {
+    teams = [
+      {
+        id: 'teamId',
+        color: '#abcabc',
+        generalConversationId: '10000000-0000-0000-0000-000000000000',
+        displayName: 'test team!',
+        description: 'team that tests',
+        status: {
+          isArchived: false
+        }
+      }
+    ];
+  });
+
+  it('should return initial state', () => {
+    expect(reducer(undefined, {}))
+      .toMatchSnapshot();
+  });
+
+  it('should handle FETCH_TEAMS', () => {
+    expect(reducer(initialState, {
+      type: FETCH_TEAMS
+    })).toMatchSnapshot();
+  });
+
+  it('should handle STORE_TEAMS', () => {
+    expect(reducer(initialState, {
+      type: STORE_TEAMS,
+      payload: {
+        teams
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle STORE_TEAMS_ERROR', () => {
+    expect(reducer(initialState, {
+      type: STORE_TEAMS_ERROR,
+      payload: {
+        error: new Error('429 Retry')
+      }
+    })).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
As part of the investigation into 429 error handling, it was discovered that we are not storing the error from the teams convo endpoint which has the highest rate of 429 errors of most endpoints.

This will be a step towards being able to respond to 429 errors.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-129689