### PR TITLE
Fixed Chat Color Contrast: Light grey file size text fails contrast

### DIFF
--- a/packages/node_modules/@webex/react-component-chip-file/src/styles.css
+++ b/packages/node_modules/@webex/react-component-chip-file/src/styles.css
@@ -28,6 +28,7 @@
 .size {
   display: inline-block;
   margin-right: 10px;
+  color: #757575;
 }
 
 .icon {

--- a/packages/node_modules/@webex/react-component-confirmation-modal/src/styles.css
+++ b/packages/node_modules/@webex/react-component-confirmation-modal/src/styles.css
@@ -126,7 +126,7 @@
 
 .dialogueModalActionBtn {
   font-family: CiscoSans, 'Helvetica Neue', Arial;
-  color: #049fd9;
+  color: #037EAB;
 }
 
 .dialogueModalActionBtn:hover,

--- a/packages/node_modules/@webex/react-component-confirmation-modal/src/styles.css
+++ b/packages/node_modules/@webex/react-component-confirmation-modal/src/styles.css
@@ -132,7 +132,7 @@
 .dialogueModalActionBtn:hover,
 .dialogueModalActionBtn:active {
   color: #fefefe;
-  background-color: #049fd9;
+  background-color: #037EAB;
 }
 
 .dialogueModalActionBtnRed {

--- a/packages/node_modules/@webex/react-container-message-composer/src/mentions.css
+++ b/packages/node_modules/@webex/react-container-message-composer/src/mentions.css
@@ -58,7 +58,7 @@
 
 .mentions--multiLine .mentions__input::placeholder {
   overflow: hidden;
-  color: #858688;
+  color: #6D6D6F;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
### Problem
* Currently in the react messages widget, the file upload thumbnail subtitle was failing the colour contrast test.
* The colour was too light and not dark enough.

### Fix
* Code has been added to modify the CSS class colour of that subtitle to the required one (as given by Applause)
* **Currently could not really write tests for this. Hence marking PR as a draft**

### JIRA ISSUES
[SPARK-549502](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-549502)
[SPARK-550132](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550132)
[SPARK-550133](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550133)

### Screenshots
Original             	   |  Fixed
:-------------------------:|:-------------------------:
**<img width="499" alt="Screenshot 2024-08-08 at 11 37 02 AM" src="https://github.com/user-attachments/assets/acf87bce-5016-43d2-b402-a3c5be2ea82e">**  |  **<img width="499" alt="Screenshot 2024-08-08 at 11 37 57 AM" src="https://github.com/user-attachments/assets/93ac9e71-fbb1-4eac-ac97-39e143f5c58e">**

Original             	   |  Fixed
:-------------------------:|:-------------------------:
**<img width="499" alt="Screenshot 2024-08-08 at 5 21 48 PM" src="https://github.com/user-attachments/assets/f34209ed-9c8c-4f1e-8a6d-7a6d52717e8a">**  |  **<img width="499" alt="Screenshot 2024-08-08 at 5 46 31 PM" src="https://github.com/user-attachments/assets/e125fdff-160b-45ff-8f7a-97680b996667">**


Original             	   |  Fixed
:-------------------------:|:-------------------------:
**<img width="499" alt="Screenshot 2024-08-08 at 5 10 36 PM" src="https://github.com/user-attachments/assets/7627e604-e10e-4f9b-927e-9b6c72414c15">**  |  **<img width="499" alt="Screenshot 2024-08-08 at 5 11 51 PM" src="https://github.com/user-attachments/assets/d3e2233d-a0c6-4058-b313-25dcc79dc76d">**

Original             	   |  Fixed
:-------------------------:|:-------------------------:
**<img width="499" alt="Screenshot 2024-08-09 at 10 39 15 AM" src="https://github.com/user-attachments/assets/e73ae8d5-1290-4bca-8af6-98c46c957da3">**  |  **<img width="499" alt="Screenshot 2024-08-09 at 10 38 10 AM" src="https://github.com/user-attachments/assets/86bd85ae-b618-417b-b795-f41b722ed8be">**

