### PR TITLE
fix(spark:526782): callhistory item aria lable for date and time

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -112,7 +112,7 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
-      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}`}
+      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
         <Avatar initials={chInitals} title={chTitle} size={32} />

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -112,7 +112,7 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
-      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${(missedCallText)}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}`}
+      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
         <Avatar initials={chInitals} title={chTitle} size={32} />

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -112,15 +112,16 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
+      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${(missedCallText)}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
-        <Avatar aria-label={chInitals} initials={chInitals} title={chTitle} size={32} />
+        <Avatar initials={chInitals} title={chTitle} size={32} />
       </ListItemBaseSection>
       <ListItemBaseSection position="fill" className={sc('content')}>
         <Flex>
           <Flex direction="column" className={sc('content-wrap')}>
             <div title={titleCase(name) + " " + (name === phoneNumber ? '' : phoneNumber)}>
-              <Text type="body-primary" className={sc('name')} aria-label={name}>
+              <Text type="body-primary" className={sc('name')}>
                 {name}
               </Text>
             </div>
@@ -129,7 +130,6 @@ export const CallHistoryItem = ({
               <Text 
                 type={`${(phoneNumber && callingSpecific) ? "body-primary" : "body-secondary"}`}
                 className={`${sc('phoneNumber')} ${name === '' ? sc('font_adjust') : ''} ${(phoneNumber && callingSpecific) ? sc('margin_zero') : ''}`}
-                aria-label={phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber)}
                 >
                 {phoneNumber}
               </Text>
@@ -140,7 +140,6 @@ export const CallHistoryItem = ({
                 <Text
                 type="body-secondary" 
                 className={`${sc('phoneNumber')}`}
-                aria-label={callingSpecific}
                 >
                 {callingSpecific}
               </Text>
@@ -162,7 +161,7 @@ export const CallHistoryItem = ({
               </Flex>
             )}
             {isMissed && (
-              <Text type="body-secondary" className={sc('duration')} aria-label={missedCallText}>
+              <Text type="body-secondary" className={sc('duration')}>
                 {t('missedCallText')}
               </Text>
             )}
@@ -170,7 +169,6 @@ export const CallHistoryItem = ({
               <Text 
                 type="body-secondary" 
                 className={sc('duration')}
-                aria-label={formatDurationForAnnouncement(durationSeconds as number)}
                 >
                 {duration}
               </Text>
@@ -193,7 +191,6 @@ export const CallHistoryItem = ({
               color="join"
               className={sc('audio-btn')}
               title={t('audioCallLabel')}
-              aria-label={t('audioCallLabel')}
               onPress={handleAudioPress}
               data-testid='make-audio-call'
             >
@@ -206,7 +203,6 @@ export const CallHistoryItem = ({
               color="join"
               className={sc('video-btn')}
               title={t('videoCallLabel')}
-              aria-label={t('videoCallLabel')}
               onPress={handleVideoPress}
               data-testid='make-video-call'
             >
@@ -221,10 +217,10 @@ export const CallHistoryItem = ({
             alignItems="flex-end"
             className={sc('datetime')}
           >
-            <Text type="body-secondary" className={sc('date')}  aria-label={startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime)}>
+            <Text type="body-secondary" className={sc('date')}>
               {startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime)}
             </Text>
-            <Text type="body-secondary" className={`${sc('time')} ${sc('margin_adjust')}`} aria-label={startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime)}>
+            <Text type="body-secondary" className={`${sc('time')} ${sc('margin_adjust')}`}>
               {startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime)}
             </Text>
           </Flex>

--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -75,7 +75,7 @@ export const CallHistoryItem = ({
   const isOutgoing = direction?.toLowerCase() === 'outgoing';
   const duration = formatDurationFromSeconds(durationSeconds ? durationSeconds : 0);
   const chTitle = name ? name : phoneNumber;
-  const chInitals = name ? removeBracketsAndContent(name) : removeBracketsAndContent(phoneNumber);
+  const chInitials = name ? removeBracketsAndContent(name) : removeBracketsAndContent(phoneNumber);
   const recentCallsLabel = 'Recent calls'
 
   const [cssClasses, sc] = useWebexClasses('call-history-item', undefined, {
@@ -112,10 +112,10 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
-      aria-label={`${(chInitals)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
+      aria-label={`${(chInitials)}, ${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
-        <Avatar initials={chInitals} title={chTitle} size={32} />
+        <Avatar initials={chInitials} title={chTitle} size={32} />
       </ListItemBaseSection>
       <ListItemBaseSection position="fill" className={sc('content')}>
         <Flex>

--- a/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
@@ -2,17 +2,17 @@
 /* eslint-disable react/destructuring-assignment */
 import { SliderState, SliderStateOptions, useSliderState } from 'react-stately';
 
+import React, { MutableRefObject, useRef } from 'react';
 import {
+  VisuallyHidden,
   mergeProps,
   useFocusRing,
   useNumberFormatter,
   useSlider,
   useSliderThumb,
-  VisuallyHidden,
 } from 'react-aria';
-import React, { MutableRefObject, useRef } from 'react';
-import useWebexClasses from './hooks/useWebexClasses';
 import './ScrubbingBar.styles.scss';
+import useWebexClasses from './hooks/useWebexClasses';
 
 type IScrubbingBarThumbProps = {
   state: SliderState;
@@ -49,14 +49,15 @@ const ScrubbingBarThumb = ({
   return (
     <div
       data-testid="scrubbing-bar-thumb"
-      {...thumbProps}
+      {...mergeProps(thumbProps, focusProps)}
       className={`${className} ${isFocusVisible ? 'focus' : ''}`}
       style={{
         left: `calc(calc(100% - 16px) * ${state.getThumbPercent(index)})`,
       }}
+      tabIndex={0}
     >
       <VisuallyHidden>
-        <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
+        <input ref={inputRef} {...inputProps} />
       </VisuallyHidden>
     </div>
   );

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -84,7 +84,7 @@ export const VoicemailItem = ({
       onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
-      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}`}
+      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}, ${unread ? t('unreadVoicemail') : ''}`}
     >
       <ListItemBaseSection position="fill">
         <Avatar initials={vmInitals} title={voicemail.name} size={32} className={sc('avatar')} />

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -51,7 +51,7 @@ export const VoicemailItem = ({
   const [cssClasses, sc] = useWebexClasses('voicemail-item', undefined, {
     unread:voicemail.unread
   });
-  const vmInitals = voicemail?.name ? removeBracketsAndContent(voicemail?.name) : removeBracketsAndContent(voicemail?.address);
+  const vmInitials = voicemail?.name ? removeBracketsAndContent(voicemail?.name) : removeBracketsAndContent(voicemail?.address);
   const durationInSeconds = Math.floor(voicemail.duration / 1000);
   const formattedDuration = new Date(durationInSeconds * 1000).toISOString().substr(11, 8); // Format as "HH:mm:ss"
   const palyOrPause = voicemailSrc ? t('pauseVoicemail') : t('playVoicemail');
@@ -84,10 +84,10 @@ export const VoicemailItem = ({
       onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
-      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}, ${unread ? t('unreadVoicemail') : ''}, ${t('voicemailFocusButton')}`}
+      aria-label={`${(vmInitials)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}, ${unread ? t('unreadVoicemail') : ''}, ${t('voicemailFocusButton')}`}
     >
       <ListItemBaseSection position="fill">
-        <Avatar initials={vmInitals} title={voicemail.name} size={32} className={sc('avatar')} />
+        <Avatar initials={vmInitials} title={voicemail.name} size={32} className={sc('avatar')} />
         <Flex direction="column">
           <Text type="body-primary" className={sc('name')}>
             {voicemail.name}

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -84,7 +84,7 @@ export const VoicemailItem = ({
       onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
-      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}, ${unread ? t('unreadVoicemail') : ''}`}
+      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}, ${unread ? t('unreadVoicemail') : ''}, ${t('voicemailFocusButton')}`}
     >
       <ListItemBaseSection position="fill">
         <Avatar initials={vmInitals} title={voicemail.name} size={32} className={sc('avatar')} />

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -7,17 +7,17 @@ import {
 } from '@momentum-ui/react-collaboration';
 import { IWebexVoicemail } from '@webex/component-adapter-interfaces/dist/esm/src';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import './VoicemailItem.styles.scss';
 import { VoicemailPlaybackControls } from './VoicemailPlaybackControls';
 import useWebexClasses from './hooks/useWebexClasses';
 import { removeBracketsAndContent } from './utils/avatarInitials';
-import { 
-  formatDate, 
-  formatTime, 
-  formatTimeToSupport24Hours, 
-  formatDateDDMMYYYY 
+import {
+  formatDate,
+  formatDateDDMMYYYY,
+  formatTime,
+  formatTimeToSupport24Hours
 } from './utils/dateUtils';
-import { useTranslation } from 'react-i18next';
 
 export interface IVoicemailItemProps {
   voicemail: IWebexVoicemail;
@@ -51,6 +51,10 @@ export const VoicemailItem = ({
   const [cssClasses, sc] = useWebexClasses('voicemail-item', undefined, {
     unread:voicemail.unread
   });
+  const vmInitals = voicemail?.name ? removeBracketsAndContent(voicemail?.name) : removeBracketsAndContent(voicemail?.address);
+  const durationInSeconds = Math.floor(voicemail.duration / 1000);
+  const formattedDuration = new Date(durationInSeconds * 1000).toISOString().substr(11, 8); // Format as "HH:mm:ss"
+  const palyOrPause = voicemailSrc ? t('pauseVoicemail') : t('playVoicemail');
 
   const readVoicemail = useCallback(() => {
     if (onRead) {
@@ -80,9 +84,10 @@ export const VoicemailItem = ({
       onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
+      aria-label={`${(vmInitals)}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, 00:00:00 , ${t('voicemailScrubbingBar')}, ${formattedDuration}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}, ${isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}`}
     >
       <ListItemBaseSection position="fill">
-        <Avatar initials={voicemail?.name ? removeBracketsAndContent(voicemail?.name) : removeBracketsAndContent(voicemail?.address)} title={voicemail.name} size={32} className={sc('avatar')} />
+        <Avatar initials={vmInitals} title={voicemail.name} size={32} className={sc('avatar')} />
         <Flex direction="column">
           <Text type="body-primary" className={sc('name')}>
             {voicemail.name}
@@ -109,14 +114,12 @@ export const VoicemailItem = ({
             <Text
               type="body-secondary"
               className={`${sc('date')} chromatic-ignore`}
-              aria-label={isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}
             >
               {isLocaleGerman ? formatDateDDMMYYYY(voicemail.date) : formatDate(voicemail.date)}
             </Text>
             <Text
               type="body-secondary"
               className={`${sc('time')} ${sc('margin_adjust')} chromatic-ignore`}
-              aria-label={isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}
             >
               {isLocaleGerman ? formatTimeToSupport24Hours(voicemail.date) : formatTime(voicemail.date)}
             </Text>
@@ -127,7 +130,6 @@ export const VoicemailItem = ({
               color="join"
               onPress={useMakeAudioCall}
               title={t('audioCallLabel')}
-              aria-label={t('audioCallLabel')}
               disabled={voicemail?.address === '' ? true : false}
               data-testid='make-audio-call'
             >
@@ -140,7 +142,6 @@ export const VoicemailItem = ({
               color="join"
               onPress={useMakeVideoCall}
               title={t('videoCallLabel')}
-              aria-label={t('videoCallLabel')}
               disabled={voicemail?.address === '' ? true : false}
               data-testid='make-video-call'
             >
@@ -155,7 +156,6 @@ export const VoicemailItem = ({
                onPress={onDelete}  
                data-testid="delete-button"
                title={t('deleteVoicemail')}
-               aria-label={t('deleteVoicemail')}
                >
                 <svg width="10" height="14" viewBox="0 0 10 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8.9998 3.99988H0.999306C0.858683 3.99991 0.719649 4.0296 0.591274 4.087C0.4629 4.14439 0.348072 4.22822 0.254284 4.333C0.160495 4.43777 0.0898545 4.56115 0.0469714 4.69508C0.0040883 4.829 -0.0100734 4.97046 0.00541074 5.11023L0.746131 11.7762C0.813563 12.3879 1.10444 12.9531 1.56297 13.3634C2.02151 13.7738 2.6154 14.0004 3.23075 13.9999H6.76835C7.3837 14.0004 7.9776 13.7738 8.43613 13.3634C8.89466 12.9531 9.18554 12.3879 9.25297 11.7762L9.99347 5.11023C10.0091 4.97046 9.99498 4.82898 9.95215 4.69503C9.90932 4.56108 9.8387 4.43767 9.74492 4.33287C9.65114 4.22807 9.5363 4.14425 9.4079 4.08687C9.27951 4.02949 9.14043 3.99984 8.9998 3.99988ZM8.2593 11.6659C8.21871 12.0328 8.04411 12.3719 7.76897 12.6181C7.49384 12.8642 7.13752 13.0002 6.76833 12.9999H3.23073C2.86154 13.0002 2.50523 12.8642 2.23009 12.6181C1.95495 12.3719 1.78035 12.0328 1.73977 11.6659L0.999266 4.99988H8.99977L8.2593 11.6659Z" fill="var(--mds-color-theme-text-primary-normal)" fillOpacity="0.95"/>

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.styles.scss
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.styles.scss
@@ -2,7 +2,7 @@ $C: wxc-voicemail-playback-controls;
 
 .#{$C} {
   &__play-icon {
-    margin-left: 3px; //fix off-centered play icon
+    margin-left: 1px; //fix off-centered play icon
   }
 }
 

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
@@ -4,7 +4,7 @@ import {
   IconNext,
   Text,
 } from '@momentum-ui/react-collaboration';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrubbingBar } from './ScrubbingBar';
 import './VoicemailItem.styles.scss';
@@ -19,6 +19,7 @@ export interface IVoicemailPlaybackControlsProps {
   className?: string;
   duration: number;
   audioSrcLoader?: boolean;
+  focusPauseButton?: () => void;
 }
 
 export const VoicemailPlaybackControls = ({
@@ -34,9 +35,17 @@ export const VoicemailPlaybackControls = ({
   const playAudio = () => {
     onPlay();
     setPlaying(true);
+    focusPauseButton();
   };
+  const pauseButtonRef = useRef<HTMLButtonElement>(null);
   const [cssClasses, sc] = useWebexClasses('voicemail-playback-controls');
 
+  const focusPauseButton = () => {
+    setTimeout(() => {
+      pauseButtonRef?.current?.focus();
+    }, 200);
+  };
+  
   return (
     <Flex
       xgap=".5rem"
@@ -44,9 +53,19 @@ export const VoicemailPlaybackControls = ({
       className={`${className} ${cssClasses}`}
     >
       {playing && audioSrc ? (
-        <ButtonCircle outline size={28} onPress={() => setPlaying(false)} data-testid="pause-button" title={t('pauseVoicemail')}>
-          <IconNext name="pause" autoScale={150} />
-        </ButtonCircle>
+        <ButtonCircle
+        outline
+        size={28}
+        onPress={() => {
+          setPlaying(false);
+          focusPauseButton();
+        }}
+        data-testid="pause-button"
+        title={t('pauseVoicemail')}
+        ref={pauseButtonRef}
+      >
+        <IconNext name="pause" autoScale={150} />
+      </ButtonCircle>
       ) : (
           (audioSrcLoader && audioSrc === '') ? (<div className='vmLoader'><div className="md-loading-spinner-wrapper" data-testid="loading-icon">
             <div className="md-icon-wrapper">

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
 import {
   ButtonCircle,
   Flex,
   IconNext,
   Text,
 } from '@momentum-ui/react-collaboration';
-import './VoicemailItem.styles.scss';
-import { ScrubbingBar } from './ScrubbingBar';
-import { useAudio } from './hooks/useAudio';
-import { formatDuration } from './utils/dateUtils';
-import useWebexClasses from './hooks/useWebexClasses';
-import './VoicemailPlaybackControls.styles.scss';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { ScrubbingBar } from './ScrubbingBar';
+import './VoicemailItem.styles.scss';
+import './VoicemailPlaybackControls.styles.scss';
+import { useAudio } from './hooks/useAudio';
+import useWebexClasses from './hooks/useWebexClasses';
+import { formatDuration } from './utils/dateUtils';
 
 export interface IVoicemailPlaybackControlsProps {
   audioSrc: string;
@@ -44,7 +44,7 @@ export const VoicemailPlaybackControls = ({
       className={`${className} ${cssClasses}`}
     >
       {playing && audioSrc ? (
-        <ButtonCircle outline size={28} onPress={() => setPlaying(false)} data-testid="pause-button" title={t('pauseVoicemail')} aria-label={t('pauseVoicemail')}>
+        <ButtonCircle outline size={28} onPress={() => setPlaying(false)} data-testid="pause-button" title={t('pauseVoicemail')}>
           <IconNext name="pause" autoScale={150} />
         </ButtonCircle>
       ) : (
@@ -65,7 +65,7 @@ export const VoicemailPlaybackControls = ({
           </div>
           </div>)
           :
-          (<ButtonCircle outline size={28} onPress={playAudio} data-testid="play-button" title={t('playVoicemail')} aria-label={t('playVoicemail')}>
+          (<ButtonCircle outline size={28} onPress={playAudio} data-testid="play-button" title={t('playVoicemail')}>
             <IconNext name="play" autoScale={150} className={sc('play-icon')} />
           </ButtonCircle>)
 
@@ -76,7 +76,6 @@ export const VoicemailPlaybackControls = ({
         value={[curTime]}
         onChange={([value]) => setClickedTime(value)}
         step={Math.min(duration / 1000, 0.1)}
-        aria-label="voicemail scrubbing bar"
       />
       <Text data-testid="total-duration">{formatDuration(duration / 1000)}</Text>
     </Flex>

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
@@ -4,7 +4,7 @@ import {
   IconNext,
   Text,
 } from '@momentum-ui/react-collaboration';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrubbingBar } from './ScrubbingBar';
 import './VoicemailItem.styles.scss';
@@ -35,16 +35,15 @@ export const VoicemailPlaybackControls = ({
   const playAudio = () => {
     onPlay();
     setPlaying(true);
-    focusPauseButton();
   };
   const pauseButtonRef = useRef<HTMLButtonElement>(null);
   const [cssClasses, sc] = useWebexClasses('voicemail-playback-controls');
 
-  const focusPauseButton = () => {
-    setTimeout(() => {
+  useEffect(() => {
+    if (pauseButtonRef.current) {
       pauseButtonRef?.current?.focus();
-    }, 200);
-  };
+    }
+  }, [playing, audioSrcLoader, audioSrc]);
   
   return (
     <Flex
@@ -58,7 +57,6 @@ export const VoicemailPlaybackControls = ({
         size={28}
         onPress={() => {
           setPlaying(false);
-          focusPauseButton();
         }}
         data-testid="pause-button"
         title={t('pauseVoicemail')}


### PR DESCRIPTION
Description:
This PR includes changes for Windows, Mac, and web platforms.
Call History Changes:
1. Voiceover for displayed time and date of the call.
2. Voiceover for outgoing and incoming call information.
3. Instructions on how to focus on action buttons.

Voicemail Changes:
1. Voiceover for unread voicemails represented with an icon.
2. Instructions on how to focus on action buttons.
3. Media seek slider now announces the correct role and label. Previously, it had a confusing label and value 
4. focus was lost once the Play button was activated.
5. Media seek slider is missing a visible focus outline

Jira's Link
**Win** - Recent Calls: JAWS: The displayed time and date for the calls are not conveyed
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526782

**Win** - Recent Calls: JAWS: Unread voicemails represents with icon is not conveyed to SR users
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526779

**Web** - Voicemail: Screen Readers: Blue dot indicating unread message is not announced
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526745

**Mac** - Voicemail: VoiceOver: Media seek slider announces no role and confusing label and value
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526786

**Mac** - Recent Calls: VoiceOver: Outgoing/incoming call information is not announced
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526784

**Web** - Recent Calls: Screen Readers Outgoing/incoming call information is not announced
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526740

**Win** - Voicemail: Keybord Navigation: Focus is lost once Play button is activated
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526772

**Web** - Voicemail: Keyboard Navigation: Pause voicemail button is not focusable
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526741

**Mac** - Voicemail: Keyboard Navigation: Pause voicemail button is not focusable
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526787

**Win** - Recent Calls: JAWS: No visual/announced instructions on how to focus action buttons
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526780

**Mac** - Voicemail: KN: No visual/announced instructions on how to focus action buttons for list item
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526788

**Web** - Voicemail: KN: No visual or announced instructions on how to focus the action buttons for each
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526742

**Mac** - Voicemail: Keyboard Navigation: Media seek slider is missing a visible focus outline
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526785

**Win** - Voicemail: Keybord Navigation: Media seek slider has no visible focus indicator
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526771
