### PR TITLE
Unregister device when removing widget

### DIFF
--- a/packages/node_modules/@webex/react-redux-spark-fixtures/src/__fixtures__/spark.js
+++ b/packages/node_modules/@webex/react-redux-spark-fixtures/src/__fixtures__/spark.js
@@ -36,7 +36,8 @@ export default function createSpark() {
         },
         remove: genMockFunction(),
         getServiceUrl: jest.fn(() => ''),
-        register: genMockFunction()
+        register: genMockFunction(),
+        unregister: genMockFunction()
       },
 
       encryption: {

--- a/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/actions.test.js.snap
@@ -42,3 +42,25 @@ Array [
   },
 ]
 `;
+
+exports[`sdk actions should unregister this device with spark 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "status": Object {
+        "unregistering": true,
+      },
+    },
+    "type": "spark/UPDATE_SPARK_STATUS",
+  },
+  Object {
+    "payload": Object {
+      "status": Object {
+        "registered": false,
+        "unregistering": false,
+      },
+    },
+    "type": "spark/UPDATE_SPARK_STATUS",
+  },
+]
+`;

--- a/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/component.test.js.snap
+++ b/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/component.test.js.snap
@@ -120,6 +120,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -171,6 +172,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -215,6 +217,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -289,6 +293,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -340,6 +345,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -384,6 +390,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -463,6 +471,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -514,6 +523,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -558,6 +568,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -669,6 +681,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -720,6 +733,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -764,6 +778,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -838,6 +854,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -889,6 +906,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -933,6 +951,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -1012,6 +1032,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -1063,6 +1084,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -1107,6 +1129,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -1215,6 +1239,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -1266,6 +1291,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -1310,6 +1336,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -1384,6 +1412,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -1435,6 +1464,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -1479,6 +1509,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -1558,6 +1590,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -1609,6 +1642,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -1653,6 +1687,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -1883,6 +1919,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -1934,6 +1971,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -1978,6 +2016,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -2268,6 +2308,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "encryption": Object {
@@ -2319,6 +2360,7 @@ Object {
                             "services": Object {
                               "roomServiceUrl": "https://example.com/devices/services/room/1",
                             },
+                            "unregister": [MockFunction],
                             "url": "https://example.com/devices/1",
                           },
                           "change:registered",
@@ -2363,6 +2405,8 @@ Object {
                     "registered": false,
                     "registerError": false,
                     "registering": false,
+                    "unregisterError": false,
+                    "unregistering": false,
                   },
                 },
                 "storeSparkInstance": [Function],
@@ -2493,6 +2537,7 @@ Object {
                   "services": Object {
                     "roomServiceUrl": "https://example.com/devices/services/room/1",
                   },
+                  "unregister": [MockFunction],
                   "url": "https://example.com/devices/1",
                 },
                 "encryption": Object {
@@ -2544,6 +2589,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "change:registered",
@@ -2588,6 +2634,8 @@ Object {
               "registered": false,
               "registerError": false,
               "registering": false,
+              "unregisterError": false,
+              "unregistering": false,
             },
           },
           "storeSparkInstance": [Function],
@@ -2662,6 +2710,7 @@ Object {
                   "services": Object {
                     "roomServiceUrl": "https://example.com/devices/services/room/1",
                   },
+                  "unregister": [MockFunction],
                   "url": "https://example.com/devices/1",
                 },
                 "encryption": Object {
@@ -2713,6 +2762,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "change:registered",
@@ -2757,6 +2807,8 @@ Object {
               "registered": false,
               "registerError": false,
               "registering": false,
+              "unregisterError": false,
+              "unregistering": false,
             },
           },
           "storeSparkInstance": [Function],
@@ -2993,6 +3045,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "encryption": Object {
@@ -3044,6 +3097,7 @@ Object {
                             "services": Object {
                               "roomServiceUrl": "https://example.com/devices/services/room/1",
                             },
+                            "unregister": [MockFunction],
                             "url": "https://example.com/devices/1",
                           },
                           "change:registered",
@@ -3088,6 +3142,8 @@ Object {
                     "registered": false,
                     "registerError": false,
                     "registering": false,
+                    "unregisterError": false,
+                    "unregistering": false,
                   },
                 },
                 "storeSparkInstance": [Function],
@@ -3210,6 +3266,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -3261,6 +3318,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -3305,6 +3363,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -3423,6 +3483,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -3474,6 +3535,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -3518,6 +3580,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -3592,6 +3656,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -3643,6 +3708,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -3687,6 +3753,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -3766,6 +3834,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -3817,6 +3886,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -3861,6 +3931,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -3972,6 +4044,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -4023,6 +4096,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -4067,6 +4141,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -4141,6 +4217,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -4192,6 +4269,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -4236,6 +4314,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -4315,6 +4395,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -4366,6 +4447,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -4410,6 +4492,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -4518,6 +4602,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -4569,6 +4654,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -4613,6 +4699,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -4687,6 +4775,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -4738,6 +4827,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -4782,6 +4872,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -4861,6 +4953,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -4912,6 +5005,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -4956,6 +5050,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -5186,6 +5282,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -5237,6 +5334,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -5281,6 +5379,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -5824,6 +5924,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "encryption": Object {
@@ -5875,6 +5976,7 @@ Object {
                               "services": Object {
                                 "roomServiceUrl": "https://example.com/devices/services/room/1",
                               },
+                              "unregister": [MockFunction],
                               "url": "https://example.com/devices/1",
                             },
                             "change:registered",
@@ -5919,6 +6021,8 @@ Object {
                       "registered": false,
                       "registerError": false,
                       "registering": false,
+                      "unregisterError": false,
+                      "unregistering": false,
                     },
                   },
                   "storeSparkInstance": [Function],
@@ -6049,6 +6153,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -6100,6 +6205,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -6144,6 +6250,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -6218,6 +6326,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -6269,6 +6378,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -6313,6 +6423,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -6549,6 +6661,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "encryption": Object {
@@ -6600,6 +6713,7 @@ Object {
                               "services": Object {
                                 "roomServiceUrl": "https://example.com/devices/services/room/1",
                               },
+                              "unregister": [MockFunction],
                               "url": "https://example.com/devices/1",
                             },
                             "change:registered",
@@ -6644,6 +6758,8 @@ Object {
                       "registered": false,
                       "registerError": false,
                       "registering": false,
+                      "unregisterError": false,
+                      "unregistering": false,
                     },
                   },
                   "storeSparkInstance": [Function],
@@ -6766,6 +6882,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -6817,6 +6934,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -6861,6 +6979,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -7262,6 +7382,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -7313,6 +7434,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -7357,6 +7479,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -7431,6 +7555,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -7482,6 +7607,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -7526,6 +7652,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -7605,6 +7733,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -7656,6 +7785,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -7700,6 +7830,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -7811,6 +7943,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -7862,6 +7995,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -7906,6 +8040,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -7980,6 +8116,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -8031,6 +8168,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -8075,6 +8213,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -8154,6 +8294,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -8205,6 +8346,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -8249,6 +8391,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -8357,6 +8501,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -8408,6 +8553,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -8452,6 +8598,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -8526,6 +8674,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -8577,6 +8726,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -8621,6 +8771,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -8700,6 +8852,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -8751,6 +8904,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -8795,6 +8949,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -8967,6 +9123,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -9018,6 +9175,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -9062,6 +9220,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -9136,6 +9296,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "encryption": Object {
@@ -9187,6 +9348,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "change:registered",
@@ -9231,6 +9393,8 @@ Object {
                   "registered": false,
                   "registerError": false,
                   "registering": false,
+                  "unregisterError": false,
+                  "unregistering": false,
                 },
               },
               "storeSparkInstance": [Function],
@@ -9310,6 +9474,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "encryption": Object {
@@ -9361,6 +9526,7 @@ Object {
                             "services": Object {
                               "roomServiceUrl": "https://example.com/devices/services/room/1",
                             },
+                            "unregister": [MockFunction],
                             "url": "https://example.com/devices/1",
                           },
                           "change:registered",
@@ -9405,6 +9571,8 @@ Object {
                     "registered": false,
                     "registerError": false,
                     "registering": false,
+                    "unregisterError": false,
+                    "unregistering": false,
                   },
                 },
                 "storeSparkInstance": [Function],
@@ -9772,6 +9940,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "encryption": Object {
@@ -9823,6 +9992,7 @@ Object {
                             "services": Object {
                               "roomServiceUrl": "https://example.com/devices/services/room/1",
                             },
+                            "unregister": [MockFunction],
                             "url": "https://example.com/devices/1",
                           },
                           "change:registered",
@@ -9867,6 +10037,8 @@ Object {
                     "registered": false,
                     "registerError": false,
                     "registering": false,
+                    "unregisterError": false,
+                    "unregistering": false,
                   },
                 },
                 "storeSparkInstance": [Function],
@@ -9941,6 +10113,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "encryption": Object {
@@ -9992,6 +10165,7 @@ Object {
                             "services": Object {
                               "roomServiceUrl": "https://example.com/devices/services/room/1",
                             },
+                            "unregister": [MockFunction],
                             "url": "https://example.com/devices/1",
                           },
                           "change:registered",
@@ -10036,6 +10210,8 @@ Object {
                     "registered": false,
                     "registerError": false,
                     "registering": false,
+                    "unregisterError": false,
+                    "unregistering": false,
                   },
                 },
                 "storeSparkInstance": [Function],
@@ -10115,6 +10291,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "encryption": Object {
@@ -10166,6 +10343,7 @@ Object {
                               "services": Object {
                                 "roomServiceUrl": "https://example.com/devices/services/room/1",
                               },
+                              "unregister": [MockFunction],
                               "url": "https://example.com/devices/1",
                             },
                             "change:registered",
@@ -10210,6 +10388,8 @@ Object {
                       "registered": false,
                       "registerError": false,
                       "registering": false,
+                      "unregisterError": false,
+                      "unregistering": false,
                     },
                   },
                   "storeSparkInstance": [Function],
@@ -10550,6 +10730,7 @@ Object {
                   "services": Object {
                     "roomServiceUrl": "https://example.com/devices/services/room/1",
                   },
+                  "unregister": [MockFunction],
                   "url": "https://example.com/devices/1",
                 },
                 "encryption": Object {
@@ -10601,6 +10782,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "change:registered",
@@ -10645,6 +10827,8 @@ Object {
               "registered": false,
               "registerError": false,
               "registering": false,
+              "unregisterError": false,
+              "unregistering": false,
             },
           },
           "storeSparkInstance": [Function],
@@ -11437,6 +11621,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "encryption": Object {
@@ -11488,6 +11673,7 @@ Object {
                               "services": Object {
                                 "roomServiceUrl": "https://example.com/devices/services/room/1",
                               },
+                              "unregister": [MockFunction],
                               "url": "https://example.com/devices/1",
                             },
                             "change:registered",
@@ -11532,6 +11718,8 @@ Object {
                       "registered": false,
                       "registerError": false,
                       "registering": false,
+                      "unregisterError": false,
+                      "unregistering": false,
                     },
                   },
                   "storeSparkInstance": [Function],
@@ -11662,6 +11850,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -11713,6 +11902,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -11757,6 +11947,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -11831,6 +12023,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "encryption": Object {
@@ -11882,6 +12075,7 @@ Object {
                         "services": Object {
                           "roomServiceUrl": "https://example.com/devices/services/room/1",
                         },
+                        "unregister": [MockFunction],
                         "url": "https://example.com/devices/1",
                       },
                       "change:registered",
@@ -11926,6 +12120,8 @@ Object {
                 "registered": false,
                 "registerError": false,
                 "registering": false,
+                "unregisterError": false,
+                "unregistering": false,
               },
             },
             "storeSparkInstance": [Function],
@@ -12648,6 +12844,7 @@ Object {
                           "services": Object {
                             "roomServiceUrl": "https://example.com/devices/services/room/1",
                           },
+                          "unregister": [MockFunction],
                           "url": "https://example.com/devices/1",
                         },
                         "encryption": Object {
@@ -12699,6 +12896,7 @@ Object {
                               "services": Object {
                                 "roomServiceUrl": "https://example.com/devices/services/room/1",
                               },
+                              "unregister": [MockFunction],
                               "url": "https://example.com/devices/1",
                             },
                             "change:registered",
@@ -12743,6 +12941,8 @@ Object {
                       "registered": false,
                       "registerError": false,
                       "registering": false,
+                      "unregisterError": false,
+                      "unregistering": false,
                     },
                   },
                   "storeSparkInstance": [Function],
@@ -12869,6 +13069,7 @@ Object {
                   "services": Object {
                     "roomServiceUrl": "https://example.com/devices/services/room/1",
                   },
+                  "unregister": [MockFunction],
                   "url": "https://example.com/devices/1",
                 },
                 "encryption": Object {
@@ -12920,6 +13121,7 @@ Object {
                       "services": Object {
                         "roomServiceUrl": "https://example.com/devices/services/room/1",
                       },
+                      "unregister": [MockFunction],
                       "url": "https://example.com/devices/1",
                     },
                     "change:registered",
@@ -12964,6 +13166,8 @@ Object {
               "registered": false,
               "registerError": false,
               "registering": false,
+              "unregisterError": false,
+              "unregistering": false,
             },
           },
           "storeSparkInstance": [Function],
@@ -13046,6 +13250,7 @@ Object {
                 "services": Object {
                   "roomServiceUrl": "https://example.com/devices/services/room/1",
                 },
+                "unregister": [MockFunction],
                 "url": "https://example.com/devices/1",
               },
               "encryption": Object {
@@ -13097,6 +13302,7 @@ Object {
                     "services": Object {
                       "roomServiceUrl": "https://example.com/devices/services/room/1",
                     },
+                    "unregister": [MockFunction],
                     "url": "https://example.com/devices/1",
                   },
                   "change:registered",
@@ -13141,6 +13347,8 @@ Object {
             "registered": false,
             "registerError": false,
             "registering": false,
+            "unregisterError": false,
+            "unregistering": false,
           },
         },
         "storeSparkInstance": [Function],

--- a/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/reducer.test.js.snap
@@ -10,6 +10,8 @@ Immutable.Map {
     "registered": false,
     "registerError": true,
     "registering": false,
+    "unregisterError": false,
+    "unregistering": false,
   },
 }
 `;
@@ -26,6 +28,24 @@ Immutable.Map {
     "registered": false,
     "registerError": false,
     "registering": false,
+    "unregisterError": false,
+    "unregistering": false,
+  },
+}
+`;
+
+exports[`spark reducer should handle UNREGISTER_DEVICE_FAILURE 1`] = `
+Immutable.Map {
+  "error": [Error: device failure],
+  "spark": null,
+  "status": Immutable.Record {
+    "authenticated": false,
+    "authenticating": false,
+    "registered": false,
+    "registerError": false,
+    "registering": false,
+    "unregisterError": true,
+    "unregistering": false,
   },
 }
 `;
@@ -40,6 +60,8 @@ Immutable.Map {
     "registered": true,
     "registerError": false,
     "registering": false,
+    "unregisterError": false,
+    "unregistering": false,
   },
 }
 `;
@@ -54,6 +76,8 @@ Immutable.Map {
     "registered": false,
     "registerError": false,
     "registering": false,
+    "unregisterError": false,
+    "unregistering": false,
   },
 }
 `;

--- a/packages/node_modules/@webex/react-redux-spark/src/actions.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/actions.js
@@ -1,12 +1,22 @@
 import {getStatusFromInstance} from './helpers';
 
 export const REGISTER_DEVICE_FAILURE = 'spark/REGISTER_DEVICE_FAILURE';
+export const UNREGISTER_DEVICE_FAILURE = 'spark/UNREGISTER_DEVICE_FAILURE';
 export const STORE_SPARK_INSTANCE = 'spark/STORE_SPARK_INSTANCE';
 export const UPDATE_SPARK_STATUS = 'spark/UPDATE_SPARK_STATUS';
 
 function registerDeviceFailure(error) {
   return {
     type: REGISTER_DEVICE_FAILURE,
+    payload: {
+      error
+    }
+  };
+}
+
+function unregisterDeviceFailure(error) {
+  return {
+    type: UNREGISTER_DEVICE_FAILURE,
     payload: {
       error
     }
@@ -41,5 +51,16 @@ export function registerDevice(spark) {
     return spark.internal.device.register()
       .then(() => dispatch(updateSparkStatus({registering: false, registered: true})))
       .catch((error) => dispatch(registerDeviceFailure(error)));
+  };
+}
+
+
+export function unregisterDevice(spark) {
+  return (dispatch) => {
+    dispatch(updateSparkStatus({unregistering: true}));
+
+    return spark.internal.device.unregister()
+      .then(() => dispatch(updateSparkStatus({unregistering: false, registered: false})))
+      .catch((error) => dispatch(unregisterDeviceFailure(error)));
   };
 }

--- a/packages/node_modules/@webex/react-redux-spark/src/actions.test.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/actions.test.js
@@ -37,6 +37,15 @@ describe('sdk actions', () => {
       });
   });
 
+  it('should unregister this device with spark', () => {
+    const spark = createMockSpark();
+
+    return mockStore.dispatch(actions.unregisterDevice(spark))
+      .then(() => {
+        expect(mockStore.getActions()).toMatchSnapshot();
+      });
+  });
+
   it('should handle registration errors', () => {
     const spark = createMockSpark();
 

--- a/packages/node_modules/@webex/react-redux-spark/src/component.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/component.js
@@ -85,7 +85,7 @@ export class SparkComponent extends Component {
 
   /**
    * Register the device if the user has been authenticated
-   * and the device is not regusterd yet.
+   * and the device is not registered yet.
    * @param {Object} sparkInstance
    */
   setupDevice(sparkInstance) {

--- a/packages/node_modules/@webex/react-redux-spark/src/reducer.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/reducer.js
@@ -2,6 +2,7 @@ import {fromJS, Record} from 'immutable';
 
 import {
   REGISTER_DEVICE_FAILURE,
+  UNREGISTER_DEVICE_FAILURE,
   STORE_SPARK_INSTANCE,
   UPDATE_SPARK_STATUS
 } from './actions';
@@ -11,7 +12,9 @@ const Status = Record({
   authenticating: false,
   registered: false,
   registerError: false,
-  registering: false
+  registering: false,
+  unregisterError: false,
+  unregistering: false
 });
 
 export const initialState = fromJS({
@@ -37,6 +40,11 @@ export default function reducer(state = initialState, action) {
       return state.set('error', fromJS(action.payload.error))
         .setIn(['status', 'registerError'], true)
         .setIn(['status', 'registering'], false);
+
+    case UNREGISTER_DEVICE_FAILURE:
+      return state.set('error', fromJS(action.payload.error))
+        .setIn(['status', 'unregisterError'], true)
+        .setIn(['status', 'unregistering'], false);
 
     default:
       return state;

--- a/packages/node_modules/@webex/react-redux-spark/src/reducer.test.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/reducer.test.js
@@ -1,6 +1,7 @@
 import reducer, {initialState} from './reducer';
 import {
   REGISTER_DEVICE_FAILURE,
+  UNREGISTER_DEVICE_FAILURE,
   STORE_SPARK_INSTANCE,
   UPDATE_SPARK_STATUS
 } from './actions';
@@ -42,6 +43,15 @@ describe('spark reducer', () => {
   it('should handle REGISTER_DEVICE_FAILURE', () => {
     expect(reducer(initialState, {
       type: REGISTER_DEVICE_FAILURE,
+      payload: {
+        error: new Error('device failure')
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle UNREGISTER_DEVICE_FAILURE', () => {
+    expect(reducer(initialState, {
+      type: UNREGISTER_DEVICE_FAILURE,
       payload: {
         error: new Error('device failure')
       }

--- a/packages/node_modules/@webex/widget-space/src/container.js
+++ b/packages/node_modules/@webex/widget-space/src/container.js
@@ -11,6 +11,8 @@ import LoadingScreen from '@webex/react-component-loading-screen';
 import Timer from '@webex/react-component-timer';
 import ErrorDisplay from '@webex/react-component-error-display';
 
+import {unregisterDevice} from '../../react-redux-spark/src/actions';
+
 import ActivityMenu from './components/activity-menu';
 
 import {storeDestination} from './actions';
@@ -78,6 +80,13 @@ const defaultProps = {
 };
 
 export class SpaceWidget extends Component {
+  componentWillUnmount() {
+    const {sparkInstance} = this.props;
+
+    // Make sure we unregister device when unmouting this component
+    this.props.unregisterDevice(sparkInstance);
+  }
+
   render() {
     const {props} = this;
     const {
@@ -209,7 +218,8 @@ export default compose(
   connect(
     null,
     (dispatch) => bindActionCreators({
-      storeDestination
+      storeDestination,
+      unregisterDevice
     }, dispatch)
   ),
   ...enhancers


### PR DESCRIPTION
This PR handle the issue mentioned on this ticket: Ticket: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-147741

Basically when we "Remove Widget" we also make sure that we remove (DELETE) the device.

Steps to test it: 
1) Add you Access Token
2) In the "Space Widget" section click on "Open Space Widget"
3) Open the Developer console and go to the "Network" tab 
4) Click on "Remove Widget"
5) You should see a DELETE call to `https://wdm-a.wbx2.com/wdm/api/v1/devices/<<devideId>>`

![Screen Shot 2020-06-23 at 12 09 18 PM](https://user-images.githubusercontent.com/3578942/85428174-d260fb80-b54a-11ea-8ecf-75a35747400c.png)
