### PR TITLE
fix(voicemail): Media seek slider announces no role and voiceover

### DIFF
--- a/packages/node_modules/@webex/widget-call-history/src/utils/voiceOver.ts
+++ b/packages/node_modules/@webex/widget-call-history/src/utils/voiceOver.ts
@@ -39,3 +39,21 @@ export const formatDurationForAnnouncement = (seconds: number): string => {
       }
     return `duration ${announcement}`;
   };
+
+  export const formatSleekBarCurrTimeDurationForAnnouncement = (duration: number): string => {
+
+    const durationInSeconds = duration / 1000;
+    const hours = Math.floor(durationInSeconds / 3600);
+    const minutes = Math.floor((durationInSeconds % 3600) / 60);
+    const seconds = Math.floor(durationInSeconds % 60);
+    const milliseconds = Math.floor((duration - seconds * 1000 - minutes * 60000 - hours * 3600000));
+
+    const parts = [
+      hours > 0 ? `${hours} hour${hours !== 1 ? 's' : ''}` : '',
+      minutes > 0 ? `${minutes} minute${minutes !== 1 ? 's' : ''}` : '',
+      seconds > 0 ? `${seconds} second${seconds !== 1 ? 's' : ''}` : '',
+      milliseconds > 0 ? `${milliseconds} millisecond${milliseconds !== 1 ? 's' : ''}` : '',
+    ].filter(part => part !== '');
+
+    return parts.join(' ');
+  };

--- a/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/ScrubbingBar.tsx
@@ -13,12 +13,15 @@ import {
 } from 'react-aria';
 import './ScrubbingBar.styles.scss';
 import useWebexClasses from './hooks/useWebexClasses';
+import { formatSleekBarCurrTimeDurationForAnnouncement, formatVoiceMailTimeDurationForAnnouncement } from '@webex/widget-call-history/src/utils/voiceOver';
+import { useTranslation } from 'react-i18next';
 
 type IScrubbingBarThumbProps = {
   state: SliderState;
   index: number;
   trackRef: MutableRefObject<HTMLDivElement | null>;
   className?: string;
+  currTime?: number[];
 };
 
 /**
@@ -34,6 +37,7 @@ const ScrubbingBarThumb = ({
   trackRef,
   index,
   className = undefined,
+  currTime
 }: IScrubbingBarThumbProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isFocused, setIsFocused] = useState(false);
@@ -65,6 +69,9 @@ const ScrubbingBarThumb = ({
       tabIndex={0}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      role="slider"
+      aria-valuenow={currTime ? currTime[0] : 0}
+      aria-valuetext={currTime ? `${formatSleekBarCurrTimeDurationForAnnouncement(currTime[0] * 1000)}` : ""}
     >
       <VisuallyHidden>
         <input ref={inputRef} {...inputProps} />
@@ -76,6 +83,8 @@ const ScrubbingBarThumb = ({
 export interface IScrubbingBarProps
   extends Partial<SliderStateOptions<number[]>> {
   numberFormatOptions?: unknown;
+  duration?: number;
+  voicemailName?: string;
 }
 
 export const ScrubbingBar = ({ ...rest }: IScrubbingBarProps) => {
@@ -93,9 +102,10 @@ export const ScrubbingBar = ({ ...rest }: IScrubbingBarProps) => {
     ...rest,
   });
   const { groupProps, trackProps } = useSlider(rest, state, trackRef);
+  const { t } = useTranslation('WebexVoicemail');
 
   return (
-    <div {...groupProps} className={cssClasses} data-testid="scrubbing-bar">
+    <div {...groupProps} className={cssClasses} data-testid="scrubbing-bar" aria-label={`${t('voicemailFrom')} ${rest.voicemailName}, ${t('slider')}, 0 minute 0 second of ${rest.duration ? (formatVoiceMailTimeDurationForAnnouncement(rest.duration as number)) : '0'}`}>
       <div {...trackProps} ref={trackRef} className={sc('track')}>
         <div
           className={sc('viewed')}
@@ -106,6 +116,7 @@ export const ScrubbingBar = ({ ...rest }: IScrubbingBarProps) => {
           state={state}
           trackRef={trackRef}
           className={sc('thumb')}
+          currTime={rest.value}
         />
       </div>
     </div>

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailItem.tsx
@@ -108,6 +108,7 @@ export const VoicemailItem = ({
           audioSrc={voicemailSrc}
           audioSrcLoader={voicemailSrcLoader}
           setIsAnnouncePlayOrPause={setIsAnnouncePlayOrPause}
+          voicemailName={voicemail.name}
         />
         <div className={sc('meta')}>
           <Flex

--- a/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
+++ b/packages/node_modules/@webex/widget-voice-mail/src/VoicemailPlaybackControls.tsx
@@ -21,6 +21,7 @@ export interface IVoicemailPlaybackControlsProps {
   audioSrcLoader?: boolean;
   focusPauseButton?: () => void;
   setIsAnnouncePlayOrPause:React.Dispatch<React.SetStateAction<boolean>>;
+  voicemailName?: string;
 }
 
 export const VoicemailPlaybackControls = ({
@@ -30,6 +31,7 @@ export const VoicemailPlaybackControls = ({
   duration,
   audioSrcLoader = false,
   setIsAnnouncePlayOrPause,
+  voicemailName
 }: IVoicemailPlaybackControlsProps) => {
   const { t } = useTranslation('WebexVoicemail');
   const { curTime, playing, setPlaying, setClickedTime } =
@@ -103,6 +105,8 @@ export const VoicemailPlaybackControls = ({
         value={[curTime]}
         onChange={([value]) => setClickedTime(value)}
         step={Math.min(duration / 1000, 0.1)}
+        voicemailName={voicemailName}
+        duration={duration}
       />
       <Text data-testid="total-duration">{formatDuration(duration / 1000)}</Text>
     </Flex>


### PR DESCRIPTION
This pr consists of changes required to announce role, label and value when it is focused and when slider is moved arrow keys current time stamp will be announced.

[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526743?src=confmacro](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526743?src=confmacro)