### PR TITLE
fix(style): reduce spacing between meta and message

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
@@ -26,7 +26,7 @@
   display: flex;
   padding: 0;
   margin: 0;
-  margin-bottom: 7px;
+  margin-bottom: 4px;
   font-family: CiscoSansTT Regular, 'Helvetica Neue', Arial;
   font-size: 12px;
   font-weight: 300;


### PR DESCRIPTION
Changed from:
![before](https://user-images.githubusercontent.com/85583636/130647433-6609240c-c241-414a-b69a-5bbb40e3c52e.png)

To:
![after](https://user-images.githubusercontent.com/85583636/130647447-db8ac0f8-5b3e-4cb0-8408-7ac4d0bd4d5f.png)

according to [SPARK-219840](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-219840)