### PR TITLE
chore(webpack): update the dev server CSP

### DIFF
--- a/scripts/webpack/webpack.dev.babel.js
+++ b/scripts/webpack/webpack.dev.babel.js
@@ -51,7 +51,12 @@ module.exports = (env) => webpackConfigBase({
       publicPath: false
     },
     headers: {
-      'Content-Security-Policy': 'script-src \'self\' \'unsafe-inline\' code.s4d.io; style-src \'self\' \'unsafe-inline\' code.s4d.io; media-src \'self\' code.s4d.io *.clouddrive.com *.giphy.com *.webexcontent.com data: blob:; font-src \'self\' code.s4d.io; img-src \'self\' code.s4d.io *.clouddrive.com data: blob: *.rackcdn.com; connect-src \'self\' localhost ws://localhost:8000 wss://*.wbx.com wss://*.wbx2.com wss://*.ciscospark.com ws://*.wbx.com *.wbx2.com https://*.wbx2.com *.webex.com code.s4d.io *.ciscospark.com *.giphy.com *.webexcontent.com https://*.clouddrive.com/;'
+      'Content-Security-Policy': "script-src 'self' 'unsafe-inline' https://code.s4d.io; "
+        + "style-src 'self' 'unsafe-inline' https://code.s4d.io; "
+        + "media-src 'self' https://code.s4d.io https://*.clouddrive.com https://*.giphy.com https://*.webexcontent.com data: blob:; "
+        + "font-src 'self' https://code.s4d.io; "
+        + "img-src 'self' https://*.clouddrive.com https://code.s4d.io https://*.webexcontent.com data: blob: https://*.rackcdn.com; "
+        + "connect-src 'self' localhost ws://localhost:8000 wss://*.ciscospark.com wss://*.wbx.com wss://*.wbx2.com https://*.ciscospark.com https://*.clouddrive.com/ https://code.s4d.io https://*.giphy.com https://*.wbx2.com https://*.webex.com  https://*.webexcontent.com;"
     }
   }
 }, env);


### PR DESCRIPTION
Changes to the CSP spec have made definitions without a protocol match the protocol of the requested page instead of a wildcard. We need to be explicit on the protocol the connection is made to. 

This will match an update to the [developer portal documentation](https://developer.webex.com/docs/widgets#content-security-policy) as well.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-142925