### PR TITLE
chore(): upgrade s3 circleci orb to v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
 
 # Orb to grab `s3` capability for us
 orbs:
-  aws-s3: circleci/aws-s3@2.0.0
+  aws-s3: circleci/aws-s3@3.0.0
   jq: circleci/jq@1.9.0
 
 # Reusable commands for jobs


### PR DESCRIPTION
No new breaking changes with v3 of the orb, they're updating their internal tooling and cleaning up some code

https://github.com/CircleCI-Public/aws-s3-orb/pull/23