### PR TITLE
fix(dialpad): allow longpress for '0' and '*'

### DIFF
--- a/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
+++ b/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
@@ -3,6 +3,7 @@ import { ButtonDialpad } from '@momentum-ui/react-collaboration';
 import './NumberPad.scss';
 import useWebexClasses from './hooks/useWebexClasses';
 import { useGridFocus } from './hooks/useGridFocus';
+import { longPressDuration, longPressHandledValues } from './utils/WebexDialPad'
 
 const dialPadButtonTexts = [
   {
@@ -77,8 +78,37 @@ export const NumberPad = ({
     useGridFocus<HTMLButtonElement>(childrenRef);
     const numberPadRef = useRef<HTMLDivElement>(null);
     const [isNumberPadFocused, setNumberPadFocused] = useState(false); 
+    const [buttonPressStart, setButtonPressStart] = useState(0);
     const NUMBER_PAD_FOCUSED = 'NumberPadFocused';
     const SEARCH_INPUT_FOCUSED = 'SearchInputFocused';
+    const [timeoutID, setTimeoutID] = useState<NodeJS.Timeout>();
+
+    const onPress = (value: string, letters: string | undefined) => {
+      //Will pass the primary value of the dialpad button if button pressed is other than '0' or '*'
+      //or
+      //The button pressed is '0' or '*' but the duration of press is less than our predetermined duration of press to consider it as a long press.
+      if (!longPressHandledValues.includes(value) || (longPressHandledValues.includes(value) && (Date.now() - buttonPressStart) < longPressDuration)) {
+        timeoutID && clearTimeout(timeoutID);
+        onButtonPress(value);
+      }
+    }
+
+    const onPressStart = (value: string, letters: string | undefined) => {
+      //Storing the exact time when the press starts
+      setButtonPressStart(Date.now());
+      //Will set the timer for long press only for '0' and '*' buttons in dialpad
+      if (longPressHandledValues.includes(value)) {
+        let timer = setTimeout(() => {
+          // If the duration of press exceeds or is equal to our predetermined duration (duration after which we will consider a press as long press) 
+          // will automatically set the search input value to secondary content of dialpad element i.e letters.
+          if ((Date.now() - buttonPressStart) >= longPressDuration) {
+            letters && onButtonPress(letters);
+            clearTimeout(timer);
+          }
+        }, longPressDuration);
+        setTimeoutID(timer);
+      }
+    }
 
     useEffect(() => {
       const handleFocusIn = (event: FocusEvent) => {
@@ -141,7 +171,9 @@ export const NumberPad = ({
           primaryText={value}
           secondaryText={letters}
           size={64}
-          onPress={() => onButtonPress(value)}
+          onPress={() => {
+            onPress(value, letters)
+          }}
           ref={(ref: HTMLButtonElement) => {
             childrenRef.current[index] = ref;
           }}
@@ -154,6 +186,9 @@ export const NumberPad = ({
             setNumberPadFocused(false);
           }} 
           disabled={disabled}
+          onPressStart={() => {
+            onPressStart(value, letters)
+          }}
         />
       ))}
     </div>

--- a/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
+++ b/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
@@ -83,10 +83,10 @@ export const NumberPad = ({
     const SEARCH_INPUT_FOCUSED = 'SearchInputFocused';
     const [timeoutID, setTimeoutID] = useState<NodeJS.Timeout>();
 
-    const onPress = (value: string, letters: string | undefined) => {
-      //Will pass the primary value of the dialpad button if button pressed is other than '0' or '*'
-      //or
-      //The button pressed is '0' or '*' but the duration of press is less than our predetermined duration of press to consider it as a long press.
+    const onPress = (value: string) => {
+      //Will pass the primary value of the dialpad button 
+      //If button pressed is other than '0' or '*', 
+      //If the button pressed is '0' or '*' but the duration of press is less than our predetermined duration of press to consider it as a long press.
       if (!longPressHandledValues.includes(value) || (longPressHandledValues.includes(value) && (Date.now() - buttonPressStart) < longPressDuration)) {
         timeoutID && clearTimeout(timeoutID);
         onButtonPress(value);
@@ -159,6 +159,15 @@ export const NumberPad = ({
         window.removeEventListener('keyup', handleEvent);
       };
     }, []);
+
+    useEffect(() => {
+      return () => {
+        // Clear timeout on unmount to prevent memory leaks
+        if (timeoutID) {
+          clearTimeout(timeoutID);
+        }
+      };
+    }, []);
     
 
   return (
@@ -172,7 +181,7 @@ export const NumberPad = ({
           secondaryText={letters}
           size={64}
           onPress={() => {
-            onPress(value, letters)
+            onPress(value)
           }}
           ref={(ref: HTMLButtonElement) => {
             childrenRef.current[index] = ref;

--- a/packages/node_modules/@webex/widget-number-pad/src/utils/WebexDialPad.ts
+++ b/packages/node_modules/@webex/widget-number-pad/src/utils/WebexDialPad.ts
@@ -1,0 +1,4 @@
+//Duration at or after which a button press will be considered as long press
+export const longPressDuration = 700;
+//Dialpad buttons for which long press will be handled
+export const longPressHandledValues = ['*', '0'];


### PR DESCRIPTION
Handled long press on 0 and * from Dialpad, which will allow  the use of the '+' symbol by long-pressing '0' and ',' symbol by long-pressing '*' on the Dialpad in plugin for MS Teams.

[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-517897](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-517897)