### PR TITLE
fix(space-widgets): fix for joining meeting using SIP destination

### DIFF
--- a/packages/node_modules/@webex/widget-space/src/container.js
+++ b/packages/node_modules/@webex/widget-space/src/container.js
@@ -11,8 +11,6 @@ import LoadingScreen from '@webex/react-component-loading-screen';
 import Timer from '@webex/react-component-timer';
 import ErrorDisplay from '@webex/react-component-error-display';
 
-import {CONSTANTS} from '@webex/plugin-meetings';
-
 import {unregisterDevice} from '../../react-redux-spark/src/actions';
 
 import ActivityMenu from './components/activity-menu';
@@ -112,7 +110,6 @@ export class SpaceWidget extends Component {
     } = props;
     const {formatMessage} = props.intl;
     let errorElement;
-    const currentConversation = conversation.getIn(['url']);
 
     if (errors.get('hasError') || conversation.getIn(['status', 'error'])) {
       let widgetError = errors.get('errors').first();
@@ -148,10 +145,7 @@ export class SpaceWidget extends Component {
       const {preferredWebexSite} = sparkInstance.meetings;
       let isMeetButtonDisabled = false;
 
-      if (sparkInstance.meetings.getMeetingByType(CONSTANTS.CONVERSATION_URL, currentConversation)) {
-        isMeetButtonDisabled = false;
-      }
-      else {
+      if (props.destinationType === 'spaceId' && currentActivity === 'meet' && activityTypes[3].name === 'meet') {
         isMeetButtonDisabled = !preferredWebexSite;
       }
 
@@ -236,7 +230,7 @@ export class SpaceWidget extends Component {
             {menuButton}
           </div>
           <div className={classNames('webex-widget-body', styles.widgetBody)}>
-            {isMeetButtonDisabled && currentActivity === 'meet' ? errorElementSpace : widgets}
+            {isMeetButtonDisabled ? errorElementSpace : widgets}
           </div>
         </div>
       );


### PR DESCRIPTION
After the change done as part of PR: https://github.com/webex/react-widgets/pull/1337, joining meetings using SIP URI stopped working.
Jira:  https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505404

This happened due to the check added for fetching the meeting info based on the conversation URL which was impacting the SIP URI cases as well for guest users. 
Fixed the check and it is working for SIP URI but not for the conversation URL