### PR TITLE
feat(webex): set audio and video dynamically to calls in widgets

### DIFF
--- a/packages/node_modules/@webex/redux-module-media/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-media/src/actions.js
@@ -218,6 +218,31 @@ export function listenForCalls(sparkInstance) {
 }
 
 /**
+ * Checks if the machine has at least one audio or video device
+ * @returns {Promise.<Object>} {
+ *    audio: true/false,
+ *    video: true/false
+ *}
+ */
+function getSupportedDevice() {
+  return Promise.resolve().then(() => {
+    if (!navigator.mediaDevices || navigator.mediaDevices.enumerateDevices === undefined) {
+      return {
+        audio: false,
+        video: false
+      };
+    }
+
+    // Reference for device.kind: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+    return navigator.mediaDevices.enumerateDevices()
+      .then((devices) => ({
+        audio: devices.filter((device) => device.kind === 'audioinput').length > 0,
+        video: devices.filter((device) => device.kind === 'videoinput').length > 0
+      }));
+  });
+}
+
+/**
  * Call a user with an email address or userId
  *
  * @export
@@ -226,30 +251,32 @@ export function listenForCalls(sparkInstance) {
  * @param {Object} data.options
  * @returns {Promise}
  */
-export function placeCall(sparkInstance, {
-  destination,
-  options = {audio: true, video: true}
-}) {
+export function placeCall(sparkInstance, {destination, options}) {
   return (dispatch) => {
     let call, id;
 
-    try {
-      call = sparkInstance.phone.dial(
-        destination,
-        Object.assign(
-          options,
-          {
-            offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true}
-          }
-        )
-      );
-      ({call, id} = processCall({dispatch, call}));
-    }
-    catch (e) {
-      // Ignore, will be caught on call.on('error')
-    }
+    return getSupportedDevice()
+      .then(({audio, video}) => {
+        try {
+          call = sparkInstance.phone.dial(
+            destination,
+            Object.assign(
+              options,
+              {
+                offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true},
+                audio,
+                video
+              }
+            )
+          );
+          ({call, id} = processCall({dispatch, call}));
+        }
+        catch (e) {
+          // Ignore, will be caught on call.on('error')
+        }
 
-    return Promise.resolve({call, id});
+        return {call, id};
+      });
   };
 }
 


### PR DESCRIPTION
I noticed we have unit test only for the functions that dispatch an action in `redux-module-media/src/actions.js` so I didn't add unit test for this new function.  This is just a helper function to automatically set `audio` and `video` constraints before calling `placeCall`.

I'm having a hard time to test it locally since it needs https to have access to the `navigator.mediaDevices` object and its methods. 

Is it possible to deploy it to Netlify and test it before we merged it? 
