### PR TITLE
fix(voiceover): reordered item voiceover text not reinitializing

### DIFF
--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
@@ -267,6 +267,7 @@ export const SpeedDialForm = ({
                   label={t('form.firstName.label')}
                   aria-label={formData?.givenName}
                   placeholder={t('form.firstName.placeholder')}
+                  clearAriaLabel={t("search.labels.clear")}
                   onBlur={onBlur}
                   onInput={(e) => {
                     // setAvatarName(e.currentTarget.value);
@@ -303,6 +304,7 @@ export const SpeedDialForm = ({
                   aria-label={value}
                   placeholder={t('form.lastName.placeholder')}
                   onBlur={onBlur}
+                  clearAriaLabel={t("search.labels.clear")}
                   onInput={(e) => {
                     setFormData({
                       ...formData,
@@ -368,6 +370,7 @@ export const SpeedDialForm = ({
                     label={t('form.phone.label')}
                     placeholder={t('form.phone.placeholder')}
                     aria-label={formData.currentCallAddress}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={(e) => {
                       setFormData({
@@ -411,6 +414,7 @@ export const SpeedDialForm = ({
                     label={t('form.mail.label')}
                     placeholder={t('form.mail.placeholder')}
                     aria-label={formData.currentCallAddress}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={onChange}
                     ref={ref}
@@ -448,6 +452,7 @@ export const SpeedDialForm = ({
                     label={t('form.sip.label')}
                     placeholder={t('form.sip.placeholder')}
                     aria-label={formData.currentCallAddress}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={onChange}
                     ref={ref}
@@ -487,6 +492,7 @@ export const SpeedDialForm = ({
                   label={t('form.firstName.label')}
                   aria-label={formData?.givenName}
                   placeholder={t('form.firstName.placeholder')}
+                  clearAriaLabel={t("search.labels.clear")}
                   onBlur={onBlur}
                   onInput={(e) => {
                     // setAvatarName(e.currentTarget.value);
@@ -521,6 +527,7 @@ export const SpeedDialForm = ({
                   label={t('form.lastName.label')}
                   aria-label={value}
                   placeholder={t('form.lastName.placeholder')}
+                  clearAriaLabel={t("search.labels.clear")}
                   onBlur={onBlur}
                   onInput={(e) => {
                     setFormData({
@@ -587,6 +594,7 @@ export const SpeedDialForm = ({
                     label={t('form.phone.label')}
                     placeholder={t('form.phone.placeholder')}
                     aria-label={value}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={(e) => {
                       setFormData({
@@ -630,6 +638,7 @@ export const SpeedDialForm = ({
                     label={t('form.mail.label')}
                     placeholder={t('form.mail.placeholder')}
                     aria-label={value}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={onChange}
                     ref={ref}
@@ -667,6 +676,7 @@ export const SpeedDialForm = ({
                     label={t('form.sip.label')}
                     placeholder={t('form.sip.placeholder')}
                     aria-label={value}
+                    clearAriaLabel={t("search.labels.clear")}
                     onBlur={onBlur}
                     onInput={(e) => {
                       setFormData({

--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
@@ -40,6 +40,8 @@ export interface ISpeedDialProps {
   onEditPress?: (item: ISpeedDialRecord) => void;
 
   children?: React.ReactNode;
+  /** To handle reinitialization of aria label content after item has been rearranged  */
+  selectedNodeForRearange: Element | undefined;
 }
 
 /**

--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.tsx
@@ -53,6 +53,7 @@ const SortableItem = SortableElement<ISpeedDialProps>(
     onVideoCallPress,
     onRemovePress,
     onEditPress,
+    selectedNodeForRearange
   }: ISpeedDialProps) => { 
     const [isContactFocused, setIsContactFocused] = useState(false);
     const childRef = useRef<ChildHandles | null>(null);
@@ -86,6 +87,8 @@ const SortableItem = SortableElement<ISpeedDialProps>(
     
     const handleContextMenuTriggerBlur = () => {
       setIsContactFocused(false); 
+      // To handle reinitialization of aria label content after item has been rearranged
+      selectedNodeForRearange && selectedNodeForRearange.removeAttribute('aria-label');
     };
 
        
@@ -105,6 +108,7 @@ const SortableItem = SortableElement<ISpeedDialProps>(
         onEditPress={onEditPress}
         onRemovePress={onRemovePress}
         ref={childRef}
+        selectedNodeForRearange={selectedNodeForRearange}
       >
         <DragHandle  />
       </SpeedDialItem>
@@ -123,6 +127,7 @@ const SortableList = SortableContainer<ISpeedDialsListProps>(
     onEditPress,
     onRemovePress,
     className,
+    selectedNodeForRearange
   }: {
     items: ISpeedDialRecord[];
     onPress?: (item: ISpeedDialRecord) => void;
@@ -131,6 +136,7 @@ const SortableList = SortableContainer<ISpeedDialsListProps>(
     onEditPress?: (item: ISpeedDialRecord) => void;
     onRemovePress?: (id: string) => void;
     className: string;
+    selectedNodeForRearange: Element;
   }) => (
     <ul className={className}>
       {items &&
@@ -146,6 +152,7 @@ const SortableList = SortableContainer<ISpeedDialsListProps>(
             onVideoCallPress={onVideoCallPress}
             onEditPress={onEditPress}
             onRemovePress={onRemovePress}
+            selectedNodeForRearange={selectedNodeForRearange}
           />
         ))}
     </ul>
@@ -240,6 +247,7 @@ export const SpeedDials = ({
             node.ariaLabel = `${t('voiceover.startRearranging', { contactName: items[index].displayName, numberType: items[index].phoneType })} ${t('voiceover.adjustPosition')} ${t('voiceover.stopRearranging')} ${t('voiceover.currentPosition', { currentIndex: index+1, totalIndex: items.length })}`;
             setSelectedNode(node);
           }}
+          selectedNodeForRearange={selectedNode}
         />
       </div>
     );

--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.types.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.types.tsx
@@ -31,4 +31,6 @@ export interface ISpeedDialsListProps extends ISpeedDialEvents {
   className: string;
   /** Handle when item is pressed */
   onClick?: (id: string) => void;
+  /** To handle reinitialization of aria label content after item has been rearranged  */
+  selectedNodeForRearange: Element | undefined;
 }


### PR DESCRIPTION
Provided a fix for the problem where if a reordered item is focused once again it is announcing the text which was set when the text was set after reorder is complete and not the actual text which it should announce when focused.

[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-520895](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-520895)