### PR TITLE
fix(card-element):  enter input value for zero length of text element

### DIFF
--- a/packages/node_modules/@webex/react-component-md-text-input/src/index.js
+++ b/packages/node_modules/@webex/react-component-md-text-input/src/index.js
@@ -53,7 +53,7 @@ class MDTextInput extends AdaptiveCard.TextInput {
       <Input
         label={this.title}
         value={this.value}
-        maxLength={this.maxLength}
+        maxLength={this.maxLength || null}
         placeholder={this.placeholder}
         type={inputStyles[this.style].toLowerCase()}
         multiline={!!this.isMultiline}


### PR DESCRIPTION
 **Description of changes made** 
* User can enter value for zero `maxLength` of the `input.text` element(https://adaptivecards.io/explorer/Input.Text.html)

**Associated issue number/tracking link**  
[SPARK-124705](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-124705)