### PR TITLE
chore(webpack): serve on localhost [skip ci]

### DIFF
--- a/scripts/webpack/webpack.dev.babel.js
+++ b/scripts/webpack/webpack.dev.babel.js
@@ -32,7 +32,7 @@ module.exports = (env) => webpackConfigBase({
   plugins,
   devtool: 'source-map',
   devServer: {
-    host: '0.0.0.0',
+    host: 'localhost',
     port: process.env.PORT || 8000,
     stats: {
       colors: true,


### PR DESCRIPTION
Having the widgets serve on `0.0.0.0` did a disservice to developers trying to use media since we don't serve over https and browsers will block media access to anything not "localhost" served over http.