### PR TITLE
fix(darkTheme): signIn Ui changes

### DIFF
--- a/packages/node_modules/@webex/webex-sign-in-page/src/WebexSignInPage.scss
+++ b/packages/node_modules/@webex/webex-sign-in-page/src/WebexSignInPage.scss
@@ -41,6 +41,12 @@
     text-align: center;
     color: var(--mds-color-theme-text-secondary-normal);
     margin-top: 8px;
+    .webex-more-info {
+      color: var(--mds-color-theme-button-accent-hover);
+   }
+    .grant-consent {
+    color: var(--mds-color-theme-button-accent-hover);
+    }
   }
 }
 


### PR DESCRIPTION
MS Themes support for Dark Mode, High Contrast, Default
Changed the color of "click here" and "Grant Permission" text as per the figma to support the themes
Jira link: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-420824

<img width="1660" alt="signin" src="https://github.com/webex/react-widgets/assets/58249052/25e8c51a-087f-491c-8395-9f1bb0126b2b">
<img width="1728" alt="dark" src="https://github.com/webex/react-widgets/assets/58249052/e1baaff1-f900-436c-9abd-0f5fedff99c9">

