### PR TITLE
fix(spacewidget): add focus to the attach file button

### DIFF
--- a/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/__snapshots__/index.test.js.snap
@@ -7,26 +7,54 @@ exports[`MessageComposer component snapshot tests renders properly 1`] = `
   <div
     className="webex-message-composer-buttons buttonsArea"
   >
-    <input
-      className="webex-file-input fileInput"
-      id="messageFileInput-FAKE_INPUT_ID"
-      multiple="multiple"
-      onChange={[Function]}
-      type="file"
-    />
-    <label
-      htmlFor="messageFileInput-FAKE_INPUT_ID"
+    <button
+      alt=""
+      aria-labelledby=""
+      aria-pressed={null}
+      className="md-button md-button--circle md-button--none"
+      data-md-event-key="md-button-1"
+      disabled={false}
+      id="md-button-1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "style": Object {},
+        }
+      }
+      tabIndex={0}
+      type="button"
     >
-      <i
-        aria-label="Attach Files"
-        className="md-icon icon icon-attachment_16"
+      <span
+        className="md-button__children"
         style={
           Object {
-            "fontSize": 16,
+            "opacity": "1",
           }
         }
-      />
-    </label>
+      >
+        <input
+          className="webex-file-input fileInput"
+          id="messageFileInput-FAKE_INPUT_ID"
+          multiple="multiple"
+          onChange={[Function]}
+          type="file"
+        />
+        <label
+          htmlFor="messageFileInput-FAKE_INPUT_ID"
+        >
+          <i
+            aria-label="Attach Files"
+            className="md-icon icon icon-attachment_16"
+            style={
+              Object {
+                "fontSize": 16,
+              }
+            }
+          />
+        </label>
+      </span>
+    </button>
   </div>
   <div
     className="webex-textarea-container textAreaContainer"
@@ -103,26 +131,54 @@ exports[`MessageComposer component snapshot tests renders submit button 1`] = `
   <div
     className="webex-message-composer-buttons buttonsArea"
   >
-    <input
-      className="webex-file-input fileInput"
-      id="messageFileInput-FAKE_INPUT_ID"
-      multiple="multiple"
-      onChange={[Function]}
-      type="file"
-    />
-    <label
-      htmlFor="messageFileInput-FAKE_INPUT_ID"
+    <button
+      alt=""
+      aria-labelledby=""
+      aria-pressed={null}
+      className="md-button md-button--circle md-button--none"
+      data-md-event-key="md-button-2"
+      disabled={false}
+      id="md-button-2"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "style": Object {},
+        }
+      }
+      tabIndex={0}
+      type="button"
     >
-      <i
-        aria-label="Attach Files"
-        className="md-icon icon icon-attachment_16"
+      <span
+        className="md-button__children"
         style={
           Object {
-            "fontSize": 16,
+            "opacity": "1",
           }
         }
-      />
-    </label>
+      >
+        <input
+          className="webex-file-input fileInput"
+          id="messageFileInput-FAKE_INPUT_ID"
+          multiple="multiple"
+          onChange={[Function]}
+          type="file"
+        />
+        <label
+          htmlFor="messageFileInput-FAKE_INPUT_ID"
+        >
+          <i
+            aria-label="Attach Files"
+            className="md-icon icon icon-attachment_16"
+            style={
+              Object {
+                "fontSize": 16,
+              }
+            }
+          />
+        </label>
+      </span>
+    </button>
   </div>
   <div
     className="webex-textarea-container textAreaContainer"

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/ComposerButtons.js
@@ -4,30 +4,43 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import uuid from 'uuid';
 
-import {Icon} from '@momentum-ui/react';
+import {Button, Icon} from '@momentum-ui/react';
 
 import styles from './ComposerButtons.css';
 
 function ComposerButtons({onAttachFile, composerActions}) {
   const inputId = `messageFileInput-${uuid.v4()}`;
+  const fileRef = React.createRef();
+
+  function handleClick() {
+    fileRef.current?.click();
+  }
 
   return (
     (
       composerActions.attachFiles &&
       <div className={classNames('webex-message-composer-buttons', styles.buttonsArea)}>
-        <input
-          className={classNames('webex-file-input', styles.fileInput)}
-          id={inputId}
-          multiple="multiple"
-          onChange={onAttachFile}
-          type="file"
-        />
-        <label htmlFor={inputId}>
-          <Icon
-            ariaLabel="Attach Files"
-            name="attachment_16"
+        <Button
+          circle
+          onClick={handleClick}
+          size={32}
+          removeStyle
+        >
+          <input
+            ref={fileRef}
+            className={classNames('webex-file-input', styles.fileInput)}
+            id={inputId}
+            multiple="multiple"
+            onChange={onAttachFile}
+            type="file"
           />
-        </label>
+          <label htmlFor={inputId}>
+            <Icon
+              ariaLabel="Attach Files"
+              name="attachment_16"
+            />
+          </label>
+        </Button>
       </div>
     ) || null
   );

--- a/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
+++ b/packages/node_modules/@webex/react-container-message-composer/src/components/__snapshots__/ComposerButtons.test.js.snap
@@ -4,34 +4,41 @@ exports[`ComposerButtons component renders properly with attachFiles enabled 1`]
 <div
   className="webex-message-composer-buttons buttonsArea"
 >
-  <input
-    className="webex-file-input fileInput"
-    id="messageFileInput-FAKE_INPUT_ID"
-    multiple="multiple"
-    onChange={[Function]}
-    type="file"
-  />
-  <label
-    htmlFor="messageFileInput-FAKE_INPUT_ID"
+  <ForwardRef(render)
+    circle={true}
+    onClick={[Function]}
+    removeStyle={true}
+    size={32}
   >
-    <Icon
-      append={false}
-      ariaLabel="Attach Files"
-      buttonClassName=""
-      buttonProps={null}
-      className=""
-      color=""
-      description=""
-      name="attachment_16"
-      onClick={null}
-      prepend={false}
-      size={null}
-      sizeOverride={false}
-      style={null}
-      title=""
-      type=""
+    <input
+      className="webex-file-input fileInput"
+      id="messageFileInput-FAKE_INPUT_ID"
+      multiple="multiple"
+      onChange={[Function]}
+      type="file"
     />
-  </label>
+    <label
+      htmlFor="messageFileInput-FAKE_INPUT_ID"
+    >
+      <Icon
+        append={false}
+        ariaLabel="Attach Files"
+        buttonClassName=""
+        buttonProps={null}
+        className=""
+        color=""
+        description=""
+        name="attachment_16"
+        onClick={null}
+        prepend={false}
+        size={null}
+        sizeOverride={false}
+        style={null}
+        title=""
+        type=""
+      />
+    </label>
+  </ForwardRef(render)>
 </div>
 `;
 


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-539198 

Problem: The Choose a file button in the chat panel doesn't visually appear, focusable using the Tab key, and selectable using the Enter key to choose a file so the user cannot identify the functionality of the control.

Fix: Added the Button element to bring the keyboard focus for the input element used to attach files.

<img width="507" alt="Screenshot 2024-08-02 at 9 59 29 PM" src="https://github.com/user-attachments/assets/4bf3d044-749c-48ad-8aac-d543a07e7b24">