### PR TITLE
feat(widget-demo): add composer actions to example

### DIFF
--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
@@ -369,6 +369,7 @@ class DemoWidget extends Component {
     const destinationTypeField = `destinationType: '${mode}'`;
     const initialActivityField = `initialActivity: '${this.state.initialActivity}'`;
     const secondaryActivitiesFullWidth = `secondaryActivitiesFullWidth: ${this.state.secondaryActivitiesFullWidth}`;
+    const composerActionsDisplay = `composerActions: ${JSON.stringify(this.state.composerActions)}`;
 
     const spaceCode = `<div id="my-webex-widget" />
 <script>
@@ -380,7 +381,8 @@ class DemoWidget extends Component {
     ${destinationTypeField},
     ${activityTypesField},
     ${initialActivityField},
-    ${secondaryActivitiesFullWidth}
+    ${secondaryActivitiesFullWidth},
+    ${composerActionsDisplay}
   });
 </script>`;
 


### PR DESCRIPTION
During a request in the ask space, I noticed the composer actions config isn't in the example code in the samples. Added here:

![image](https://user-images.githubusercontent.com/190647/81075266-1c692180-8eb8-11ea-9fe2-3b43d1d65e56.png)
