### PR TITLE
fix(voiceover): add breaks between announcements

### DIFF
--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
@@ -223,7 +223,7 @@ export const SpeedDialItem = forwardRef(({
               }}
               ref={contactRef}
               onClick={handleClick}
-              aria-label={`${abbrDisplayName(item?.displayName)} ${t('form.phoneTypes.'+ item?.phoneType)} ${t('addSpeedBanner.dial.header')} ${t('voiceover.enterCall', {callType: isAudio ? t('item.audioCall.label') : t('item.videoCall.label')})} ${t('voiceover.openContextMenu')} ${t('voiceover.rearrangeItem')}`}
+              aria-label={`${abbrDisplayName(item?.displayName)}, ${t('form.phoneTypes.'+ item?.phoneType)}, ${t('addSpeedBanner.dial.header')}, ${t('voiceover.enterCall', {callType: isAudio ? t('item.audioCall.label') : t('item.videoCall.label')})}, ${t('voiceover.openContextMenu')}, ${t('voiceover.rearrangeItem')}`}
             >
               <Flex
                 alignItems="center"

--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDials.tsx
@@ -244,7 +244,7 @@ export const SpeedDials = ({
           axis="xy"
           className={sc('list')}
           updateBeforeSortStart={({node, index}, event) => {
-            node.ariaLabel = `${t('voiceover.startRearranging', { contactName: items[index].displayName, numberType: items[index].phoneType })} ${t('voiceover.adjustPosition')} ${t('voiceover.stopRearranging')} ${t('voiceover.currentPosition', { currentIndex: index+1, totalIndex: items.length })}`;
+            node.ariaLabel = `${t('voiceover.startRearranging', { contactName: items[index].displayName, numberType: items[index].phoneType })}, ${t('voiceover.adjustPosition')}, ${t('voiceover.stopRearranging')}, ${t('voiceover.currentPosition', { currentIndex: index+1, totalIndex: items.length })}`;
             setSelectedNode(node);
           }}
           selectedNodeForRearange={selectedNode}


### PR DESCRIPTION
add commas/breaks between announcements? (e.g., “Started rearranging XYZ Work, Use arrow keys to adjust position, Press Space again to stop rearranging, etc...)