### PR TITLE
fix(speeddial):Teams Integration: Create Speeddial limited to 12 characters.

### DIFF
--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
@@ -354,7 +354,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,6}$/,
+                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,9}$/,
                     message: t('form.phone.invalid'),
                   },
                 }}
@@ -578,7 +578,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,6}$/,
+                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,9}$/,
                     message: t('form.phone.invalid'),
                   },
                 }}


### PR DESCRIPTION
Create a speed dial form previously allowed 10 to 12 characters. Now it will allow 10 to 15 characters.
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-533233](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-533233)