### PR TITLE
Add ability to turn off presence

### DIFF
--- a/packages/node_modules/@webex/private-react-component-space-destination/src/index.js
+++ b/packages/node_modules/@webex/private-react-component-space-destination/src/index.js
@@ -38,13 +38,16 @@ const propTypes = {
   onInitialActivityChange: PropTypes.func.isRequired,
   onModeChange: PropTypes.func.isRequired,
   onSecondaryFullWidthChange: PropTypes.func.isRequired,
-  secondaryFullWidth: PropTypes.bool
+  secondaryFullWidth: PropTypes.bool,
+  disablePresence: PropTypes.bool,
+  onDisablePresenceChange: PropTypes.func.isRequired
 };
 
 const defaultProps = {
   destinationPropMode: null,
   onDestinationPropTypeChange: () => {},
-  secondaryFullWidth: false
+  secondaryFullWidth: false,
+  disablePresence: false
 };
 
 function SpaceDestination(props) {
@@ -217,6 +220,15 @@ function SpaceDestination(props) {
           htmlId="secondaryFullWidth"
           label="secondaryActivitiesFullWidth"
           onChange={props.onSecondaryFullWidthChange}
+        />
+      </div>
+      <div>
+        <h3>Disable Presence</h3>
+        <Checkbox
+          checked={props.disablePresence}
+          htmlId="disablePresence"
+          label="Disable Presence"
+          onChange={props.onDisablePresenceChange}
         />
       </div>
       { props.destinationPropMode &&

--- a/packages/node_modules/@webex/redux-module-users/src/actions.js
+++ b/packages/node_modules/@webex/redux-module-users/src/actions.js
@@ -71,9 +71,10 @@ function storeCurrentUserId(id) {
 /**
  * Retrieves the current user using internal APIs
  * @param {Object} sparkInstance
+ * @param {bool} disablePresence
  * @returns {Function}
  */
-export function fetchCurrentUser(sparkInstance) {
+export function fetchCurrentUser(sparkInstance, disablePresence) {
   return (dispatch, getState) => {
     const {users} = getState();
     // Check for stored current User
@@ -102,7 +103,10 @@ export function fetchCurrentUser(sparkInstance) {
       }
     }
     dispatch(fetchCurrentUserRequest(userId));
-    dispatch(subscribeToPresenceUpdates([userId], sparkInstance));
+    // call subscription api conditionally
+    if (!disablePresence) {
+      dispatch(subscribeToPresenceUpdates([userId], sparkInstance));
+    }
 
     return sparkInstance.internal.user.get()
       .then((user) => {

--- a/packages/node_modules/@webex/webex-widget-base/src/enhancers/withCurrentUser.js
+++ b/packages/node_modules/@webex/webex-widget-base/src/enhancers/withCurrentUser.js
@@ -33,7 +33,8 @@ function fetchUser(props) {
     /* eslint-enable no-warning-comments */
     const sparkInstance = spark.get('spark');
 
-    props.fetchCurrentUser(sparkInstance);
+    // pass on boolean to disable presence call conditionally
+    props.fetchCurrentUser(sparkInstance, props.disablePresence);
   }
 }
 

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
@@ -74,7 +74,8 @@ class DemoWidget extends Component {
       spaceLoadCountInputErrors: [],
       spaceRunning: false,
       spaceWidgetProps: {},
-      stickyMode: false
+      stickyMode: false,
+      disablePresence: false
     };
   }
 
@@ -295,6 +296,13 @@ class DemoWidget extends Component {
   }
 
   @autobind
+  handleDisablePresenceChange(event) {
+    const {checked} = event.target;
+
+    return this.setState({disablePresence: checked});
+  }
+
+  @autobind
   async openSpaceWidget({
     destinationId, destinationType
   }) {
@@ -308,7 +316,8 @@ class DemoWidget extends Component {
         }
       },
       spaceActivities: this.state.activities,
-      secondaryActivitiesFullWidth: this.state.secondaryActivitiesFullWidth
+      secondaryActivitiesFullWidth: this.state.secondaryActivitiesFullWidth,
+      disablePresence: this.state.disablePresence
     };
 
     if (this.state.accessTokenType === 'JWT') {
@@ -370,6 +379,7 @@ class DemoWidget extends Component {
     const initialActivityField = `initialActivity: '${this.state.initialActivity}'`;
     const secondaryActivitiesFullWidth = `secondaryActivitiesFullWidth: ${this.state.secondaryActivitiesFullWidth}`;
     const composerActionsDisplay = `composerActions: ${JSON.stringify(this.state.composerActions)}`;
+    const disablePresence = `disablePresence: ${JSON.stringify(this.state.disablePresence)}`;
 
     const spaceCode = `<div id="my-webex-widget" />
 <script>
@@ -382,7 +392,8 @@ class DemoWidget extends Component {
     ${activityTypesField},
     ${initialActivityField},
     ${secondaryActivitiesFullWidth},
-    ${composerActionsDisplay}
+    ${composerActionsDisplay},
+    ${disablePresence}
   });
 </script>`;
 
@@ -450,6 +461,8 @@ class DemoWidget extends Component {
                     onModeChange={this.handleModeChange}
                     onSecondaryFullWidthChange={this.handleSecondaryFullWidthChange}
                     secondaryFullWidth={this.state.secondaryActivitiesFullWidth}
+                    onDisablePresenceChange={this.handleDisablePresenceChange}
+                    disablePresence={this.state.disablePresence}
                   />
                 }
                 { this.state.spaceRunning &&

--- a/packages/node_modules/@webex/widget-message/src/container.js
+++ b/packages/node_modules/@webex/widget-message/src/container.js
@@ -121,7 +121,8 @@ const injectedPropTypes = {
   getFeature: PropTypes.func.isRequired,
   participants: PropTypes.array.isRequired,
   activities: PropTypes.object.isRequired,
-  conversationId: PropTypes.string
+  conversationId: PropTypes.string,
+  disablePresence: PropTypes.bool
 };
 
 export const ownPropTypes = {
@@ -381,7 +382,9 @@ export class MessageWidget extends Component {
     if (nextProps.participants) {
       const userIds = nextProps.participants.map((p) => p.id);
 
-      this.props.subscribeToPresenceUpdates(userIds, sparkInstance);
+      if (!this.props.disablePresence) {
+        this.props.subscribeToPresenceUpdates(userIds, sparkInstance);
+      }
     }
     if (!widgetMessage.get('isListeningToBufferState')) {
       this.listenToBufferState(conversation.get('url'), sparkInstance);

--- a/packages/node_modules/@webex/widget-space/src/container.js
+++ b/packages/node_modules/@webex/widget-space/src/container.js
@@ -56,6 +56,7 @@ export const ownPropTypes = {
     PropTypes.string,
     PropTypes.bool
   ]),
+  disablePresence: PropTypes.bool,
   ...activityMenuPropTypes,
   ...injectedPropTypes
 };
@@ -76,7 +77,8 @@ const defaultProps = {
     message: true,
     people: true
   },
-  startCall: false
+  startCall: false,
+  disablePresence: false
 };
 
 export class SpaceWidget extends Component {


### PR DESCRIPTION
Adding a prop so that users may disable the presence feature of the Space widget. Disabling presence could optimize widget load time, as there will be less APIs to call.