### PR TITLE
feat(widget-recents): load requested number of spaces

### DIFF
--- a/packages/node_modules/@webex/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@webex/widget-recents/src/enhancers/setup.js
@@ -19,6 +19,8 @@ import {updateWidgetStatus} from '../actions';
 import {getToParticipant, getSpaceAvatar} from '../helpers';
 import getRecentsWidgetProps from '../selector';
 
+export const DEFAULT_SPACE_COUNT = 25;
+
 /**
  * Store the "to" participant in a 1:1 convo
  * This user is needed in our store to calculate a space title
@@ -128,12 +130,14 @@ function getInitialSpaces(props) {
     widgetStatus
   } = props;
 
+  const spaceLoadCount = (props.spaceLoadCount > 0) ? props.spaceLoadCount : DEFAULT_SPACE_COUNT;
+
   if (!widgetStatus.isFetchingInitialSpaces
     && !widgetStatus.hasFetchedInitialSpaces) {
     props.updateWidgetStatus({isFetchingInitialSpaces: true});
     if (props.basicMode) {
       props.fetchSpacesHydra(sparkInstance, {
-        max: props.spaceLoadCount
+        max: spaceLoadCount
       })
         .then(() => props.updateWidgetStatus({
           hasFetchedInitialSpaces: true,
@@ -148,11 +152,13 @@ function getInitialSpaces(props) {
        * and decrypt individually to give a good initial user experience.
        */
       props.fetchSpacesEncrypted(sparkInstance, {
-        conversationsLimit: 25
+        conversationsLimit: spaceLoadCount
       })
         .then((encryptedSpaces) => {
           props.updateWidgetStatus({
-            hasFetchedInitialSpaces: true
+            hasFetchedInitialSpaces: true,
+            // We don't currently have a second load state (pagination to come)
+            hasFetchedAllSpaces: true
           });
 
           // As the spaces decrypt, get the avatar for them
@@ -172,40 +178,6 @@ function getInitialSpaces(props) {
   }
 }
 
-/**
- * Gets a large batch of spaces to add to the existing
- * initially loaded spaces.
- *
- * @param {object} props
- */
-function getAllSpaces(props) {
-  const {
-    sparkInstance,
-    widgetStatus,
-    spaceLoadCount
-  } = props;
-
-  if (!widgetStatus.isFetchingAllSpaces
-    && !widgetStatus.hasFetchedAllSpaces) {
-    props.updateWidgetStatus({isFetchingAllSpaces: true});
-    props.fetchSpaces(sparkInstance, {
-      conversationsLimit: spaceLoadCount
-    })
-      .then((spaces) => {
-        spaces.forEach((space) => {
-          // Store the to user in a direct convo to calculate space title
-          if (space.type === SPACE_TYPE_ONE_ON_ONE) {
-            storeToParticipant(space, props);
-          }
-        });
-      })
-      .then(() => {
-        props.updateWidgetStatus({
-          hasFetchedAllSpaces: true
-        });
-      });
-  }
-}
 
 /**
  * Fetches the avatars for all the loaded spaces
@@ -258,10 +230,6 @@ export function setup(props) {
       // Initial fetching workflow
       if (!widgetStatus.hasFetchedInitialSpaces) {
         getInitialSpaces(props);
-      }
-      else if (!widgetStatus.hasFetchedAllSpaces && !props.basicMode) {
-        // Initial spaces have been fetched, load more
-        getAllSpaces(props);
       }
       else if (!widgetStatus.hasFetchedAvatars && !props.basicMode) {
         // All spaces have been fetched, load avatars

--- a/packages/node_modules/@webex/widget-recents/src/enhancers/setup.test.js
+++ b/packages/node_modules/@webex/widget-recents/src/enhancers/setup.test.js
@@ -1,4 +1,4 @@
-import {setup} from './setup';
+import {DEFAULT_SPACE_COUNT, setup} from './setup';
 
 describe('widget-recents: enhancers: setup', () => {
   let props;
@@ -147,6 +147,15 @@ describe('widget-recents: enhancers: setup', () => {
 
           expect(fetchConfig.max).toBe(10);
         });
+
+        it('should default the amount if not provided by spaceLoadCount to DEFAULT_SPACE_COUNT', () => {
+          props.spaceLoadCount = '';
+
+          setup(props);
+          const fetchConfig = props.fetchSpacesHydra.mock.calls[0][1];
+
+          expect(fetchConfig.max).toBe(DEFAULT_SPACE_COUNT);
+        });
       });
     });
 
@@ -161,12 +170,6 @@ describe('widget-recents: enhancers: setup', () => {
         // Initial Fetch
         props.widgetStatus.isFetchingInitialSpaces = true;
         props.widgetStatus.hasFetchedInitialSpaces = true;
-      });
-
-      it('should get all spaces', () => {
-        setup(props);
-
-        expect(props.fetchSpaces).toHaveBeenCalled();
       });
 
       it('should not get all spaces again during all space load', () => {


### PR DESCRIPTION
Removing the secondary space load due to the default limit and hard coded 25 being the same amount.

This also makes the first spaces request follow the limit passed in params.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-217484