### PR TITLE
fix(ActivityShare): accessibility for download buttons

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-share-file/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-activity-share-file/src/__snapshots__/index.test.js.snap
@@ -57,7 +57,7 @@ exports[`ActivityShareFile component renders properly 1`] = `
       className="webex-share-action-item shareActionItem"
     >
       <ForwardRef(render)
-        ariaLabel="Download"
+        ariaLabel="Download testImage.js"
         circle={true}
         onClick={[Function]}
         size={32}

--- a/packages/node_modules/@webex/react-component-activity-share-file/src/index.js
+++ b/packages/node_modules/@webex/react-component-activity-share-file/src/index.js
@@ -59,7 +59,7 @@ function ActivityShareFile(props) {
         <div className={classNames('webex-share-item-actions', styles.shareActions)}>
           <div className={classNames('webex-share-action-item', styles.shareActionItem)}>
             <Button
-              ariaLabel="Download"
+              ariaLabel={`Download ${displayName}`}
               style={{backgroundColor: 'black'}}
               circle
               onClick={handleDownloadClick}

--- a/packages/node_modules/@webex/react-component-activity-share-files/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-share-files/src/styles.css
@@ -6,3 +6,7 @@
 .shareList {
   width: 320px;
 }
+
+.shareList div[class="md-content__hover"]{
+  visibility: visible;
+}

--- a/packages/node_modules/@webex/react-component-activity-share-thumbnail/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-activity-share-thumbnail/src/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ exports[`ActivityShareThumbnail post component renders loaded thumbnail properly
       actionNode={
         <div>
           <ForwardRef(render)
-            ariaLabel="Download"
+            ariaLabel="Download testImage.js"
             circle={true}
             onClick={[Function]}
             size={32}
@@ -73,7 +73,7 @@ exports[`ActivityShareThumbnail post component renders loading state properly 1`
       actionNode={
         <div>
           <ForwardRef(render)
-            ariaLabel="Download"
+            ariaLabel="Download testImage.js"
             circle={true}
             onClick={[Function]}
             size={32}
@@ -165,7 +165,7 @@ exports[`ActivityShareThumbnail post component renders thumbnail properly 1`] = 
       actionNode={
         <div>
           <ForwardRef(render)
-            ariaLabel="Download"
+            ariaLabel="Download testImage.js"
             circle={true}
             onClick={[Function]}
             size={32}

--- a/packages/node_modules/@webex/react-component-activity-share-thumbnail/src/index.js
+++ b/packages/node_modules/@webex/react-component-activity-share-thumbnail/src/index.js
@@ -61,7 +61,7 @@ function ActivityShareThumbnail(props) {
   const actionNode = (
     <div>
       <Button
-        ariaLabel="Download"
+        ariaLabel={`Download ${displayName}`}
         style={{backgroundColor: 'black'}}
         circle
         onClick={handleDownloadClick}


### PR DESCRIPTION
## Closes [SPARK-550176](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550176)

### This pull request addresses
This PR addresses the issue of download buttons not being accessible. The download buttons can be accessed through `Shift + Tab` but the image files' Download button was not accessible.

### by making the following changes
- To fix it, we have disabled the `hover` ability of the Image component rather show the file name and downlaod button by default. This makes the download button present to be accessible by doing `Shift + Tab`
- Additionally, I've added the file names along with the download button's aria-label so that it doesn't simply read Download but rather what to download.

### Screen recording

https://github.com/user-attachments/assets/bcbca58d-c9a1-4d6b-8142-36254226edba


