### PR TITLE
feat(widget-space): display meeting timer in space widget menu

### DIFF
--- a/packages/node_modules/@webex/widget-space/src/container.js
+++ b/packages/node_modules/@webex/widget-space/src/container.js
@@ -144,13 +144,19 @@ export class SpaceWidget extends Component {
               <span className={classNames(`webex-tab-${at.name}`, styles.tabMeet)}>
                 <Button
                   ariaLabel={at.displayName}
-                  circle
+                  circle={!callStartTime}
                   id={styles.huddle}
                   color="green"
                   size={25}
                   onClick={() => props.handleActivityChange(at)}
                 >
                   <Icon name={`icon-${at.buttonType}_16`} />
+                  {
+                    callStartTime &&
+                    <div className={classNames(`webex-tab-${at.name}--huddle-timer`, styles.huddleTimer)}>
+                      <Timer startTime={callStartTime} />
+                    </div>
+                  }
                 </Button>
               </span>
             ));

--- a/packages/node_modules/@webex/widget-space/src/styles.css
+++ b/packages/node_modules/@webex/widget-space/src/styles.css
@@ -98,6 +98,11 @@
   background-color: #08421F;
 }
 
+.huddleTimer {
+  margin-left: 8px;
+  font-size: 14px;
+}
+
 .tabOther {
   background: transparent;
   box-shadow: 0px 0px 0px transparent;


### PR DESCRIPTION
Add meeting timer in space widget menu.

Fixes #SPARK-223764

------------

Notes:

Noticed that the timer only works if the call is already in progress. When `call.activeParticipantsCount` is 0, the component will not update as expected. When `call.activeParticipantsCount` is initially greater than 0, the component will update as expected. Perhaps an action isn't firing as expected or perhaps incorrect logic in a reducer.

Also `call.isActive` and `call.isConnected` does not update as expected.