### PR TITLE
fix(SPARK-526771): Media seek slider focus

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -112,7 +112,7 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
-      aria-label={`${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific)}, ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
+      aria-label={`${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific ? callingSpecific + ',' : '')} ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
         <Avatar initials={chInitials} title={chTitle} size={32} />

--- a/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
@@ -58,7 +58,7 @@ const ScrubbingBarThumb = ({
     <div
       data-testid="scrubbing-bar-thumb"
       {...mergeProps(thumbProps, focusProps)}
-      className={`${className} ${isFocused ? 'md-focus-ring-wrapper' : ''}`}
+      className={`${className} ${isFocused ? 'vm-focus-ring-wrapper' : ''}`}
       style={{
         left: `calc(calc(100% - 16px) * ${state.getThumbPercent(index)})`,
       }}

--- a/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/destructuring-assignment */
 import { SliderState, SliderStateOptions, useSliderState } from 'react-stately';
 
-import React, { MutableRefObject, useRef } from 'react';
+import React, { MutableRefObject, useRef, useState } from 'react';
 import {
   VisuallyHidden,
   mergeProps,
@@ -36,6 +36,7 @@ const ScrubbingBarThumb = ({
   className = undefined,
 }: IScrubbingBarThumbProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [isFocused, setIsFocused] = useState(false);
   const { thumbProps, inputProps } = useSliderThumb(
     {
       index,
@@ -45,16 +46,25 @@ const ScrubbingBarThumb = ({
     state
   );
 
-  const { focusProps, isFocusVisible } = useFocusRing();
+  const { focusProps } = useFocusRing();
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
   return (
     <div
       data-testid="scrubbing-bar-thumb"
       {...mergeProps(thumbProps, focusProps)}
-      className={`${className} ${isFocusVisible ? 'focus' : ''}`}
+      className={`${className} ${isFocused ? 'md-focus-ring-wrapper' : ''}`}
       style={{
         left: `calc(calc(100% - 16px) * ${state.getThumbPercent(index)})`,
       }}
       tabIndex={0}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
     >
       <VisuallyHidden>
         <input ref={inputRef} {...inputProps} />


### PR DESCRIPTION
Description: **isFocusVisible** from **useFocusRing** is consistently returning false even when the thumb is focused.
Instead of relying on isFocusVisible, we can handle focus and blur by using focus state.

Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526771