### PR TITLE
fix(card-css): wrap fact value text

### DIFF
--- a/packages/node_modules/@webex/react-component-adaptive-card/src/adaptiveCard.scss
+++ b/packages/node_modules/@webex/react-component-adaptive-card/src/adaptiveCard.scss
@@ -264,4 +264,9 @@
   .ac-image {
     max-height: none !important;
   }
+  .ac-fact-value {
+    .ac-textBlock {
+      word-wrap: anywhere !important;
+    }
+  }
 }


### PR DESCRIPTION
**Description of changes made (Required)**
* Neither `FactSet` nor `fact` has a wrap parameter, but [factset config](https://docs.microsoft.com/en-us/adaptive-cards/rendering-cards/host-config#schema-factsetconfig) uses `wrap:true` by default.

**Associated issue number/tracking link (Required)**
[SPARK-180138](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-180138)

**Relevant screenshots to UI (Optional)**

**Before bug fix:**
<img width="389" alt="Screenshot 2020-10-22 at 7 49 21 PM" src="https://user-images.githubusercontent.com/55378170/96886574-57c8ce00-14a1-11eb-8ab3-affad6b5baf4.png">



**After:**
<img width="359" alt="Screenshot 2020-10-22 at 7 55 06 PM" src="https://user-images.githubusercontent.com/55378170/96886592-5ac3be80-14a1-11eb-93fa-1d0d9a36a4f2.png">

