### PR TITLE
fix(react-redux-spark): add proxy to existing sdk

### DIFF
--- a/packages/node_modules/@webex/react-redux-spark/src/component.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/component.js
@@ -12,7 +12,7 @@ import {
   storeSparkInstance,
   storeSparkAdaptor
 } from './actions';
-import {createSDKGuestInstance, createSDKInstance} from './sdk';
+import {createSDKGuestInstance, createSDKInstance, createSDKInstanceProxy} from './sdk';
 import {getStatusFromInstance} from './helpers';
 
 const injectedPropTypes = {
@@ -70,7 +70,7 @@ export class SparkComponent extends Component {
     if (!sparkInstance) {
       // SDK Instance passed via props
       if (sdkInstance) {
-        this.storeSDKInstance(sdkInstance);
+        createSDKInstanceProxy(sdkInstance, this.props.name).then(this.storeSDKInstance);
       }
       // Guest token passed via props
       else if (guestToken) {

--- a/packages/node_modules/@webex/react-redux-spark/src/sdk.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/sdk.js
@@ -106,7 +106,6 @@ function defaultConfig(options = {}) {
   };
 }
 
-
 /**
  * Creates a sdk instance with the access token
  * @param {string} accessToken
@@ -141,4 +140,33 @@ export function createSDKGuestInstance(jwt, options = {}) {
   });
 
   return webexSDKInstance.authorization.requestAccessTokenFromJwt({jwt}).then(() => webexSDKInstance);
+}
+
+/**
+ * Creates a proxy for the SDK to enable hijacking of the appName/appVersion
+ * before a request is sent to server. For usage with widgets where an
+ * existing SDK instance is used.
+ *
+ * @param {Object} sdkInstance An instance of the Webex SDK
+ * @param {*} name The name of the app to use
+ * @returns {Promise<object>}
+ */
+export async function createSDKInstanceProxy(sdkInstance, name) {
+  const appName = `webex-widgets${name ? `-${name}` : ''}`;
+  const appVersion = process.env.REACT_WEBEX_VERSION;
+
+  const sdkHandler = {
+    get(target, prop, receiver) {
+      const sdk = target;
+
+      if (prop === 'config') {
+        sdk.config.appName = appName;
+        sdk.config.appVersion = appVersion;
+      }
+
+      return Reflect.get(sdk, prop, receiver);
+    }
+  };
+
+  return new Proxy(sdkInstance, sdkHandler);
 }

--- a/packages/node_modules/@webex/react-redux-spark/src/sdk.test.js
+++ b/packages/node_modules/@webex/react-redux-spark/src/sdk.test.js
@@ -1,0 +1,28 @@
+import {createSDKInstance, createSDKInstanceProxy} from './sdk';
+
+describe('SDK', () => {
+  describe('createSDKInstance', () => {
+    it('should resolve instance with config defaults', async () => {
+      const instance = await createSDKInstance('abc123');
+
+      expect(instance.config.appName).toBe('webex-widgets');
+    });
+    it('should resolve instance with appName passed in', async () => {
+      const instance = await createSDKInstance('abc123', {name: 'test-app'});
+
+      expect(instance.config.appName).toStrictEqual('webex-widgets-test-app');
+    });
+  });
+  describe('createSDKInstanceProxy', () => {
+    it('should resolve with instance proxy', async () => {
+      const instance = await createSDKInstance('abc123', {name: 'old-name'});
+
+      expect(instance.config.appName).toStrictEqual('webex-widgets-old-name');
+
+      const proxyInstance = await createSDKInstanceProxy(instance, 'new-name');
+
+      expect(proxyInstance.config.appName).toStrictEqual('webex-widgets-new-name');
+      expect(proxyInstance.config.appVersion).toStrictEqual(process.env.REACT_WEBEX_VERSION);
+    });
+  });
+});


### PR DESCRIPTION
Proxy SDK allows us to track metrics from SDK instances that are created outside the widget.

![image](https://user-images.githubusercontent.com/6610308/133328856-792abf8c-240c-40bc-90b0-6bd782b11198.png)
