### PR TITLE
feat(ActivityText): add block padding

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-text/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-text/src/styles.css
@@ -53,3 +53,15 @@
 .activityText p {
   margin: 0;
 }
+
+.activityText p:not(:last-of-type) {
+  margin-bottom: 10px;
+}
+
+.activityText ol, .activityText pre, .activityText ul {
+  margin: 1em 0!important;
+}
+
+.activityText ul {
+  margin-left: 2em !important;
+}


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-153362

The css spacing didn't match the web client and desktop clients for paragraphs and blocks.

Pre Changes Widget:
![image](https://user-images.githubusercontent.com/190647/94612304-ea929600-0270-11eb-9c82-f809308defb5.png)

Web Client:
![image](https://user-images.githubusercontent.com/190647/94612940-d307dd00-0271-11eb-96da-8d7d888e0914.png)

Mac Client:
![image](https://user-images.githubusercontent.com/190647/94612996-e9159d80-0271-11eb-8a8f-5cf47ecc6f96.png)

Post PR Widget:
![image](https://user-images.githubusercontent.com/190647/94614204-cdab9200-0273-11eb-8a2d-fecfe58f760a.png)

