### PR TITLE
Add Drag and Drop file size limit

### DIFF
--- a/packages/node_modules/@webex/react-component-utils/src/constants.js
+++ b/packages/node_modules/@webex/react-component-utils/src/constants.js
@@ -86,6 +86,17 @@ export const TEXT_INPUT_ELEMENT = 'Input.Text';
 export const TOGGLE_INPUT_ELEMENT = 'Input.Toggle';
 export const CHOICE_SET_INPUT_ELEMENT = 'Input.ChoiceSet';
 
+
+export const FILE_TYPES = {
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
+  'application/pdf': 'pdf',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'presentation',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'doc',
+  'application/vnd.ms-excel': 'spreadsheet',
+  'application/octet-stream': 'binary',
+  'application/zip': 'zip'
+};
+
 export const FILE_ATTACHMENT_MAX_SIZE = 150000000; // 150 MB threshold limit
 
 export const ADAPTIVE_CARD_HOST_CONFIG = {

--- a/packages/node_modules/@webex/react-component-utils/src/files.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.js
@@ -1,14 +1,6 @@
 import uuid from 'uuid';
 
-const FILE_TYPES = {
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
-  'application/pdf': 'pdf',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'presentation',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'doc',
-  'application/vnd.ms-excel': 'spreadsheet',
-  'application/octet-stream': 'binary',
-  'application/zip': 'zip'
-};
+import {FILE_ATTACHMENT_MAX_SIZE, FILE_TYPES} from './constants';
 
 /**
  * Converts bytes to human readable size
@@ -114,4 +106,34 @@ export function getFileType(mimeType) {
   }
 
   return 'file';
+}
+
+/**
+ * Checks the files in an array and determines if their file size is too large.
+ *
+ * @param {Array} files An array of file objects with a `size` property
+ * @param {function} addError Function from the errors redux action
+ * @param {function} removeError Function from the errors redux action
+ * @returns {boolean0}
+ */
+export function checkMaxFileSize(files, addError, removeError) {
+  const maxSizeExceeded = files.some((file) => file.size >= FILE_ATTACHMENT_MAX_SIZE);
+
+  if (maxSizeExceeded) {
+    const errorID = 'file-attachment-threshold';
+
+    addError({
+      id: errorID,
+      actionTitle: 'Dismiss',
+      onAction: () => removeError(errorID),
+      displayTitle: 'Too big for the web!',
+      displaySubtitle: 'Only attachments smaller than 150MB are allowed',
+      temporary: true
+    });
+
+
+    return false;
+  }
+
+  return true;
 }

--- a/packages/node_modules/@webex/react-component-utils/src/files.test.js
+++ b/packages/node_modules/@webex/react-component-utils/src/files.test.js
@@ -1,0 +1,42 @@
+import {FILE_ATTACHMENT_MAX_SIZE} from './constants';
+import {checkMaxFileSize} from './files';
+
+describe('files utilities', () => {
+  describe('checkMaxFileSize()', () => {
+    let addError, files;
+
+    beforeEach(() => {
+      addError = jest.fn();
+    });
+
+    describe('when all files are under file size limit', () => {
+      beforeEach(() => {
+        files = [{size: FILE_ATTACHMENT_MAX_SIZE - 1}];
+      });
+
+      it('returns true when all files are under file size limit', () => {
+        expect(checkMaxFileSize(files, addError)).toBe(true);
+      });
+
+      it('does not call addError', () => {
+        checkMaxFileSize(files, addError);
+        expect(addError).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when a file is over the file size limit', () => {
+      beforeEach(() => {
+        files = [{size: FILE_ATTACHMENT_MAX_SIZE + 1}];
+      });
+
+      it('returns false', () => {
+        expect(checkMaxFileSize(files, addError)).toBe(false);
+      });
+
+      it('calls addError', () => {
+        checkMaxFileSize(files, addError);
+        expect(addError).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/node_modules/@webex/react-container-message-composer/src/container.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/container.js
@@ -19,7 +19,7 @@ import {
 import {searchForUser} from '@webex/redux-module-search';
 import PresenceAvatar from '@webex/react-container-presence-avatar';
 import FileStagingArea from '@webex/react-component-file-staging-area';
-import {constructFiles, FILE_ATTACHMENT_MAX_SIZE} from '@webex/react-component-utils';
+import {constructFiles, checkMaxFileSize} from '@webex/react-component-utils';
 import {addError, removeError} from '@webex/redux-module-errors';
 
 import ComposerButtons from './components/ComposerButtons';
@@ -180,19 +180,8 @@ export class MessageComposer extends Component {
       } = props;
 
       const files = constructFiles(e.target.files);
-      const maxSizeExceeded = files.some((file) => file.size >= FILE_ATTACHMENT_MAX_SIZE);
 
-      if (maxSizeExceeded) {
-        props.addError({
-          id: 'file-attachment-threshold',
-          actionTitle: 'Dismiss',
-          onAction: () => props.removeError('file-attachment-threshold'),
-          displayTitle: 'Too big for the web!',
-          displaySubtitle: 'Only attachments smaller than 150MB are allowed',
-          temporary: true
-        });
-      }
-      else {
+      if (checkMaxFileSize(files, props.addError, props.removeError)) {
         props.addFiles(conversation, activity, files, sparkInstance);
       }
 

--- a/packages/node_modules/@webex/widget-message/src/container.js
+++ b/packages/node_modules/@webex/widget-message/src/container.js
@@ -8,7 +8,7 @@ import {debounce, has, throttle, filter} from 'lodash';
 import {autobind} from 'core-decorators';
 import {compose} from 'recompose';
 
-import {constructFiles, API_ACTIVITY_VERB, CARD_CONTAINS_IMAGE, ACTIVITY_OBJECT_CONTENT_CATEGORY_IMAGES} from '@webex/react-component-utils';
+import {checkMaxFileSize, constructFiles, API_ACTIVITY_VERB, CARD_CONTAINS_IMAGE, ACTIVITY_OBJECT_CONTENT_CATEGORY_IMAGES} from '@webex/react-component-utils';
 
 import {fetchAvatarsForUsers} from '@webex/redux-module-avatar';
 
@@ -683,7 +683,7 @@ export class MessageWidget extends Component {
     } = props;
     const files = constructFiles(acceptedFiles);
 
-    if (files.length) {
+    if (files.length && checkMaxFileSize(files, props.addError, props.removeError)) {
       props.addFiles(conversation, activity, files, sparkInstance);
     }
   }


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-172895

We were checking for large files upon clicking the attach button, but drag and drop was not using the same check. 