### PR TITLE
fix(MessageComposer): use icon as label for file input

### DIFF
--- a/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
@@ -7,52 +7,24 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
   <div
     className="webex-message-composer-buttons buttonsArea"
   >
+    <input
+      className="webex-file-input fileInput"
+      id="messageFileInput-FAKE_INPUT_ID"
+      multiple="multiple"
+      onChange={[Function]}
+      type="file"
+    />
     <label
       htmlFor="messageFileInput-FAKE_INPUT_ID"
     >
-      <button
-        alt="Attach Files"
+      <i
         aria-label="Attach Files"
-        aria-pressed={null}
-        className="md-button md-button--36 md-button--icon"
-        data-md-event-key="md-button-1"
-        disabled={false}
-        id="md-button-1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
+        className="md-icon icon icon-attachment_16"
         style={
           Object {
-            "style": Object {},
+            "fontSize": 16,
           }
         }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="md-button__children"
-          style={
-            Object {
-              "opacity": "1",
-            }
-          }
-        >
-          <i
-            aria-label={null}
-            className="md-icon icon icon-attachment_16"
-            style={
-              Object {
-                "fontSize": 16,
-              }
-            }
-          />
-        </span>
-      </button>
-      <input
-        className="webex-file-input fileInput"
-        id="messageFileInput-FAKE_INPUT_ID"
-        multiple="multiple"
-        onChange={[Function]}
-        type="file"
       />
     </label>
   </div>

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
@@ -1,7 +1,7 @@
+/* eslint-disable jsx-a11y/label-has-for */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import bowser from 'bowser';
 import uuid from 'uuid';
 
 import {Icon} from '@momentum-ui/react';
@@ -11,30 +11,21 @@ import styles from './ComposerButtons.css';
 function ComposerButtons({onAttachFile, composerActions}) {
   const inputId = `messageFileInput-${uuid.v4()}`;
 
-  function handleFileIconClick(event) {
-    if (event.type === 'click' || event.type === 'keydown' && (event.keyCode === 13 || event.keyCode === 32)) {
-      if (!bowser.safari) {
-        document.getElementById(inputId).click();
-      }
-    }
-  }
-
   return (
     (
       composerActions.attachFiles &&
       <div className={classNames('webex-message-composer-buttons', styles.buttonsArea)}>
+        <input
+          className={classNames('webex-file-input', styles.fileInput)}
+          id={inputId}
+          multiple="multiple"
+          onChange={onAttachFile}
+          type="file"
+        />
         <label htmlFor={inputId}>
           <Icon
             ariaLabel="Attach Files"
             name="attachment_16"
-            onClick={handleFileIconClick}
-          />
-          <input
-            className={classNames('webex-file-input', styles.fileInput)}
-            id={inputId}
-            multiple="multiple"
-            onChange={onAttachFile}
-            type="file"
           />
         </label>
       </div>

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
@@ -4,6 +4,13 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
 <div
   className="webex-message-composer-buttons buttonsArea"
 >
+  <input
+    className="webex-file-input fileInput"
+    id="messageFileInput-FAKE_INPUT_ID"
+    multiple="multiple"
+    onChange={[Function]}
+    type="file"
+  />
   <label
     htmlFor="messageFileInput-FAKE_INPUT_ID"
   >
@@ -16,20 +23,13 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
       color=""
       description=""
       name="attachment_16"
-      onClick={[Function]}
+      onClick={null}
       prepend={false}
       size={null}
       sizeOverride={false}
       style={null}
       title=""
       type=""
-    />
-    <input
-      className="webex-file-input fileInput"
-      id="messageFileInput-FAKE_INPUT_ID"
-      multiple="multiple"
-      onChange={[Function]}
-      type="file"
     />
   </label>
 </div>


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-180467

We did some strange things to get momentum icon buttons to work, but this solution is easier and works across browsers.