### PR TITLE
SPARK-526800 - KB: No instructions on how to reorder the speed dial list

### DIFF
--- a/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
+++ b/packages/node_modules/@webex/widget-speed-dial/src/SpeedDialItem.tsx
@@ -85,6 +85,7 @@ export const SpeedDialItem = forwardRef(({
   const [isSubMenuVisible, setSubMenuVisible] = useState(false);
   const [isContextMenuVisible, setIsContextMenuVisible] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);
+  const dragandDropActionRef = useRef<HTMLDivElement>(null);
 
   useImperativeHandle(ref, () => ({
     handleEnterKey: (e) => {
@@ -149,6 +150,12 @@ export const SpeedDialItem = forwardRef(({
         p.style.marginTop = "1.875rem";
         p.style.color = "var(--mds-color-theme-text-accent-normal)";
       }
+      if (dragandDropActionRef.current) {
+        const svgElement: HTMLDivElement = dragandDropActionRef.current.querySelector('svg');
+        if (svgElement) {
+          svgElement.style.visibility = 'visible';
+        }
+      }
     },
     removeHoverEffect: () => {
       let avatar: HTMLDivElement = actionsRef.current?.childNodes[0];
@@ -166,6 +173,13 @@ export const SpeedDialItem = forwardRef(({
         let p: HTMLParagraphElement = svg?.childNodes[0];
         p.style.marginTop = "";
         p.style.color = "";
+      }
+      if (dragandDropActionRef.current) {
+        const svgElement: HTMLDivElement = dragandDropActionRef.current.querySelector('svg');
+        if (svgElement) {
+          svgElement.style.visibility = '';
+          svgElement.style.color = ""
+        }
       }
     }
   }));
@@ -279,7 +293,7 @@ export const SpeedDialItem = forwardRef(({
                 role="button"
               >
                 {children && (
-                  <div className={sc('drag-handle')}>
+                  <div className={sc('drag-handle')} ref={dragandDropActionRef}>
                     <span className={sc('drag-icon')}>{children}</span>
                   </div>
                 )}


### PR DESCRIPTION
Description: Showing the draggable icon (the icon with 6 dots) on focus as it is done on hover, so the KB user is aware that the items can be rearranged.

<img width="418" alt="Screenshot 2024-08-05 at 10 39 17 AM" src="https://github.com/user-attachments/assets/8d518077-a5bc-4529-ab95-bcf39cfc84b7">

<img width="396" alt="Screenshot 2024-08-05 at 10 40 08 AM" src="https://github.com/user-attachments/assets/321f686b-deaf-44ed-8c76-adb42e9cf1da">

