### PR TITLE
fix(VMandCHRowSelected): fixed CH and VM row selected issue

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -86,7 +86,7 @@ export const CallHistoryItem = ({
       isPadded
       isSelected={isSelected}
       className={cssClasses}
-      onPress={onPress}
+      // onPress={onPress}
       data-testid="call-history-item"
     >
       <ListItemBaseSection position="start" className={sc('icon')}>

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -68,7 +68,7 @@ export const VoicemailItem = ({
       size={50}
       isPadded
       isSelected={isSelected}
-      onPress={onClick}
+      // onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
     >


### PR DESCRIPTION
**Description:** This PR provides a fix for the issue where the 'selected' state does not get cleared after moving the cursor outside of a row or clicking outside the row. The solution was achieved by removing the 'OnPress' method from both the call history and voicemail sections.

Jira link: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-488831