### PR TITLE
fix(VMnullCheck): Voicemail null check fix

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -98,7 +98,7 @@ export const CallHistoryItem = ({
             </Text>
             <Text 
               type="body-secondary" 
-              className={`${sc('phoneNumber')} ${ name === '' ? '' :  sc('margin_adjust')}`}
+              className={`${sc('phoneNumber')} ${ name && phoneNumber ? sc('margin_adjust') : name === '' ? sc('font_adjust') : ''}`}
               aria-label={phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber)}
               >
               {phoneNumber}
@@ -127,7 +127,7 @@ export const CallHistoryItem = ({
               <Text 
                 type="body-secondary" 
                 className={sc('duration')}
-                aria-label={durationSeconds && formatDurationForAnnouncement(durationSeconds as number)}
+                aria-label={formatDurationForAnnouncement(durationSeconds as number)}
                 >
                 {duration}
               </Text>

--- a/packages/node_modules/@webex/widget-call-history/src/utils/voiceOver.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/utils/voiceOver.ts
@@ -11,7 +11,7 @@ export const formatDurationForAnnouncement = (seconds: number): string => {
       .filter(Boolean) // Remove empty strings
       .join(' ');
   
-    return formattedDuration;
+    return `duration ${formattedDuration}`;
   };
   
   export const formatPhoneNumberForAnnouncement = (phoneNumber: string): string => {

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -78,7 +78,10 @@ export const VoicemailItem = ({
           <Text type="body-primary" className={sc('name')}>
             {voicemail.name}
           </Text>
-          <Text type="body-secondary" className={`${sc('phone')} ${ voicemail.name === '' ? '' :  sc('margin_adjust')}`}>
+          <Text 
+            type="body-secondary" 
+            className={`${sc('phone')} ${ voicemail?.name && voicemail?.address ?  sc('margin_adjust') : voicemail?.name === '' ? sc('font_adjust') : ''}`}
+            >
             {voicemail.address}
           </Text>
         </Flex>
@@ -112,6 +115,7 @@ export const VoicemailItem = ({
               size={32}
               color="join"
               onPress={useMakeAudioCall}
+              disabled={voicemail?.address === '' ? true : false}
               data-testid='make-audio-call'
             >
               <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,6 +126,7 @@ export const VoicemailItem = ({
               size={32}
               color="join"
               onPress={useMakeVideoCall}
+              disabled={voicemail?.address === '' ? true : false}
               data-testid='make-video-call'
             >
               <svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Description:

- Disabling audio and video buttons if the voicemail address is not available
- Need to use the same style as we use on caller name to the phone number/address when there is no name present for both Call-history and Voicemail features