### PR TITLE
fix(style): update metadata color

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
@@ -30,7 +30,7 @@
   font-family: CiscoSansTT Regular, 'Helvetica Neue', Arial;
   font-size: 12px;
   font-weight: 300;
-  color: #666;
+  color: #545454;
   text-align: left;
   word-wrap: break-word;
   cursor: auto;


### PR DESCRIPTION
Changed metadata color from #666:
![before](https://user-images.githubusercontent.com/85583636/130649089-680b3df7-d468-4845-a4cb-7454be3242c5.png)


to #545454 according to figma spec:
![after](https://user-images.githubusercontent.com/85583636/130649115-01f794ab-fd4a-4f25-9ee6-81f4b3ced078.png)

[SPARK-219857](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-219857)