### PR TITLE
Set limit on attachments

### DIFF
--- a/packages/node_modules/@webex/react-component-utils/src/constants.js
+++ b/packages/node_modules/@webex/react-component-utils/src/constants.js
@@ -86,6 +86,8 @@ export const TEXT_INPUT_ELEMENT = 'Input.Text';
 export const TOGGLE_INPUT_ELEMENT = 'Input.Toggle';
 export const CHOICE_SET_INPUT_ELEMENT = 'Input.ChoiceSet';
 
+export const MAXIMUM_BYTES = 150000000; // 150 MB threshold limit
+
 export const ADAPTIVE_CARD_HOST_CONFIG = {
   hostCapabilities: {
     capabilities: null

--- a/packages/node_modules/@webex/react-component-utils/src/constants.js
+++ b/packages/node_modules/@webex/react-component-utils/src/constants.js
@@ -86,7 +86,7 @@ export const TEXT_INPUT_ELEMENT = 'Input.Text';
 export const TOGGLE_INPUT_ELEMENT = 'Input.Toggle';
 export const CHOICE_SET_INPUT_ELEMENT = 'Input.ChoiceSet';
 
-export const MAXIMUM_BYTES = 150000000; // 150 MB threshold limit
+export const FILE_ATTACHMENT_MAX_SIZE = 150000000; // 150 MB threshold limit
 
 export const ADAPTIVE_CARD_HOST_CONFIG = {
   hostCapabilities: {

--- a/packages/node_modules/@webex/react-component-utils/src/files.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.js
@@ -1,6 +1,5 @@
 import uuid from 'uuid';
 
-
 const FILE_TYPES = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
   'application/pdf': 'pdf',

--- a/packages/node_modules/@webex/react-component-utils/src/files.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.js
@@ -1,6 +1,5 @@
 import uuid from 'uuid';
 
-import {FILE_ATTACHMENT_MAX_SIZE} from './constants';
 
 const FILE_TYPES = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
@@ -53,8 +52,7 @@ export function constructFile(file) {
     displayName: file.name,
     fileSize: file.size,
     fileSizePretty: bytesToSize(file.size),
-    mimeType: file.type,
-    overThreshold: file.size >= FILE_ATTACHMENT_MAX_SIZE
+    mimeType: file.type
   });
 }
 

--- a/packages/node_modules/@webex/react-component-utils/src/files.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.js
@@ -1,5 +1,7 @@
 import uuid from 'uuid';
 
+import {MAXIMUM_BYTES} from './constants';
+
 const FILE_TYPES = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
   'application/pdf': 'pdf',
@@ -51,7 +53,8 @@ export function constructFile(file) {
     displayName: file.name,
     fileSize: file.size,
     fileSizePretty: bytesToSize(file.size),
-    mimeType: file.type
+    mimeType: file.type,
+    overThreshold: file.size >= MAXIMUM_BYTES
   });
 }
 

--- a/packages/node_modules/@webex/react-component-utils/src/files.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.js
@@ -1,6 +1,6 @@
 import uuid from 'uuid';
 
-import {MAXIMUM_BYTES} from './constants';
+import {FILE_ATTACHMENT_MAX_SIZE} from './constants';
 
 const FILE_TYPES = {
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
@@ -54,7 +54,7 @@ export function constructFile(file) {
     fileSize: file.size,
     fileSizePretty: bytesToSize(file.size),
     mimeType: file.type,
-    overThreshold: file.size >= MAXIMUM_BYTES
+    overThreshold: file.size >= FILE_ATTACHMENT_MAX_SIZE
   });
 }
 

--- a/packages/node_modules/@webex/react-container-message-composer/src/container.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/container.js
@@ -19,7 +19,7 @@ import {
 import {searchForUser} from '@webex/redux-module-search';
 import PresenceAvatar from '@webex/react-container-presence-avatar';
 import FileStagingArea from '@webex/react-component-file-staging-area';
-import {constructFiles} from '@webex/react-component-utils';
+import {constructFiles, FILE_ATTACHMENT_MAX_SIZE} from '@webex/react-component-utils';
 import {addError, removeError} from '@webex/redux-module-errors';
 
 import ComposerButtons from './components/ComposerButtons';
@@ -180,15 +180,15 @@ export class MessageComposer extends Component {
       } = props;
 
       const files = constructFiles(e.target.files);
-      const overThreshold = files.some((file) => file.overThreshold);
+      const maxSizeExceeded = files.some((file) => file.size >= FILE_ATTACHMENT_MAX_SIZE);
 
-      if (overThreshold) {
+      if (maxSizeExceeded) {
         props.addError({
           id: 'file-attachment-threshold',
           actionTitle: 'Dismiss',
           onAction: () => props.removeError('file-attachment-threshold'),
-          displayTitle: 'What if I told you',
-          displaySubtitle: 'A file you are attempting to attach is too large and will crash the browser',
+          displayTitle: 'Too big for the web!',
+          displaySubtitle: 'Only attachments smaller than 150MB are allowed',
           temporary: true
         });
       }

--- a/packages/node_modules/@webex/react-container-message-composer/src/container.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/container.js
@@ -177,8 +177,15 @@ export class MessageComposer extends Component {
       } = props;
 
       const files = constructFiles(e.target.files);
+      const overThreshold = files.some((file) => file.overThreshold);
 
-      props.addFiles(conversation, activity, files, sparkInstance);
+      if (overThreshold) {
+        // eslint-disable-next-line no-alert
+        alert('One of your files is too large to attach');
+      }
+      else {
+        props.addFiles(conversation, activity, files, sparkInstance);
+      }
 
       // Clear the value of the input so the same file can be added again.
       e.target.value = '';

--- a/packages/node_modules/@webex/react-container-message-composer/src/container.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/container.js
@@ -20,6 +20,7 @@ import {searchForUser} from '@webex/redux-module-search';
 import PresenceAvatar from '@webex/react-container-presence-avatar';
 import FileStagingArea from '@webex/react-component-file-staging-area';
 import {constructFiles} from '@webex/react-component-utils';
+import {addError, removeError} from '@webex/redux-module-errors';
 
 import ComposerButtons from './components/ComposerButtons';
 
@@ -42,7 +43,9 @@ const injectedPropTypes = {
   setUserTyping: PropTypes.func.isRequired,
   submitActivity: PropTypes.func.isRequired,
   searchForUser: PropTypes.func.isRequired,
-  storeActivityText: PropTypes.func.isRequired
+  storeActivityText: PropTypes.func.isRequired,
+  addError: PropTypes.func.isRequired,
+  removeError: PropTypes.func.isRequired
 };
 
 const propTypes = {
@@ -180,8 +183,14 @@ export class MessageComposer extends Component {
       const overThreshold = files.some((file) => file.overThreshold);
 
       if (overThreshold) {
-        // eslint-disable-next-line no-alert
-        alert('One of your files is too large to attach');
+        props.addError({
+          id: 'file-attachment-threshold',
+          actionTitle: 'Dismiss',
+          onAction: () => props.removeError('file-attachment-threshold'),
+          displayTitle: 'What if I told you',
+          displaySubtitle: 'A file you are attempting to attach is too large and will crash the browser',
+          temporary: true
+        });
       }
       else {
         props.addFiles(conversation, activity, files, sparkInstance);
@@ -328,6 +337,8 @@ export default connect(
     setUserTyping,
     submitActivity,
     searchForUser,
-    storeActivityText
+    storeActivityText,
+    addError,
+    removeError
   }, dispatch)
 )(MessageComposer);


### PR DESCRIPTION
This PR is to fix [160675](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-160675).  When a single attachment is larger than 150mb on chrome or firefox it causes the browser to crash when the files are added, This PR fixes that by adding a threshold property that will be true if file size is over 150mb.  Right now the only cue to user is an alert that tells them one of the attached files is too large.