### PR TITLE
fix(speeddial): phone number regex change

### DIFF
--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
@@ -354,7 +354,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,9}$/,
+                    value: /^\+?[\d\W]*$/,
                     message: t('form.phone.invalid'),
                   },
                 }}
@@ -578,7 +578,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^[+]?[(]?\d{3}[)]?[-\s.]?\d{3}[-\s.]?\d{4,9}$/,
+                    value: /^\+?[\d\W]*$/,
                     message: t('form.phone.invalid'),
                   },
                 }}

--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialForm.tsx
@@ -354,7 +354,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^\+?[\d\W]*$/,
+                    value: /^[^A-Za-z\s]{1,}$/,
                     message: t('form.phone.invalid'),
                   },
                 }}
@@ -578,7 +578,7 @@ export const SpeedDialForm = ({
                 rules={{
                   required: t('form.phone.required'),
                   pattern: {
-                    value: /^\+?[\d\W]*$/,
+                    value: /^[^A-Za-z\s]{1,}$/,
                     message: t('form.phone.invalid'),
                   },
                 }}


### PR DESCRIPTION
This PR is to change regex, used for validation check of phone number in speed dial add and edit.
1) Will not limit the length of numbers in the speed dial input field. There will be a minimum length of 1.
2) Allow special chars to be saved in between the numbers. (this is for example used when dialing into Webex meetings or other IVR-based systems. That interacts with DTMF tones. e.g. "," would insert 2sec pause")

[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535963](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535963)