### PR TITLE
 feat(space-widget): add optional props showSubmitButton & sendMessageOnReturnKey

### DIFF
--- a/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
@@ -95,3 +95,121 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
   </div>
 </div>
 `;
+
+exports[`MessageComposer component snapshot tests renders submit button 1`] = `
+<div
+  className="webex-message-composer messageComposer"
+>
+  <div
+    className="webex-message-composer-buttons buttonsArea"
+  >
+    <input
+      className="webex-file-input fileInput"
+      id="messageFileInput-FAKE_INPUT_ID"
+      multiple="multiple"
+      onChange={[Function]}
+      type="file"
+    />
+    <label
+      htmlFor="messageFileInput-FAKE_INPUT_ID"
+    >
+      <i
+        aria-label="Attach Files"
+        className="md-icon icon icon-attachment_16"
+        style={
+          Object {
+            "fontSize": 16,
+          }
+        }
+      />
+    </label>
+  </div>
+  <div
+    className="webex-textarea-container textAreaContainer"
+  >
+    <div
+      style={
+        Object {
+          "overflowY": "visible",
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        style={Object {}}
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "transparent",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "color": "transparent",
+              "display": "block",
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "relative",
+              "resize": "none",
+              "top": 0,
+              "whiteSpace": "pre-wrap",
+              "width": "inherit",
+              "wordWrap": "break-word",
+            }
+          }
+        >
+           
+        </div>
+        <textarea
+          onBlur={[Function]}
+          onChange={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onSelect={[Function]}
+          onSubmit={[Function]}
+          placeholder="Message Placeholder"
+          rows={1}
+          style={
+            Object {
+              "backgroundColor": "transparent",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": "100%",
+              "overflow": "hidden",
+              "position": "absolute",
+              "resize": "none",
+              "top": 0,
+              "width": "100%",
+            }
+          }
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="chatSubmitButtonContainer"
+    >
+      <button
+        aria-label="Send"
+        className="chatSubmitButton"
+        disabled={true}
+        onClick={[Function]}
+        type="submit"
+      >
+        <i
+          aria-label={null}
+          className="md-icon icon icon-send_16"
+          style={
+            Object {
+              "color": "rgba(220, 220, 220, 1)",
+              "fontSize": 16,
+            }
+          }
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/node_modules/@webex/react-container-message-composer/src/container.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/container.js
@@ -20,6 +20,7 @@ import {searchForUser} from '@webex/redux-module-search';
 import PresenceAvatar from '@webex/react-container-presence-avatar';
 import FileStagingArea from '@webex/react-component-file-staging-area';
 import {constructFiles, checkMaxFileSize} from '@webex/react-component-utils';
+import {Icon} from '@momentum-ui/react';
 import {addError, removeError} from '@webex/redux-module-errors';
 
 import ComposerButtons from './components/ComposerButtons';
@@ -55,12 +56,16 @@ const propTypes = {
   onSubmit: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   showMentions: PropTypes.bool,
+  showSubmitButton: PropTypes.bool,
+  sendMessageOnReturnKey: PropTypes.bool,
   ...injectedPropTypes
 };
 
 const defaultProps = {
   placeholder: '',
-  showMentions: false
+  showMentions: false,
+  showSubmitButton: false,
+  sendMessageOnReturnKey: true
 };
 
 
@@ -122,8 +127,10 @@ export class MessageComposer extends Component {
   @autobind
   handleKeyDown(e) {
     if (e.keyCode === 13 && !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
-      this.handleSubmit();
-      e.preventDefault();
+      if (this.props.sendMessageOnReturnKey) {
+        this.handleSubmit();
+        e.preventDefault();
+      }
     }
   }
 
@@ -246,7 +253,8 @@ export class MessageComposer extends Component {
       composerActions,
       messageComposer,
       placeholder,
-      conversation
+      conversation,
+      showSubmitButton
     } = this.props;
 
     const files = activity.get('files');
@@ -257,6 +265,7 @@ export class MessageComposer extends Component {
 
     const textAreaFocusStyle = messageComposer.getIn(['status', 'hasTextAreaFocus']) ? styles.hasFocus : '';
     const mentionMarkup = '@{__display__}|__id__|';
+    const canSendMessage = !!text;
 
     // Only show mentions if this is not a one on one convo
     const showMentions = props.showMentions && !conversation.getIn(['status', 'isOneOnOne']);
@@ -294,6 +303,13 @@ export class MessageComposer extends Component {
               trigger="@"
             />
           </MentionsInput>
+          {showSubmitButton &&
+            <div className={styles.chatSubmitButtonContainer}>
+              <button className={styles.chatSubmitButton} type="submit" onClick={this.handleSubmit} aria-label="Send" disabled={!canSendMessage}>
+                <Icon name="icon-send_16" color={canSendMessage ? 'black' : 'gray-20'} />
+              </button>
+            </div>
+          }
         </div>
       </div>
     );

--- a/packages/node_modules/@webex/react-container-message-composer/src/index.test.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/index.test.js
@@ -40,6 +40,24 @@ describe('MessageComposer component', () => {
 
       uuidSpy.mockRestore();
     });
+
+    it('renders submit button', () => {
+      const uuidSpy = jest.spyOn(uuid, 'v4').mockReturnValue('FAKE_INPUT_ID');
+
+      component = renderer.create(
+        <MessageComposerComponent
+          composerActions={{attachFiles: true}}
+          onSubmit={jest.fn()}
+          placeholder="Message Placeholder"
+          sparkInstance={spark}
+          value="This is a message"
+          showSubmitButton
+        />
+      );
+      expect(component).toMatchSnapshot();
+
+      uuidSpy.mockRestore();
+    });
   });
 
   describe('class method tests', () => {
@@ -134,9 +152,16 @@ describe('MessageComposer component', () => {
         };
       });
 
-      it('submits upon enter key with no modifiers', () => {
-        messageComposer.handleKeyDown(event);
-        expect(messageComposer.handleSubmit).toHaveBeenCalled();
+      it('doesn\'t submit upon enter key when sendMessageOnReturnKey is false', () => {
+        const messageComposerDisabled = new MessageComposer({
+          ...props,
+          sendMessageOnReturnKey: false
+        });
+
+        messageComposerDisabled.handleSubmit = jest.fn();
+
+        messageComposerDisabled.handleKeyDown(event);
+        expect(messageComposerDisabled.handleSubmit).not.toHaveBeenCalled();
       });
 
       it('doesn\'t submit upon enter key with shift modifiers', () => {

--- a/packages/node_modules/@webex/react-container-message-composer/src/styles.css
+++ b/packages/node_modules/@webex/react-container-message-composer/src/styles.css
@@ -34,3 +34,24 @@
 .textareaContainerBig {
   height: 150px;
 }
+
+.chatSubmitButtonContainer {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+}
+
+.chatSubmitButton {
+  position: relative;
+  cursor: pointer;
+  background: none;
+  border: none;
+  outline: none;
+  height: 16px;
+  width: 16px;
+  padding: 0px;
+}
+
+.chatSubmitButton:disabled  {
+  cursor: not-allowed;
+}

--- a/packages/node_modules/@webex/widget-message/src/container.js
+++ b/packages/node_modules/@webex/widget-message/src/container.js
@@ -134,7 +134,9 @@ export const ownPropTypes = {
   hasAcknowledgementsDisabled: PropTypes.bool,
   muteNotifications: PropTypes.bool,
   onEvent: PropTypes.func,
-  eventNames: PropTypes.object
+  eventNames: PropTypes.object,
+  showSubmitButton: PropTypes.bool,
+  sendMessageOnReturnKey: PropTypes.bool
 };
 
 const fetchMoreActivitiesIfNecessary = ({
@@ -750,7 +752,9 @@ export class MessageWidget extends Component {
       currentUser,
       muteNotifications,
       widgetMessage,
-      features
+      features,
+      showSubmitButton,
+      sendMessageOnReturnKey
     } = props;
     const {formatMessage} = this.props.intl;
 
@@ -814,6 +818,8 @@ export class MessageWidget extends Component {
                 placeholder={formatMessage(messages.messageComposerPlaceholder, {displayName})}
                 showMentions
                 sparkInstance={sparkInstance}
+                showSubmitButton={showSubmitButton}
+                sendMessageOnReturnKey={sendMessageOnReturnKey}
               />
             </div>
           </div>
@@ -849,6 +855,11 @@ export class MessageWidget extends Component {
 MessageWidget.propTypes = {
   ...ownPropTypes,
   ...injectedPropTypes
+};
+
+MessageWidget.defaultProps = {
+  showSubmitButton: false,
+  sendMessageOnReturnKey: true
 };
 
 const ConnectedMessageWidget = wrapConversationMercury(MessageWidget);

--- a/packages/node_modules/@webex/widget-space/README.md
+++ b/packages/node_modules/@webex/widget-space/README.md
@@ -187,6 +187,8 @@ When loading the widgets there are some configuration options you can provide:
 | `logLevel` | `data-log-level` | (default: `silent`) When present, widget will log debug information to console. This can be set to: `error`, `warn`, `debug`, `info`, `trace`, or `silent` |
 | `secondaryActivitiesFullWidth` | N/A: global only feature | (default: `false`) When true, the widget's secondary activities will cover the entire main widget area. When false, only a portion of the widget will be covered.
 | `spaceActivities` | N/A: global only feature | (default: `spaceActivities: {files: true, meet: true, message: true, people: true}`). When present and a property is set to false, that activity will be disabled in the activities menu. Disabling the initial activity will result in an error.
+| `showSubmitButton` | N/A: global only feature | (default: `false`). When property is set to true, a submit button will be available in the message composer.
+| `sendMessageOnReturnKey` | N/A: global only feature | (default: `true`). When property is set to false, the return key will not send a message when typing in the composer. This is useful if you want to allow users to insert blank lines in their messages. Setting both `sendMessageOnReturnKey` and `showSubmitButton` to `false` will result in an error.
 
 ### External Control
 

--- a/packages/node_modules/@webex/widget-space/src/container.js
+++ b/packages/node_modules/@webex/widget-space/src/container.js
@@ -58,6 +58,8 @@ export const ownPropTypes = {
   ]),
   disablePresence: PropTypes.bool,
   disableFlags: PropTypes.bool,
+  showSubmitButton: PropTypes.bool,
+  sendMessageOnReturnKey: PropTypes.bool,
   ...activityMenuPropTypes,
   ...injectedPropTypes
 };
@@ -80,7 +82,9 @@ const defaultProps = {
   },
   startCall: false,
   disablePresence: false,
-  disableFlags: false
+  disableFlags: false,
+  showSubmitButton: false,
+  sendMessageOnReturnKey: true
 };
 
 export class SpaceWidget extends Component {

--- a/packages/node_modules/@webex/widget-space/src/enhancers/errors.js
+++ b/packages/node_modules/@webex/widget-space/src/enhancers/errors.js
@@ -177,11 +177,45 @@ function checkActivityTypes(props) {
   }
 }
 
+/**
+ * Verifies the prop based messaging options are valid
+ * @param {Object} props
+ */
+function checkCanSendMessage(props) {
+  const {
+    activityTypes,
+    errors,
+    showSubmitButton,
+    sendMessageOnReturnKey
+  } = props;
+  const {formatMessage} = props.intl;
+  const defaultActivity = 'message';
+
+  if (activityTypes && activityTypes.length > 0) {
+    const invalidMessagingId = 'ciscospark.container.space.error.invalidSendMessageConfiguration';
+    const hasEnabledMessaging = activityTypes.some((activity) => activity.name === defaultActivity);
+    const hasErrorCurrently = errors.get('errors').has(invalidMessagingId);
+
+    if (hasEnabledMessaging && !showSubmitButton && !sendMessageOnReturnKey && !hasErrorCurrently) {
+      props.addError({
+        id: invalidMessagingId,
+        displayTitle: formatMessage(messages.invalidSendMessageConfiguration),
+        temporary: false
+      });
+    }
+
+    if (hasEnabledMessaging && (showSubmitButton || sendMessageOnReturnKey) && hasErrorCurrently) {
+      props.removeError(invalidMessagingId);
+    }
+  }
+}
+
 function checkForErrors(props) {
   checkForMercuryErrors(props);
   checkForRegistrationErrors(props);
   checkForDestinationErrors(props);
   checkActivityTypes(props);
+  checkCanSendMessage(props);
 }
 
 export default compose(

--- a/packages/node_modules/@webex/widget-space/src/messages.js
+++ b/packages/node_modules/@webex/widget-space/src/messages.js
@@ -30,6 +30,10 @@ export default defineMessages({
     id: 'ciscospark.container.space.error.invalidActivity',
     defaultMessage: 'Error: The selected initial activity is invalid'
   },
+  invalidSendMessageConfiguration: {
+    id: 'ciscospark.container.space.error.invalidSendMessageConfiguration',
+    defaultMessage: 'Error: The current configuration will not allow for sending messages'
+  },
   unableToLoad: {
     id: 'ciscospark.container.space.error.unabletoload',
     defaultMessage: 'Unable to Load Space'

--- a/packages/node_modules/@webex/widget-space/src/selector.js
+++ b/packages/node_modules/@webex/widget-space/src/selector.js
@@ -205,9 +205,37 @@ export const getActivityTypes = createSelector(
   }
 );
 
+export const getSubmitOptions = createSelector(
+  [getOwnProps],
+  (ownProps) => {
+    const {showSubmitButton = false, sendMessageOnReturnKey = true} = ownProps;
+
+    return {showSubmitButton, sendMessageOnReturnKey};
+  }
+);
+
+
 export const getSpaceWidgetProps = createSelector(
-  [getWidget, getSpark, getMedia, getSpaceDetails, getActivityTypes, getCall, getMercuryStatus, getCurrentActivity],
-  (widget, spark, media, spaceDetails, activityTypes, call, mercuryStatus, currentActivity) => ({
+  [getWidget,
+    getSpark,
+    getMedia,
+    getSpaceDetails,
+    getActivityTypes,
+    getCall,
+    getMercuryStatus,
+    getCurrentActivity,
+    getSubmitOptions],
+  (widget,
+    spark,
+    media,
+    spaceDetails,
+    activityTypes,
+    call, mercuryStatus,
+    currentActivity,
+    {
+      showSubmitButton,
+      sendMessageOnReturnKey
+    }) => ({
     activityTypes,
     destination: widget.get('destination'),
     media,
@@ -217,6 +245,8 @@ export const getSpaceWidgetProps = createSelector(
     spaceDetails,
     widgetStatus: widget.get('status'),
     call,
-    currentActivity
+    currentActivity,
+    showSubmitButton,
+    sendMessageOnReturnKey
   })
 );


### PR DESCRIPTION
Allow users to use a send button and disable the return key for sending message. Show an error if configured in a way that will not allow users to send a message.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-267233