### PR TITLE
fix(message-composer): use unique id for input

### DIFF
--- a/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
     className="webex-message-composer-buttons buttonsArea"
   >
     <label
-      htmlFor="FAKE_INPUT_ID"
+      htmlFor="messageFileInput-FAKE_INPUT_ID"
     >
       <button
         alt="Attach Files"
@@ -49,7 +49,7 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
       </button>
       <input
         className="webex-file-input fileInput"
-        id="FAKE_INPUT_ID"
+        id="messageFileInput-FAKE_INPUT_ID"
         multiple="multiple"
         onChange={[Function]}
         type="file"

--- a/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
     className="webex-message-composer-buttons buttonsArea"
   >
     <label
-      htmlFor="messageFileUpload"
+      htmlFor="FAKE_INPUT_ID"
     >
       <button
         alt="Attach Files"
@@ -49,7 +49,7 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
       </button>
       <input
         className="webex-file-input fileInput"
-        id="messageFileUpload"
+        id="FAKE_INPUT_ID"
         multiple="multiple"
         onChange={[Function]}
         type="file"

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
@@ -2,16 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import bowser from 'bowser';
+import uuid from 'uuid';
 
 import {Icon} from '@momentum-ui/react';
 
 import styles from './ComposerButtons.css';
 
 function ComposerButtons({onAttachFile, composerActions}) {
+  const inputId = uuid.v4();
+
   function handleFileIconClick(event) {
     if (event.type === 'click' || event.type === 'keydown' && (event.keyCode === 13 || event.keyCode === 32)) {
       if (!bowser.safari) {
-        document.getElementById('messageFileUpload').click();
+        document.getElementById(inputId).click();
       }
     }
   }
@@ -20,7 +23,7 @@ function ComposerButtons({onAttachFile, composerActions}) {
     (
       composerActions.attachFiles &&
       <div className={classNames('webex-message-composer-buttons', styles.buttonsArea)}>
-        <label htmlFor="messageFileUpload">
+        <label htmlFor={inputId}>
           <Icon
             ariaLabel="Attach Files"
             name="attachment_16"
@@ -28,7 +31,7 @@ function ComposerButtons({onAttachFile, composerActions}) {
           />
           <input
             className={classNames('webex-file-input', styles.fileInput)}
-            id="messageFileUpload"
+            id={inputId}
             multiple="multiple"
             onChange={onAttachFile}
             type="file"

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
@@ -9,7 +9,7 @@ import {Icon} from '@momentum-ui/react';
 import styles from './ComposerButtons.css';
 
 function ComposerButtons({onAttachFile, composerActions}) {
-  const inputId = uuid.v4();
+  const inputId = `messageFileInput-${uuid.v4()}`;
 
   function handleFileIconClick(event) {
     if (event.type === 'click' || event.type === 'keydown' && (event.keyCode === 13 || event.keyCode === 32)) {

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.test.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
+import uuid from 'uuid';
 
 import ComposerButtons from './ComposerButtons';
 
@@ -7,6 +8,7 @@ const renderer = new ShallowRenderer();
 
 describe('ComposerButtons component', () => {
   let props;
+  let uuidSpy;
 
   beforeEach(() => {
     props = {
@@ -15,7 +17,11 @@ describe('ComposerButtons component', () => {
       },
       onAttachFile: () => {}
     };
+
+    uuidSpy = jest.spyOn(uuid, 'v4').mockReturnValue('FAKE_INPUT_ID');
   });
+
+  afterEach(() => uuidSpy.mockRestore);
 
   it('renders properly with attachFiles enabled', () => {
     renderer.render(

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
@@ -5,7 +5,7 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
   className="webex-message-composer-buttons buttonsArea"
 >
   <label
-    htmlFor="messageFileUpload"
+    htmlFor="FAKE_INPUT_ID"
   >
     <Icon
       append={false}
@@ -26,7 +26,7 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
     />
     <input
       className="webex-file-input fileInput"
-      id="messageFileUpload"
+      id="FAKE_INPUT_ID"
       multiple="multiple"
       onChange={[Function]}
       type="file"

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
@@ -5,7 +5,7 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
   className="webex-message-composer-buttons buttonsArea"
 >
   <label
-    htmlFor="FAKE_INPUT_ID"
+    htmlFor="messageFileInput-FAKE_INPUT_ID"
   >
     <Icon
       append={false}
@@ -26,7 +26,7 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
     />
     <input
       className="webex-file-input fileInput"
-      id="FAKE_INPUT_ID"
+      id="messageFileInput-FAKE_INPUT_ID"
       multiple="multiple"
       onChange={[Function]}
       type="file"

--- a/packages/node_modules/@webex/react-container-message-composer/src/index.test.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/index.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import {Map} from 'immutable';
+import uuid from 'uuid';
+
 import {reducers} from '@webex/widget-space';
 import {withInitialState} from '@webex/webex-widget-base';
 import {initialState as activityInitialState} from '@webex/redux-module-activity';
@@ -23,6 +25,8 @@ describe('MessageComposer component', () => {
 
   describe('snapshot tests', () => {
     it('renders properly', () => {
+      const uuidSpy = jest.spyOn(uuid, 'v4').mockReturnValue('FAKE_INPUT_ID');
+
       component = renderer.create(
         <MessageComposerComponent
           composerActions={{attachFiles: true}}
@@ -33,6 +37,8 @@ describe('MessageComposer component', () => {
         />
       );
       expect(component).toMatchSnapshot();
+
+      uuidSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
- Avoid multiple widgets in the DOM opening the same input element