### PR TITLE
fix(CHMakeCallchanges): CH Make Call Changes

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistory.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistory.tsx
@@ -12,7 +12,7 @@ export type CallHistoryProps = {
   onPress?: (item: ICallHistoryItemProps) => void;
   selectedItem?: ICallHistoryItemProps;
   extraCallHistoryItemProps?: ICallHistoryItemProps;
-  makeACallingToken?: string
+  makeCall?: (address: string, isVideo?: boolean) => void;
 };
 
 /**
@@ -32,7 +32,7 @@ export const CallHistory = ({
   onPress = undefined,
   selectedItem = undefined,
   extraCallHistoryItemProps = undefined,
-  makeACallingToken
+  makeCall
 }: CallHistoryProps) => {
   const [cssClasses, sc] = useWebexClasses('call-history');
 
@@ -67,8 +67,8 @@ export const CallHistory = ({
               startTime={item.startTime}
               endTime={item.endTime}
               callbackAddress={item.callbackAddress}
-              makeACallingToken={makeACallingToken}
               durationSeconds={item.durationSeconds}
+              makeCall={makeCall}
             />
           ))}
         </List>

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 
 import './CallHistoryItem.styles.scss';
 import { ICallHistoryItemProps } from './CallHistoryItem.types';
-import { useMakeCall } from './hooks/useMakeCall';
 import useWebexClasses from './hooks/useWebexClasses';
 import {
   removeBracketsAndContent
@@ -57,12 +56,11 @@ export const CallHistoryItem = ({
   audioCallLabel = 'Make an audio call',
   videoCallLabel = 'Make a video call',
   durationSeconds,
-  makeACallingToken
+  makeCall
 }: ICallHistoryItemProps) => {
   const isMissed = disposition?.toLowerCase() === 'missed';
   const isOutgoing = direction?.toLowerCase() === 'outgoing';
   const duration = formatDurationFromSeconds(durationSeconds ? durationSeconds : 0);
-  const [makeCall] = useMakeCall(makeACallingToken as string);
   const chTitle = name ? name : phoneNumber;
   const chInitals = name ? removeBracketsAndContent(name) : removeBracketsAndContent(phoneNumber);
 
@@ -139,7 +137,7 @@ export const CallHistoryItem = ({
               className={sc('audio-btn')}
               title={audioCallLabel}
               aria-label={audioCallLabel}
-              onPress={() => makeCall(callbackAddress || id, false)}
+              onPress={() => makeCall && makeCall(callbackAddress || id, false)}
               data-testid='make-audio-call'
             >
               <svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -152,7 +150,7 @@ export const CallHistoryItem = ({
               className={sc('video-btn')}
               title={videoCallLabel}
               aria-label={videoCallLabel}
-              onPress={() => makeCall(callbackAddress || id, true)}
+              onPress={() => makeCall && makeCall(callbackAddress || id, true)}
               data-testid='make-video-call'
             >
               <svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.types.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.types.ts
@@ -13,6 +13,6 @@ export interface ICallHistoryItemProps {
   itemIndex?: number;
   audioCallLabel?: string;
   videoCallLabel?: string;
-  makeACallingToken?: string;
   durationSeconds?: number;
+  makeCall?: (address: string, isVideo?: boolean) => void;
 }


### PR DESCRIPTION
Sending makeCall function from Main repository to 2nd repository(react-widgets project) as a prop.
This codes fixes that When refreshing the re-design landing page, cross launch token going as empty when trying to make call from Call History List