### PR TITLE
fix(spacewidget): updated color contrast of avatar component

### DIFF
--- a/packages/node_modules/@webex/react-component-presence-avatar/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-presence-avatar/src/__snapshots__/index.test.js.snap
@@ -3,10 +3,10 @@
 exports[`Avatar component when avatar is a self type renders with active presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}
@@ -26,10 +26,10 @@ exports[`Avatar component when avatar is a self type renders with active presenc
 exports[`Avatar component when avatar is a self type renders with ooo presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}
@@ -49,10 +49,10 @@ exports[`Avatar component when avatar is a self type renders with ooo presence 1
 exports[`Avatar component when avatar is a self type renders without presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}
@@ -72,10 +72,10 @@ exports[`Avatar component when avatar is a self type renders without presence 1`
 exports[`Avatar component when avatar is not a self type renders with active presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}
@@ -95,10 +95,10 @@ exports[`Avatar component when avatar is not a self type renders with active pre
 exports[`Avatar component when avatar is not a self type renders with ooo presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}
@@ -118,10 +118,10 @@ exports[`Avatar component when avatar is not a self type renders with ooo presen
 exports[`Avatar component when avatar is not a self type renders without presence 1`] = `
 <Avatar
   alt=""
-  backgroundColor=""
+  backgroundColor="grey"
   buttonClassName=""
   className={null}
-  color=""
+  color="white"
   failureBadge={false}
   hasNotification={false}
   hideDefaultTooltip={false}

--- a/packages/node_modules/@webex/react-component-presence-avatar/src/index.js
+++ b/packages/node_modules/@webex/react-component-presence-avatar/src/index.js
@@ -49,6 +49,8 @@ function PresenceAvatar(props) {
     presenceStatus
   } = props;
   let type = '';
+  const color = 'white';
+  const backgroundColor = 'grey';
 
   // Do not show presence on self avatars
   if (!isSelfAvatar) {
@@ -86,6 +88,8 @@ function PresenceAvatar(props) {
       type={type}
       src={image}
       size={size}
+      color={color}
+      backgroundColor={backgroundColor}
     />
   );
 }

--- a/packages/node_modules/@webex/react-container-activity-list/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-container-activity-list/src/__snapshots__/index.test.js.snap
@@ -21,8 +21,8 @@ exports[`ActivityList renders properly 1`] = `
             className="md-avatar__self"
             style={
               Object {
-                "backgroundColor": "",
-                "color": "",
+                "backgroundColor": "grey",
+                "color": "white",
               }
             }
           >
@@ -192,8 +192,8 @@ exports[`ActivityList renders properly 1`] = `
             className="md-avatar__letter"
             style={
               Object {
-                "backgroundColor": "",
-                "color": "",
+                "backgroundColor": "grey",
+                "color": "white",
               }
             }
           >
@@ -312,8 +312,8 @@ exports[`ActivityList renders threads properly 1`] = `
             className="md-avatar__self"
             style={
               Object {
-                "backgroundColor": "",
-                "color": "",
+                "backgroundColor": "grey",
+                "color": "white",
               }
             }
           >
@@ -483,8 +483,8 @@ exports[`ActivityList renders threads properly 1`] = `
             className="md-avatar__letter"
             style={
               Object {
-                "backgroundColor": "",
-                "color": "",
+                "backgroundColor": "grey",
+                "color": "white",
               }
             }
           >
@@ -596,8 +596,8 @@ exports[`ActivityList renders threads properly 1`] = `
             className="md-avatar__letter"
             style={
               Object {
-                "backgroundColor": "",
-                "color": "",
+                "backgroundColor": "grey",
+                "color": "white",
               }
             }
           >


### PR DESCRIPTION
Problem

Currently, in the react widgets when the message seen by a person who dont have profile pic then we show avatar with light grey and black letters which is not as per accessibility standards.

Fix

configured Avatar so that the Avatar is dark grey and letters are white color

JIRA

[[SPARK-549500](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-549500)


![Screenshot 2024-08-17 at 2 20 25 PM](https://github.com/user-attachments/assets/25e2b67b-1a88-4845-8171-16bec2f8614a)
