### PR TITLE
fix(spark:526772): callhistory date annuouncement

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
+++ b/packages/node_modules/@webex/widget-call-history/src/CallHistoryItem.tsx
@@ -18,6 +18,7 @@ import {
 import {
   formatDate,
   formatDateDDMMYYYY,
+  formatDateForAnnouncement,
   formatDurationFromSeconds,
   formatTime,
   formatTimeToSupport24Hours
@@ -112,7 +113,7 @@ export const CallHistoryItem = ({
       className={cssClasses}
       onPress={onPress}
       data-testid="call-history-item"
-      aria-label={`${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific ? callingSpecific + ',' : '')} ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${(startTime && isLocaleGerman ? formatDateDDMMYYYY(startTime) : formatDate(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
+      aria-label={`${(name)}, ${(phoneNumber && formatPhoneNumberForAnnouncement(phoneNumber))}, ${(callingSpecific ? callingSpecific + ',' : '')} ${isOutgoing ? t('outGoingCallText') : isMissed ? t('missedCallText') : t('incomingCallText')}, ${(formatDurationForAnnouncement(durationSeconds as number))}, ${(formatDateForAnnouncement(startTime))}, ${(startTime && isLocaleGerman ? formatTimeToSupport24Hours(startTime) : formatTime(startTime))}, ${t('recentCallsFocusButton')}`}
     >
       <ListItemBaseSection position="start" className={sc('icon')}>
         <Avatar initials={chInitials} title={chTitle} size={32} />

--- a/packages/node_modules/@webex/widget-call-history/src/utils/dateUtils.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/utils/dateUtils.ts
@@ -127,3 +127,37 @@ export function formatDateDDMMYYYY(date: string) {
     year: 'numeric',
   });
 }
+
+/**
+ * @description Handle formatting the date for announce.
+ * @param {string} date The date string to format
+ * @returns {string} A announced date as in "Today", "Yesterday", or "june 10,2024"
+ */
+export const formatDateForAnnouncement = (dateValue: string) => {
+  const date = new Date(dateValue);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (isSameDate(date, today)) {
+      return "Today";
+  }
+  if (isSameDate(date, yesterday)) {
+      return "Yesterday";
+  }
+  /* If not today or yesterday, format the date normally */
+  const options: Intl.DateTimeFormatOptions = { 
+    month: 'long', 
+    day: 'numeric', 
+    year: 'numeric'
+  };
+  const userLocale = navigator.language || 'en-US'; // fallback to 'en-US' if no locale is detected
+  return date.toLocaleDateString(userLocale, options);
+}
+
+/* Function to compare if two dates are on the same day */
+export function isSameDate(date1: Date, date2: Date) {
+  return date1.getFullYear() === date2.getFullYear() &&
+         date1.getMonth() === date2.getMonth() &&
+         date1.getDate() === date2.getDate();
+}

--- a/packages/node_modules/@webex/widget-call-history/src/utils/dateUtils.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/utils/dateUtils.ts
@@ -133,31 +133,19 @@ export function formatDateDDMMYYYY(date: string) {
  * @param {string} date The date string to format
  * @returns {string} A announced date as in "Today", "Yesterday", or "june 10,2024"
  */
-export const formatDateForAnnouncement = (dateValue: string) => {
-  const date = new Date(dateValue);
-  const today = new Date();
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-
-  if (isSameDate(date, today)) {
-      return "Today";
+export const formatDateForAnnouncement = (date: string) => {
+  const dateValue = getDateTimeFromString(date);
+  
+  if (
+    dateValue.toISODate() === DateTime.now().toISODate() ||
+    dateValue.toISODate() === DateTime.now().minus({ days: 1 }).toISODate()
+  ) {
+  return dateValue.toRelativeCalendar({});
   }
-  if (isSameDate(date, yesterday)) {
-      return "Yesterday";
+  
+  return dateValue.toLocaleString({
+    month: 'long', // Use 'long' for full month name
+    day: 'numeric',
+    year: 'numeric',
+  });
   }
-  /* If not today or yesterday, format the date normally */
-  const options: Intl.DateTimeFormatOptions = { 
-    month: 'long', 
-    day: 'numeric', 
-    year: 'numeric'
-  };
-  const userLocale = navigator.language || 'en-US'; // fallback to 'en-US' if no locale is detected
-  return date.toLocaleDateString(userLocale, options);
-}
-
-/* Function to compare if two dates are on the same day */
-export function isSameDate(date1: Date, date2: Date) {
-  return date1.getFullYear() === date2.getFullYear() &&
-         date1.getMonth() === date2.getMonth() &&
-         date1.getDate() === date2.getDate();
-}

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -6,7 +6,7 @@ import {
   Text
 } from '@momentum-ui/react-collaboration';
 import { IWebexVoicemail } from '@webex/component-adapter-interfaces/dist/esm/src';
-import { formatVoiceMailTimeDurationForAnnouncement } from '@webex/widget-call-history/src/utils/voiceOver';
+import { formatPhoneNumberForAnnouncement, formatVoiceMailTimeDurationForAnnouncement } from '@webex/widget-call-history/src/utils/voiceOver';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import './VoicemailItem.styles.scss';
@@ -85,7 +85,7 @@ export const VoicemailItem = ({
       onPress={onClick}
       data-testid="voicemail-item"
       itemIndex={itemIndex}
-      aria-label={`${unread ? t('unreadVoicemail') : ''}, ${(voicemail.name)}, ${voicemail.address}, ${palyOrPause}, ${(formatVoiceMailTimeDurationForAnnouncement(voicemail.duration as number))}, ${t('voicemailScrubbingBar')}, ${formattedDate}, ${formattedTime}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${t('voicemailFocusButton')}`}
+      aria-label={`${unread ? t('unreadVoicemail') + ',' : ''} ${(voicemail.name)}, ${formatPhoneNumberForAnnouncement(voicemail.address)}, ${palyOrPause}, ${(formatVoiceMailTimeDurationForAnnouncement(voicemail.duration as number))}, ${t('voicemailScrubbingBar')}, ${formattedDate}, ${formattedTime}, ${t('audioCallLabel')}, ${t('videoCallLabel')}, ${t('deleteVoicemail')}, ${t('voicemailFocusButton')}`}
     >
       <ListItemBaseSection position="fill">
         <Avatar initials={vmInitials} title={voicemail.name} size={32} className={sc('avatar')} />


### PR DESCRIPTION
Description:
This PR contains voiceover announcements for the call history date and in the voicemail. If there is no data, a comma should not be added
Vidcast link
https://app.vidcast.io/share/ea4598fd-1090-42d8-800f-ea0b1f62c053

<img width="1728" alt="ch1" src="https://github.com/webex/react-widgets/assets/58249052/4e87c48d-a566-4033-9eec-51a709e13a2f">

<img width="1728" alt="ch2" src="https://github.com/webex/react-widgets/assets/58249052/fb33d69b-75ca-4688-830f-6d5cb5dfd3fe">



