### PR TITLE
fix(callHistory): badge counter

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistory.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistory.tsx
@@ -14,6 +14,7 @@ export type CallHistoryProps = {
   extraCallHistoryItemProps?: ICallHistoryItemProps;
   makeCall?: (address: string, isVideo?: boolean, label?: string) => void;
   isLocaleGerman?: boolean;
+  dismissBagdeonClickRow?: () => void;
 };
 
 /**
@@ -34,7 +35,8 @@ export const CallHistory = ({
   selectedItem = undefined,
   extraCallHistoryItemProps = undefined,
   makeCall,
-  isLocaleGerman
+  isLocaleGerman,
+  dismissBagdeonClickRow
 }: CallHistoryProps) => {
   const [cssClasses, sc] = useWebexClasses('call-history');
 
@@ -57,6 +59,7 @@ export const CallHistory = ({
               onPress={() => {
                 if (onPress) {
                   onPress(item);
+                  dismissBagdeonClickRow && dismissBagdeonClickRow()
                 }
               }}
               key={item.id}
@@ -73,6 +76,7 @@ export const CallHistory = ({
               makeCall={makeCall}
               callingSpecific={item.callingSpecific}
               isLocaleGerman={isLocaleGerman}
+              dismissBagdeonClickRow={dismissBagdeonClickRow}
             />
           ))}
         </List>

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -17,10 +17,10 @@ import {
 } from './utils/avatarInitials';
 import {
   formatDate,
+  formatDateDDMMYYYY,
   formatDurationFromSeconds,
   formatTime,
-  formatTimeToSupport24Hours, 
-  formatDateDDMMYYYY 
+  formatTimeToSupport24Hours
 } from './utils/dateUtils';
 import {
   formatDurationForAnnouncement,
@@ -67,7 +67,8 @@ export const CallHistoryItem = ({
   durationSeconds,
   makeCall,
   callingSpecific = undefined,
-  isLocaleGerman
+  isLocaleGerman,
+  dismissBagdeonClickRow
 }: ICallHistoryItemProps) => {
   const { t } = useTranslation('WebexCallHistory');
   const isMissed = disposition?.toLowerCase() === 'missed';
@@ -82,6 +83,24 @@ export const CallHistoryItem = ({
     'is-outgoing': isOutgoing,
     'is-selected': isSelected as boolean,
   });
+
+  const handleAudioPress = () => {
+    if (makeCall) {
+    makeCall(callbackAddress || id, false, recentCallsLabel);
+    }
+    if(dismissBagdeonClickRow) {
+    dismissBagdeonClickRow();
+    }
+  };
+    
+  const handleVideoPress = () => {
+    if (makeCall) {
+    makeCall(callbackAddress || id, true, recentCallsLabel);
+    }
+    if(dismissBagdeonClickRow) {
+    dismissBagdeonClickRow();
+    }
+  };
 
   return (
     <ListItemBase
@@ -175,7 +194,7 @@ export const CallHistoryItem = ({
               className={sc('audio-btn')}
               title={t('audioCallLabel')}
               aria-label={t('audioCallLabel')}
-              onPress={() => makeCall && makeCall(callbackAddress || id, false, recentCallsLabel)}
+              onPress={handleAudioPress}
               data-testid='make-audio-call'
             >
               <svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -188,7 +207,7 @@ export const CallHistoryItem = ({
               className={sc('video-btn')}
               title={t('videoCallLabel')}
               aria-label={t('videoCallLabel')}
-              onPress={() => makeCall && makeCall(callbackAddress || id, true, recentCallsLabel)}
+              onPress={handleVideoPress}
               data-testid='make-video-call'
             >
               <svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.types.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.types.ts
@@ -17,4 +17,5 @@ export interface ICallHistoryItemProps {
   makeCall?: (address: string, isVideo?: boolean, label?: string) => void;
   callingSpecific?: string;
   isLocaleGerman?: boolean;
+  dismissBagdeonClickRow?: () => void;
 }


### PR DESCRIPTION
**Jira**: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-452240

**by making the following changes**
In the MSFT client side, when a user clicks on any call history record  or audio/video button, the missed call notification badge/counter should dismiss.