### PR TITLE
People tab scrollbar fix

### DIFF
--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -1,8 +1,5 @@
 .roster {
   display: -webkit-box;
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   height: 100%;
   width: 100%;
   font-family: CiscoSansTT Regular, Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -11,9 +8,6 @@
 
 .fullHeight {
   display: -webkit-box;
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;

--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -8,6 +8,10 @@
 
 .fullHeight {
   display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;

--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -1,5 +1,5 @@
 .roster {
-  display: flex;
+  display: -webkit-box;
   height: 100%;
   width: 100%;
   font-family: CiscoSansTT Regular, Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -7,7 +7,7 @@
 }
 
 .fullHeight {
-  display: flex;
+  display: -webkit-box;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;

--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -7,7 +7,7 @@
 }
 
 .fullHeight {
-  display: -webkit-box;
+  display: contents;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;

--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -1,5 +1,9 @@
 .roster {
   display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
   height: 100%;
   width: 100%;
   font-family: CiscoSansTT Regular, Helvetica Neue, Helvetica, Arial, sans-serif;

--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -5,6 +5,7 @@
   display: -webkit-flex;
   display: flex;
   height: 100%;
+  
   width: 100%;
   font-family: CiscoSansTT Regular, Helvetica Neue, Helvetica, Arial, sans-serif;
   flex-direction: column;


### PR DESCRIPTION
Fixes an issue where part of the native scrollbar in the participant list gets hidden when there are external participants.
![scroll_issue](https://user-images.githubusercontent.com/6610308/123153478-8f19c100-d41a-11eb-82a4-c3509a8f6410.jpeg)
