### PR TITLE
React Widgets: Fixed message action buttons not showing on hover and key order

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-item-base/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/__snapshots__/index.test.js.snap
@@ -48,6 +48,7 @@ exports[`ActivityItemBase component renders properly 1`] = `
     >
       <Icon
         append={false}
+        aria-pressed={false}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}
@@ -123,6 +124,7 @@ exports[`ActivityItemBase component renders properly when additional 1`] = `
     >
       <Icon
         append={false}
+        aria-pressed={false}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}
@@ -198,6 +200,7 @@ exports[`ActivityItemBase component renders properly when flagged 1`] = `
     >
       <Icon
         append={false}
+        aria-pressed={true}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}
@@ -273,6 +276,7 @@ exports[`ActivityItemBase component renders properly when flagged pending 1`] = 
     >
       <Icon
         append={false}
+        aria-pressed={true}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}
@@ -394,6 +398,7 @@ exports[`ActivityItemBase component renders properly when self 1`] = `
     >
       <Icon
         append={false}
+        aria-pressed={false}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}
@@ -493,6 +498,7 @@ exports[`ActivityItemBase component renders properly with error 1`] = `
     >
       <Icon
         append={false}
+        aria-pressed={false}
         ariaLabel="Flag for follow-up"
         buttonClassName=""
         buttonProps={null}

--- a/packages/node_modules/@webex/react-component-activity-item-base/src/index.js
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/index.js
@@ -95,6 +95,7 @@ function ActivityItemBase({
           color="black-100"
           name={isFlagged ? 'flag-active_16' : 'flag_16'}
           onClick={handleOnFlag}
+          aria-pressed={isFlagged}
         />
       </div>
     );

--- a/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
@@ -130,7 +130,3 @@
 .activityItem:focus-within .activityPostActions {
   visibility: visible;
 }
-
-.visually-hidden {
-  visibility: hidden;
-}

--- a/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-item-base/src/styles.css
@@ -126,6 +126,11 @@
   visibility: visible;
 }
 
-.activityItem:hover .activityPostActions {
+.activityItem:hover .activityPostActions,
+.activityItem:focus-within .activityPostActions {
   visibility: visible;
+}
+
+.visually-hidden {
+  visibility: hidden;
 }

--- a/packages/node_modules/@webex/react-component-confirmation-modal/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-confirmation-modal/src/__snapshots__/index.test.js.snap
@@ -3,7 +3,10 @@
 exports[`ConfirmationModal component renders properly 1`] = `
 <div>
   <div
+    aria-modal="true"
     className="webex-dialogue-modal dialogueModal"
+    role="dialog"
+    tabIndex="-1"
   >
     <div
       className="webex-dialogue-modal-body dialogModalBody"

--- a/packages/node_modules/@webex/react-component-confirmation-modal/src/index.js
+++ b/packages/node_modules/@webex/react-component-confirmation-modal/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -30,6 +30,14 @@ function ConfirmationModal({
 }) {
   const modalClassNames = classNames('webex-dialogue-modal', styles.dialogueModal);
 
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, []);
+
   const actionBtnClassNames = classNames(
     'dialogue-modal-btn',
     'dialogue-modal-action-btn',
@@ -46,7 +54,13 @@ function ConfirmationModal({
 
   return (
     <div>
-      <div className={modalClassNames}>
+      <div
+        ref={modalRef}
+        tabIndex="-1"
+        role="dialog"
+        aria-modal="true"
+        className={modalClassNames}
+      >
         <div className={classNames('webex-dialogue-modal-body', styles.dialogModalBody)}>
           <div className={classNames('webex-dialogue-modal-title-text', styles.dialogueModalTitleText)}>
             {title}

--- a/packages/node_modules/@webex/react-component-confirmation-modal/src/index.test.js
+++ b/packages/node_modules/@webex/react-component-confirmation-modal/src/index.test.js
@@ -26,5 +26,6 @@ describe('ConfirmationModal component', () => {
 
   it('renders properly', () => {
     expect(component).toMatchSnapshot();
+    expect(component.toHaveFocus);
   });
 });

--- a/packages/node_modules/@webex/react-container-activity-list/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-activity-list/src/__snapshots__/index.test.js.snap
@@ -79,7 +79,7 @@ exports[`ActivityList renders properly 1`] = `
           <button
             alt="Flag for follow-up"
             aria-label="Flag for follow-up"
-            aria-pressed={null}
+            aria-pressed={false}
             className="md-button md-button--36 md-button--icon"
             data-md-event-key="md-button-1"
             disabled={false}
@@ -242,7 +242,7 @@ exports[`ActivityList renders properly 1`] = `
           <button
             alt="Flag for follow-up"
             aria-label="Flag for follow-up"
-            aria-pressed={null}
+            aria-pressed={true}
             className="md-button md-button--36 md-button--icon"
             data-md-event-key="md-button-3"
             disabled={false}
@@ -370,7 +370,7 @@ exports[`ActivityList renders threads properly 1`] = `
           <button
             alt="Flag for follow-up"
             aria-label="Flag for follow-up"
-            aria-pressed={null}
+            aria-pressed={false}
             className="md-button md-button--36 md-button--icon"
             data-md-event-key="md-button-4"
             disabled={false}
@@ -533,7 +533,7 @@ exports[`ActivityList renders threads properly 1`] = `
           <button
             alt="Flag for follow-up"
             aria-label="Flag for follow-up"
-            aria-pressed={null}
+            aria-pressed={true}
             className="md-button md-button--36 md-button--icon"
             data-md-event-key="md-button-6"
             disabled={false}
@@ -646,7 +646,7 @@ exports[`ActivityList renders threads properly 1`] = `
           <button
             alt="Flag for follow-up"
             aria-label="Flag for follow-up"
-            aria-pressed={null}
+            aria-pressed={false}
             className="md-button md-button--36 md-button--icon"
             data-md-event-key="md-button-7"
             disabled={false}


### PR DESCRIPTION
# Problem
* Currently, in the react widgets when we have focus on the messages it does not show the action items and only shows them on hover.
* This is an issue for users on mobile and desktop as they cannot access these items nor do they have instructions to observe them.
* When we click on 'delete', the dialog window was also not keyboard focusable.

# Fix
* Code has been added so that the buttons are now visible and focusable when the message gets focus.
* The navigation is as expected in desktop and should be in mobile browsers as well (currently testing this). This clears the Applause requirements.
* The dialog window is now keyboard focusable.

## JIRA
[SPARK-549503](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-549503)
[SPARK-550134](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550134)

## GIFS
### Showing the buttons visible and focusable
![button-visible](https://github.com/user-attachments/assets/9d99172d-944e-4337-b780-a7f00a22a975)

### Showing dialog window focusable
![dialog-alert](https://github.com/user-attachments/assets/6a5d2bf4-8319-4d63-a757-eb4e490ee215)

## Screenshots
### Accessibility Label for 'Delete'
<img width="1496" alt="Screenshot 2024-08-14 at 11 12 51 AM" src="https://github.com/user-attachments/assets/fbe2254f-b4b8-4b91-a099-fb9ea60abd81">


### Accessibility Label for 'Flag'
<img width="1496" alt="Screenshot 2024-08-14 at 11 12 40 AM" src="https://github.com/user-attachments/assets/80e934fe-97ed-42e3-9176-ffbe219bf890">

### Accessibility Label for 'Selected Flag'
<img width="1496" alt="Screenshot 2024-08-14 at 3 58 23 PM" src="https://github.com/user-attachments/assets/d9cdffde-50e9-41e5-b26f-8302a3ad8717">
