### PR TITLE
fix(style): reduce thread border thickness

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-item/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-item/src/styles.css
@@ -16,7 +16,8 @@
   padding: 0 20px 0 0;
   margin: 0 14px 0 76px;
   padding-left: 12px;
-  border-left: 4px solid rgba(0, 0, 0, .12);
+  border-left: 2px solid rgba(0, 0, 0, .12);
+  border-radius: 1px;
   overflow: initial;
   outline: none;
   transition: transform 0.3s;


### PR DESCRIPTION
Reduced thread border thickness from 4px to 2px and added border radius according to figma.

From: 
![before](https://user-images.githubusercontent.com/85583636/130280346-826e4bef-b073-4cea-9e98-29aad6ec0bfa.png)

To:
![after](https://user-images.githubusercontent.com/85583636/130280359-20610992-9282-44dc-a5ea-4e212f61db0f.png)
