### PR TITLE
fix(redux-module-spaces): add code to error message

### DIFF
--- a/packages/node_modules/@webex/redux-module-spaces/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@webex/redux-module-spaces/src/__snapshots__/actions.test.js.snap
@@ -506,7 +506,7 @@ Array [
     "payload": Object {
       "error": Object {
         "code": "Error",
-        "displaySubtitle": "Unable to load spaces. Please try again later.",
+        "displaySubtitle": "Unable to load spaces. Please try again later. [Error]",
         "displayTitle": "Something's not right",
         "id": "redux-module-spaces-load",
         "temporary": false,
@@ -736,7 +736,7 @@ Array [
     "payload": Object {
       "error": Object {
         "code": "Error",
-        "displaySubtitle": "Unable to load spaces. Please try again later.",
+        "displaySubtitle": "Unable to load spaces. Please try again later. [Error]",
         "displayTitle": "Something's not right",
         "id": "redux-module-spaces-load",
         "temporary": false,

--- a/packages/node_modules/@webex/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-spaces/src/actions.js
@@ -117,14 +117,14 @@ function storeInitialSpace(id) {
 /**
  * Adds a rate limit error to the errors module
  * @param {function} dispatch
- * @param {String} code
+ * @param {String} name
  */
-function addLoadError(dispatch, code) {
+function addLoadError(dispatch, name) {
   dispatch(addError({
-    code,
+    code: name,
     id: 'redux-module-spaces-load',
     displayTitle: 'Something\'s not right',
-    displaySubtitle: 'Unable to load spaces. Please try again later.',
+    displaySubtitle: `Unable to load spaces. Please try again later. [${name}]`,
     temporary: false
   }));
 }


### PR DESCRIPTION
The scope of the changes in this pull request is adding explicit error details to the already implemented fix for [this case](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-132963). This will allow users to see an explicit messaged in the view based on the data retrieved from the JS SDK.