### PR TITLE
fix(voiceover): Win - Dial Pad: JAWS: Dial pad does not announce grouping relationship

### DIFF
--- a/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
+++ b/packages/node_modules/@webex/widget-number-pad/src/NumberPad.tsx
@@ -174,10 +174,10 @@ export const NumberPad = ({
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <div role="group" aria-label={t("label.dialPad.number")} className={cssClasses} {...keyboardProps} ref={numberPadRef}>
+    <div className={cssClasses} {...keyboardProps} ref={numberPadRef}>
       {dialPadButtonTexts.map(({ value, letters }, index) => (
         <ButtonDialpad
-          aria-label={value}
+          aria-label={value === "1" ? t("label.dialPad.number") + value : value}
           key={value}
           primaryText={value}
           secondaryText={letters}


### PR DESCRIPTION
Win - Dial Pad: JAWS: Dial pad does not announce grouping relationship
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526781](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526781)

### Provided fix: 
**The group label and role, i.e. 'Dial pad, group', should be announced only when the first number in the dial pad is focused.
Ensure the rest of the dial pad numbers are announced without ‘Dial pad, group’ as e.g.: ‘[focused number], button’**