### PR TITLE
feat(dangerouslyIgnoredRequiredPlugins): allow users to disable check…

### DIFF
--- a/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/component.test.js.snap
+++ b/packages/node_modules/@webex/react-redux-spark/src/__snapshots__/component.test.js.snap
@@ -55,6 +55,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -229,6 +230,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -408,6 +410,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -624,6 +627,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -798,6 +802,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -977,6 +982,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -1194,6 +1200,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -1368,6 +1375,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -1547,6 +1555,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -1740,6 +1749,7 @@ Object {
         },
         "memoizedProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -1766,6 +1776,7 @@ Object {
         "nextEffect": null,
         "pendingProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -1859,6 +1870,7 @@ Object {
           "notifyNestedSubs": [Function],
           "props": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -1887,6 +1899,7 @@ Object {
             "error": null,
             "props": Object {
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "registerDevice": [Function],
               "spark": Immutable.Map {
                 "error": null,
@@ -2134,6 +2147,7 @@ Object {
           "lastEffect": [Circular],
           "memoizedProps": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -2160,6 +2174,7 @@ Object {
           "nextEffect": null,
           "pendingProps": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -2253,6 +2268,7 @@ Object {
             "notifyNestedSubs": [Function],
             "props": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -2281,6 +2297,7 @@ Object {
               "error": null,
               "props": Object {
                 "addError": [Function],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "registerDevice": [Function],
                 "spark": Immutable.Map {
                   "error": null,
@@ -2517,6 +2534,7 @@ Object {
         "memoizedProps": Object {
           "accessToken": "",
           "addError": [Function],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "guestToken": "",
           "registerDevice": [Function],
           "sdkInstance": undefined,
@@ -2691,6 +2709,7 @@ Object {
         "pendingProps": Object {
           "accessToken": "",
           "addError": [Function],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "guestToken": "",
           "registerDevice": [Function],
           "sdkInstance": undefined,
@@ -2881,6 +2900,7 @@ Object {
           "lastEffect": [Circular],
           "memoizedProps": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -2907,6 +2927,7 @@ Object {
           "nextEffect": null,
           "pendingProps": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -3000,6 +3021,7 @@ Object {
             "notifyNestedSubs": [Function],
             "props": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -3028,6 +3050,7 @@ Object {
               "error": null,
               "props": Object {
                 "addError": [Function],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "registerDevice": [Function],
                 "spark": Immutable.Map {
                   "error": null,
@@ -3256,6 +3279,7 @@ Object {
           "props": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -3482,6 +3506,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -3656,6 +3681,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -3835,6 +3861,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -4051,6 +4078,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -4225,6 +4253,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -4404,6 +4433,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -4621,6 +4651,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -4795,6 +4826,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -4974,6 +5006,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -5167,6 +5200,7 @@ Object {
         },
         "memoizedProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -5193,6 +5227,7 @@ Object {
         "nextEffect": null,
         "pendingProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -5286,6 +5321,7 @@ Object {
           "notifyNestedSubs": [Function],
           "props": Object {
             "addError": [MockFunction],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "spark": Object {
               "authorization": "authorization",
               "internal": Object {
@@ -5314,6 +5350,7 @@ Object {
             "error": null,
             "props": Object {
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "registerDevice": [Function],
               "spark": Immutable.Map {
                 "error": null,
@@ -5536,6 +5573,7 @@ Object {
       "memoizedProps": Object {
         "children": <Connect(SparkComponent)
           addError={[MockFunction]}
+          dangerouslyIgnoredRequiredPlugins={Array []}
           spark={
             Object {
               "authorization": "authorization",
@@ -5574,6 +5612,7 @@ Object {
       "pendingProps": Object {
         "children": <Connect(SparkComponent)
           addError={[MockFunction]}
+          dangerouslyIgnoredRequiredPlugins={Array []}
           spark={
             Object {
               "authorization": "authorization",
@@ -5797,6 +5836,7 @@ Object {
                 >
                   <Connect(SparkComponent)
                     addError={[MockFunction]}
+                    dangerouslyIgnoredRequiredPlugins={Array []}
                     spark={
                       Object {
                         "authorization": "authorization",
@@ -5844,6 +5884,7 @@ Object {
                 >
                   <Connect(SparkComponent)
                     addError={[MockFunction]}
+                    dangerouslyIgnoredRequiredPlugins={Array []}
                     spark={
                       Object {
                         "authorization": "authorization",
@@ -5905,6 +5946,7 @@ Object {
             "lastEffect": [Circular],
             "memoizedProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -5931,6 +5973,7 @@ Object {
             "nextEffect": null,
             "pendingProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -6024,6 +6067,7 @@ Object {
               "notifyNestedSubs": [Function],
               "props": Object {
                 "addError": [MockFunction],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "spark": Object {
                   "authorization": "authorization",
                   "internal": Object {
@@ -6052,6 +6096,7 @@ Object {
                 "error": null,
                 "props": Object {
                   "addError": [Function],
+                  "dangerouslyIgnoredRequiredPlugins": Array [],
                   "registerDevice": [Function],
                   "spark": Immutable.Map {
                     "error": null,
@@ -6288,6 +6333,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -6462,6 +6508,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -6652,6 +6699,7 @@ Object {
             "lastEffect": [Circular],
             "memoizedProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -6678,6 +6726,7 @@ Object {
             "nextEffect": null,
             "pendingProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -6771,6 +6820,7 @@ Object {
               "notifyNestedSubs": [Function],
               "props": Object {
                 "addError": [MockFunction],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "spark": Object {
                   "authorization": "authorization",
                   "internal": Object {
@@ -6799,6 +6849,7 @@ Object {
                 "error": null,
                 "props": Object {
                   "addError": [Function],
+                  "dangerouslyIgnoredRequiredPlugins": Array [],
                   "registerDevice": [Function],
                   "spark": Immutable.Map {
                     "error": null,
@@ -7027,6 +7078,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -7239,6 +7291,7 @@ Object {
           >
             <Connect(SparkComponent)
               addError={[MockFunction]}
+              dangerouslyIgnoredRequiredPlugins={Array []}
               spark={
                 Object {
                   "authorization": "authorization",
@@ -7418,6 +7471,7 @@ Object {
             >
               <Connect(SparkComponent)
                 addError={[MockFunction]}
+                dangerouslyIgnoredRequiredPlugins={Array []}
                 spark={
                   Object {
                     "authorization": "authorization",
@@ -7471,6 +7525,7 @@ Object {
     "props": Object {
       "children": <Connect(SparkComponent)
         addError={[MockFunction]}
+        dangerouslyIgnoredRequiredPlugins={Array []}
         spark={
           Object {
             "authorization": "authorization",
@@ -7524,6 +7579,7 @@ Object {
   "props": Object {
     "children": <Connect(SparkComponent)
       addError={[MockFunction]}
+      dangerouslyIgnoredRequiredPlugins={Array []}
       spark={
         Object {
           "authorization": "authorization",
@@ -7641,6 +7697,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -7815,6 +7872,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -7994,6 +8052,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -8210,6 +8269,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -8384,6 +8444,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -8563,6 +8624,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -8780,6 +8842,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -8954,6 +9017,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -9133,6 +9197,7 @@ Object {
             "props": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -9326,6 +9391,7 @@ Object {
         },
         "memoizedProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -9352,6 +9418,7 @@ Object {
         "nextEffect": null,
         "pendingProps": Object {
           "addError": [MockFunction],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "spark": Object {
             "authorization": "authorization",
             "internal": Object {
@@ -9409,6 +9476,7 @@ Object {
             "memoizedProps": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -9583,6 +9651,7 @@ Object {
             "pendingProps": Object {
               "accessToken": "",
               "addError": [Function],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "guestToken": "",
               "registerDevice": [Function],
               "sdkInstance": undefined,
@@ -9762,6 +9831,7 @@ Object {
               "props": Object {
                 "accessToken": "",
                 "addError": [Function],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "guestToken": "",
                 "registerDevice": [Function],
                 "sdkInstance": undefined,
@@ -9961,6 +10031,7 @@ Object {
           "memoizedProps": Object {
             "children": <Connect(SparkComponent)
               addError={[MockFunction]}
+              dangerouslyIgnoredRequiredPlugins={Array []}
               spark={
                 Object {
                   "authorization": "authorization",
@@ -9999,6 +10070,7 @@ Object {
           "pendingProps": Object {
             "children": <Connect(SparkComponent)
               addError={[MockFunction]}
+              dangerouslyIgnoredRequiredPlugins={Array []}
               spark={
                 Object {
                   "authorization": "authorization",
@@ -10222,6 +10294,7 @@ Object {
                     >
                       <Connect(SparkComponent)
                         addError={[MockFunction]}
+                        dangerouslyIgnoredRequiredPlugins={Array []}
                         spark={
                           Object {
                             "authorization": "authorization",
@@ -10269,6 +10342,7 @@ Object {
                     >
                       <Connect(SparkComponent)
                         addError={[MockFunction]}
+                        dangerouslyIgnoredRequiredPlugins={Array []}
                         spark={
                           Object {
                             "authorization": "authorization",
@@ -10327,6 +10401,7 @@ Object {
               "memoizedProps": Object {
                 "accessToken": "",
                 "addError": [Function],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "guestToken": "",
                 "registerDevice": [Function],
                 "sdkInstance": undefined,
@@ -10501,6 +10576,7 @@ Object {
               "pendingProps": Object {
                 "accessToken": "",
                 "addError": [Function],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "guestToken": "",
                 "registerDevice": [Function],
                 "sdkInstance": undefined,
@@ -10680,6 +10756,7 @@ Object {
                 "props": Object {
                   "accessToken": "",
                   "addError": [Function],
+                  "dangerouslyIgnoredRequiredPlugins": Array [],
                   "guestToken": "",
                   "registerDevice": [Function],
                   "sdkInstance": undefined,
@@ -10892,6 +10969,7 @@ Object {
               >
                 <Connect(SparkComponent)
                   addError={[MockFunction]}
+                  dangerouslyIgnoredRequiredPlugins={Array []}
                   spark={
                     Object {
                       "authorization": "authorization",
@@ -11071,6 +11149,7 @@ Object {
                 >
                   <Connect(SparkComponent)
                     addError={[MockFunction]}
+                    dangerouslyIgnoredRequiredPlugins={Array []}
                     spark={
                       Object {
                         "authorization": "authorization",
@@ -11124,6 +11203,7 @@ Object {
             "props": Object {
               "children": <Connect(SparkComponent)
                 addError={[MockFunction]}
+                dangerouslyIgnoredRequiredPlugins={Array []}
                 spark={
                   Object {
                     "authorization": "authorization",
@@ -11216,6 +11296,7 @@ Object {
       "notifyNestedSubs": [Function],
       "props": Object {
         "addError": [MockFunction],
+        "dangerouslyIgnoredRequiredPlugins": Array [],
         "spark": Object {
           "authorization": "authorization",
           "internal": Object {
@@ -11244,6 +11325,7 @@ Object {
         "error": null,
         "props": Object {
           "addError": [Function],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "registerDevice": [Function],
           "spark": Immutable.Map {
             "error": null,
@@ -11453,6 +11535,7 @@ Object {
     "nodeType": "component",
     "props": Object {
       "addError": [MockFunction],
+      "dangerouslyIgnoredRequiredPlugins": Array [],
       "spark": Object {
         "authorization": "authorization",
         "internal": Object {
@@ -11502,6 +11585,7 @@ Object {
             "lastEffect": [Circular],
             "memoizedProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -11528,6 +11612,7 @@ Object {
             "nextEffect": null,
             "pendingProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -11572,6 +11657,7 @@ Object {
               "memoizedProps": Object {
                 "children": <Connect(SparkComponent)
                   addError={[MockFunction]}
+                  dangerouslyIgnoredRequiredPlugins={Array []}
                   spark={
                     Object {
                       "authorization": "authorization",
@@ -11610,6 +11696,7 @@ Object {
               "pendingProps": Object {
                 "children": <Connect(SparkComponent)
                   addError={[MockFunction]}
+                  dangerouslyIgnoredRequiredPlugins={Array []}
                   spark={
                     Object {
                       "authorization": "authorization",
@@ -11833,6 +11920,7 @@ Object {
                         >
                           <Connect(SparkComponent)
                             addError={[MockFunction]}
+                            dangerouslyIgnoredRequiredPlugins={Array []}
                             spark={
                               Object {
                                 "authorization": "authorization",
@@ -11880,6 +11968,7 @@ Object {
                         >
                           <Connect(SparkComponent)
                             addError={[MockFunction]}
+                            dangerouslyIgnoredRequiredPlugins={Array []}
                             spark={
                               Object {
                                 "authorization": "authorization",
@@ -11938,6 +12027,7 @@ Object {
                   >
                     <Connect(SparkComponent)
                       addError={[MockFunction]}
+                      dangerouslyIgnoredRequiredPlugins={Array []}
                       spark={
                         Object {
                           "authorization": "authorization",
@@ -12117,6 +12207,7 @@ Object {
                     >
                       <Connect(SparkComponent)
                         addError={[MockFunction]}
+                        dangerouslyIgnoredRequiredPlugins={Array []}
                         spark={
                           Object {
                             "authorization": "authorization",
@@ -12170,6 +12261,7 @@ Object {
                 "props": Object {
                   "children": <Connect(SparkComponent)
                     addError={[MockFunction]}
+                    dangerouslyIgnoredRequiredPlugins={Array []}
                     spark={
                       Object {
                         "authorization": "authorization",
@@ -12302,6 +12394,7 @@ Object {
               "notifyNestedSubs": [Function],
               "props": Object {
                 "addError": [MockFunction],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "spark": Object {
                   "authorization": "authorization",
                   "internal": Object {
@@ -12330,6 +12423,7 @@ Object {
                 "error": null,
                 "props": Object {
                   "addError": [Function],
+                  "dangerouslyIgnoredRequiredPlugins": Array [],
                   "registerDevice": [Function],
                   "spark": Immutable.Map {
                     "error": null,
@@ -12566,6 +12660,7 @@ Object {
           "memoizedProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -12740,6 +12835,7 @@ Object {
           "pendingProps": Object {
             "accessToken": "",
             "addError": [Function],
+            "dangerouslyIgnoredRequiredPlugins": Array [],
             "guestToken": "",
             "registerDevice": [Function],
             "sdkInstance": undefined,
@@ -12930,6 +13026,7 @@ Object {
             "lastEffect": [Circular],
             "memoizedProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -12956,6 +13053,7 @@ Object {
             "nextEffect": null,
             "pendingProps": Object {
               "addError": [MockFunction],
+              "dangerouslyIgnoredRequiredPlugins": Array [],
               "spark": Object {
                 "authorization": "authorization",
                 "internal": Object {
@@ -13000,6 +13098,7 @@ Object {
               "memoizedProps": Object {
                 "children": <Connect(SparkComponent)
                   addError={[MockFunction]}
+                  dangerouslyIgnoredRequiredPlugins={Array []}
                   spark={
                     Object {
                       "authorization": "authorization",
@@ -13038,6 +13137,7 @@ Object {
               "pendingProps": Object {
                 "children": <Connect(SparkComponent)
                   addError={[MockFunction]}
+                  dangerouslyIgnoredRequiredPlugins={Array []}
                   spark={
                     Object {
                       "authorization": "authorization",
@@ -13261,6 +13361,7 @@ Object {
                         >
                           <Connect(SparkComponent)
                             addError={[MockFunction]}
+                            dangerouslyIgnoredRequiredPlugins={Array []}
                             spark={
                               Object {
                                 "authorization": "authorization",
@@ -13308,6 +13409,7 @@ Object {
                         >
                           <Connect(SparkComponent)
                             addError={[MockFunction]}
+                            dangerouslyIgnoredRequiredPlugins={Array []}
                             spark={
                               Object {
                                 "authorization": "authorization",
@@ -13366,6 +13468,7 @@ Object {
                   >
                     <Connect(SparkComponent)
                       addError={[MockFunction]}
+                      dangerouslyIgnoredRequiredPlugins={Array []}
                       spark={
                         Object {
                           "authorization": "authorization",
@@ -13545,6 +13648,7 @@ Object {
                     >
                       <Connect(SparkComponent)
                         addError={[MockFunction]}
+                        dangerouslyIgnoredRequiredPlugins={Array []}
                         spark={
                           Object {
                             "authorization": "authorization",
@@ -13598,6 +13702,7 @@ Object {
                 "props": Object {
                   "children": <Connect(SparkComponent)
                     addError={[MockFunction]}
+                    dangerouslyIgnoredRequiredPlugins={Array []}
                     spark={
                       Object {
                         "authorization": "authorization",
@@ -13730,6 +13835,7 @@ Object {
               "notifyNestedSubs": [Function],
               "props": Object {
                 "addError": [MockFunction],
+                "dangerouslyIgnoredRequiredPlugins": Array [],
                 "spark": Object {
                   "authorization": "authorization",
                   "internal": Object {
@@ -13758,6 +13864,7 @@ Object {
                 "error": null,
                 "props": Object {
                   "addError": [Function],
+                  "dangerouslyIgnoredRequiredPlugins": Array [],
                   "registerDevice": [Function],
                   "spark": Immutable.Map {
                     "error": null,
@@ -13997,6 +14104,7 @@ Object {
         "props": Object {
           "accessToken": "",
           "addError": [Function],
+          "dangerouslyIgnoredRequiredPlugins": Array [],
           "guestToken": "",
           "registerDevice": [Function],
           "sdkInstance": undefined,
@@ -14179,6 +14287,7 @@ Object {
       "props": Object {
         "accessToken": "",
         "addError": [Function],
+        "dangerouslyIgnoredRequiredPlugins": Array [],
         "guestToken": "",
         "registerDevice": [Function],
         "sdkInstance": undefined,

--- a/packages/node_modules/@webex/react-redux-spark/src/component.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/component.js
@@ -27,13 +27,15 @@ const propTypes = {
   accessToken: PropTypes.string,
   guestToken: PropTypes.string,
   sdkInstance: PropTypes.object,
+  dangerouslyIgnoredRequiredPlugins: PropTypes.array,
   ...injectedPropTypes
 };
 
 const defaultProps = {
   accessToken: '',
   guestToken: '',
-  sdkInstance: undefined
+  sdkInstance: undefined,
+  dangerouslyIgnoredRequiredPlugins: []
 };
 
 const PLUGINS = ['authorization', 'logger', 'meetings', 'people', 'phone', 'rooms'];
@@ -182,30 +184,34 @@ export class SparkComponent extends Component {
     let verified = true;
 
     for (const plugin of PLUGINS) {
-      contains = Object.prototype.hasOwnProperty.call(sdkInstance, plugin);
+      if (!this.props.dangerouslyIgnoredRequiredPlugins.includes(plugin)) {
+        contains = Object.prototype.hasOwnProperty.call(sdkInstance, plugin);
 
-      if (!contains) {
-        this.props.addError({
-          id: 'webex-plugins-missing',
-          displayTitle: 'Something\'s not right. Please try again',
-          displaySubtitle: `Webex SDK instance plugin ${plugin} is not injected to the widget properly`,
-          temporary: false
-        });
-        verified = false;
+        if (!contains) {
+          this.props.addError({
+            id: 'webex-plugins-missing',
+            displayTitle: 'Something\'s not right. Please try again',
+            displaySubtitle: `Webex SDK instance plugin ${plugin} is not injected to the widget properly`,
+            temporary: false
+          });
+          verified = false;
+        }
       }
     }
 
     for (const internalPlugin of INTERNAL_PLUGINS) {
-      contains = Object.prototype.hasOwnProperty.call(sdkInstance.internal, internalPlugin);
+      if (!this.props.dangerouslyIgnoredRequiredPlugins.includes(internalPlugin)) {
+        contains = Object.prototype.hasOwnProperty.call(sdkInstance.internal, internalPlugin);
 
-      if (!contains) {
-        this.props.addError({
-          id: 'webex-internal-plugins-missing',
-          displayTitle: 'Something\'s not right. Please try again',
-          displaySubtitle: `Webex SDK instance internal plugin ${internalPlugin} is not injected to the widget properly`,
-          temporary: false
-        });
-        verified = false;
+        if (!contains) {
+          this.props.addError({
+            id: 'webex-internal-plugins-missing',
+            displayTitle: 'Something\'s not right. Please try again',
+            displaySubtitle: `Webex SDK instance internal plugin ${internalPlugin} is not injected to the widget properly`,
+            temporary: false
+          });
+          verified = false;
+        }
       }
     }
 

--- a/packages/node_modules/@webex/react-redux-spark/src/component.test.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/component.test.js
@@ -32,7 +32,8 @@ describe('spark component', () => {
       spark,
       storeSparkInstance: jest.fn(),
       updateSparkStatus: jest.fn(),
-      addError: jest.fn()
+      addError: jest.fn(),
+      dangerouslyIgnoredRequiredPlugins: []
     });
   });
 
@@ -52,6 +53,35 @@ describe('spark component', () => {
       delete spark.internal.mercury;
       sparkComponent.verifyPlugins(spark);
       expect(sparkComponent.props.addError).toHaveBeenCalled();
+    });
+
+    describe('when dangerouslyIngoredRequiredPlugins includes required plugin', () => {
+      it('does not throw an error if an internal plugin is not injected properly but is dangerously ignored', () => {
+        delete spark.phone;
+        sparkComponent = new SparkComponent({
+          spark,
+          storeSparkInstance: jest.fn(),
+          updateSparkStatus: jest.fn(),
+          addError: jest.fn(),
+          dangerouslyIgnoredRequiredPlugins: ['phone']
+        });
+        sparkComponent.verifyPlugins(spark);
+        expect(sparkComponent.props.addError).not.toHaveBeenCalled();
+      });
+
+      it('does not throw an error if external plugins are not injected properly but are dangerously ignored', () => {
+        delete spark.internal.feature;
+        delete spark.internal.flag;
+        sparkComponent = new SparkComponent({
+          spark,
+          storeSparkInstance: jest.fn(),
+          updateSparkStatus: jest.fn(),
+          addError: jest.fn(),
+          dangerouslyIgnoredRequiredPlugins: ['flag', 'feature']
+        });
+        sparkComponent.verifyPlugins(spark);
+        expect(sparkComponent.props.addError).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -112,6 +142,7 @@ describe('spark component', () => {
           storeSparkInstance={jest.fn()}
           updateSparkStatus={jest.fn()}
           addError={jest.fn()}
+          dangerouslyIgnoredRequiredPlugins={[]}
         />
       </Provider>
     );

--- a/packages/node_modules/@webex/redux-module-flags/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-flags/src/actions.js
@@ -66,7 +66,7 @@ export function fetchFlags(sparkInstance) {
   return (dispatch) => {
     dispatch(updateFlagStatus({isFetching: true}));
 
-    return sparkInstance.internal.flag.list()
+    return sparkInstance.internal?.flag?.list()
       .then((flags) => {
         let flagsMap = flags.map(constructFlag);
 

--- a/packages/node_modules/@webex/widget-message/src/container.js
+++ b/packages/node_modules/@webex/widget-message/src/container.js
@@ -368,7 +368,7 @@ export class MessageWidget extends Component {
     if (!widgetMessage.get('isListeningToTyping')) {
       this.listenToTypingEvents(conversationId, sparkInstance);
     }
-    if (!flags.getIn(['status', 'hasFetched']) && !flags.getIn(['status', 'isFetching'])) {
+    if (flags && !flags.getIn(['status', 'hasFetched']) && !flags.getIn(['status', 'isFetching'])) {
       nextProps.fetchFlags(sparkInstance);
     }
     // We only want to fetch avatars when a new activity is seen

--- a/packages/node_modules/@webex/widget-space/README.md
+++ b/packages/node_modules/@webex/widget-space/README.md
@@ -107,7 +107,7 @@ To use the space widget within an existing React appliction, a developer can ins
       accessToken: 'XXXXXXXXXXXXXX',  // Required
       destinationType: destinationTypes.USERID,
       destinationId: 'YOUR_DESTINATION_USERID',
-      activities: {
+      spaceActivities: {
         files: false,
         meet: true,
         message: false,


### PR DESCRIPTION
… for required plugins

This change is motivated by the need to inject an sdk instance that may not have certain plugins available to it. For example, plugin-phone is being deprecated but is still required for the widgets. This approach will allow for users to "dangerously" ignore such plugins when implementing the widget without introducing potential breaking changes to legacy instances of the widget.