### PR TITLE
fix(widget-roster): people tab scrollbar fix

### DIFF
--- a/packages/node_modules/@webex/widget-roster/src/styles.css
+++ b/packages/node_modules/@webex/widget-roster/src/styles.css
@@ -1,5 +1,5 @@
 .roster {
-  display: flex;
+  display: contents;
   height: 100%;
   width: 100%;
   font-family: CiscoSansTT Regular, Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -7,7 +7,7 @@
 }
 
 .fullHeight {
-  display: flex;
+  display: contents;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
Fixes an issue where part of the native scrollbar in the participant list gets hidden when there are external participants.
![scroll_issue](https://user-images.githubusercontent.com/6610308/123153478-8f19c100-d41a-11eb-82a4-c3509a8f6410.jpeg)
