### PR TITLE
fix(darktheme): darktheme hyper link color updated

### DIFF
--- a/packages/node_modules/@webex/webex-sign-in-page/src/WebexSignInPage.scss
+++ b/packages/node_modules/@webex/webex-sign-in-page/src/WebexSignInPage.scss
@@ -42,10 +42,10 @@
     color: var(--mds-color-theme-text-secondary-normal);
     margin-top: 8px;
     .webex-more-info {
-      color: var(--mds-color-theme-button-accent-hover);
+      color: var(--mds-color-theme-text-accent-normal);
    }
     .grant-consent {
-    color: var(--mds-color-theme-button-accent-hover);
+    color: var(--mds-color-theme-text-accent-normal);
     }
   }
 }
@@ -70,6 +70,9 @@
     margin: 0 auto;
     margin-bottom: 100px;
   }
+  span {
+    font-weight: 550;
+}
 }
 
 @media screen and (max-height: 444px) {


### PR DESCRIPTION
As per the IVY comments updated the hyperlink color and font weight.
https://www.figma.com/file/Mh170f6uvIf3bs1HeeFLXu/MS-int.-themes?node-id=20%3A344&mode=dev
<img width="1728" alt="uploadDarktheme" src="https://github.com/webex/react-widgets/assets/58249052/b04aac9e-329f-422a-bc57-368fded8d196">
