### PR TITLE
fix(dialpadissue): fixed focus on search input

### DIFF
--- a/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
+++ b/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
@@ -77,7 +77,7 @@ export const NumberPad = ({
     useGridFocus<HTMLButtonElement>(childrenRef);
     const numberPadRef = useRef<HTMLDivElement>(null);
     const [isNumberPadFocused, setNumberPadFocused] = useState(false); 
-    const NUMBER_PAD_FOCUSSED = 'NumberPadFocused';
+    const NUMBER_PAD_FOCUSED = 'NumberPadFocused';
     const SEARCH_INPUT_FOCUSED = 'SearchInputFocused';
 
     useEffect(() => {
@@ -86,15 +86,15 @@ export const NumberPad = ({
           const focusedButtonValue = (event.target as HTMLButtonElement)?.textContent;
           if (focusedButtonValue === '1') {
             setNumberPadFocused(true);
-            localStorage.setItem(NUMBER_PAD_FOCUSSED, JSON.stringify(true));
+            localStorage.setItem(NUMBER_PAD_FOCUSED, JSON.stringify(true));
             window.dispatchEvent(new Event('storage'));
           } else {
             setNumberPadFocused(false);
-            localStorage.removeItem(NUMBER_PAD_FOCUSSED);
+            localStorage.removeItem(NUMBER_PAD_FOCUSED);
           }
         } else {
           setNumberPadFocused(false);
-          localStorage.removeItem(NUMBER_PAD_FOCUSSED);
+          localStorage.removeItem(NUMBER_PAD_FOCUSED);
         }
       };
   
@@ -105,22 +105,31 @@ export const NumberPad = ({
       };
     }, []); 
 
-    const handleShiftTabKeyPress = (
-      event: React.KeyboardEvent<HTMLInputElement>
-    ) => {
-      if (numberPadRef.current?.contains(event.target as Node)) {
-      if (event.key === "Tab" && event.shiftKey) {
-        localStorage.setItem(SEARCH_INPUT_FOCUSED, JSON.stringify(true));
-        window.dispatchEvent(new Event('storage'));
-      }
-      else{
-        localStorage.removeItem(SEARCH_INPUT_FOCUSED);
-      }
-    }
-    else{
-      localStorage.removeItem(SEARCH_INPUT_FOCUSED);
-    }
-    };
+
+    useEffect(() => {
+      // handler object
+      const handleEvent = (event: KeyboardEvent) => {
+        if (numberPadRef.current?.contains(event.target as Node)) {
+        if (event.key === "Tab" && event.shiftKey) {             
+            localStorage.setItem(SEARCH_INPUT_FOCUSED, JSON.stringify(true));
+            window.dispatchEvent(new Event('storage'));               
+          } else {
+            localStorage.removeItem(SEARCH_INPUT_FOCUSED);
+         }          
+        } else {
+          localStorage.removeItem(SEARCH_INPUT_FOCUSED);
+       }       
+      };
+   
+      // register handler
+      window.addEventListener('keyup', handleEvent);
+    
+      // unregister handler
+      return () => {
+        window.removeEventListener('keyup', handleEvent);
+      };
+    }, []);
+    
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -132,7 +141,6 @@ export const NumberPad = ({
           primaryText={value}
           secondaryText={letters}
           size={64}
-          onKeyUp={handleShiftTabKeyPress}
           onPress={() => onButtonPress(value)}
           ref={(ref: HTMLButtonElement) => {
             childrenRef.current[index] = ref;

--- a/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
+++ b/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
@@ -77,6 +77,8 @@ export const NumberPad = ({
     useGridFocus<HTMLButtonElement>(childrenRef);
     const numberPadRef = useRef<HTMLDivElement>(null);
     const [isNumberPadFocused, setNumberPadFocused] = useState(false); 
+    const NUMBER_PAD_FOCUSSED = 'NumberPadFocused';
+    const SEARCH_INPUT_FOCUSED = 'SearchInputFocused';
 
     useEffect(() => {
       const handleFocusIn = (event: FocusEvent) => {
@@ -84,15 +86,15 @@ export const NumberPad = ({
           const focusedButtonValue = (event.target as HTMLButtonElement)?.textContent;
           if (focusedButtonValue === '1') {
             setNumberPadFocused(true);
-            localStorage.setItem('NumberPadFocused', JSON.stringify(true));
+            localStorage.setItem(NUMBER_PAD_FOCUSSED, JSON.stringify(true));
             window.dispatchEvent(new Event('storage'));
           } else {
             setNumberPadFocused(false);
-            localStorage.removeItem('NumberPadFocused');
+            localStorage.removeItem(NUMBER_PAD_FOCUSSED);
           }
         } else {
           setNumberPadFocused(false);
-          localStorage.removeItem('NumberPadFocused');
+          localStorage.removeItem(NUMBER_PAD_FOCUSSED);
         }
       };
   
@@ -102,6 +104,23 @@ export const NumberPad = ({
         document.removeEventListener('focusin', handleFocusIn);
       };
     }, []); 
+
+    const handleShiftTabKeyPress = (
+      event: React.KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (numberPadRef.current?.contains(event.target as Node)) {
+      if (event.key === "Tab" && event.shiftKey) {
+        localStorage.setItem(SEARCH_INPUT_FOCUSED, JSON.stringify(true));
+        window.dispatchEvent(new Event('storage'));
+      }
+      else{
+        localStorage.removeItem(SEARCH_INPUT_FOCUSED);
+      }
+    }
+    else{
+      localStorage.removeItem(SEARCH_INPUT_FOCUSED);
+    }
+    };
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -113,6 +132,7 @@ export const NumberPad = ({
           primaryText={value}
           secondaryText={letters}
           size={64}
+          onKeyUp={handleShiftTabKeyPress}
           onPress={() => onButtonPress(value)}
           ref={(ref: HTMLButtonElement) => {
             childrenRef.current[index] = ref;


### PR DESCRIPTION
[Jira link](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-449693)

Dialpad: Currently, shift-tab from the number key goes to the previous number in numerical order. When shift - tab from any number button, it should go back to the search field.