### PR TITLE
Fixed transparency issue in react widgets

### DIFF
--- a/packages/node_modules/@webex/react-container-message-composer/src/mentions.css
+++ b/packages/node_modules/@webex/react-container-message-composer/src/mentions.css
@@ -61,6 +61,7 @@
   color: #6D6D6F;
   text-overflow: ellipsis;
   white-space: nowrap;
+  opacity: 1;
 }
 
 .mentions .mentions__suggestions {


### PR DESCRIPTION
### Issue
* Currently, we had fixed an earlier issue regarding text colour for the message placeholder text as per - [SPARK-550132](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550132).
* However, the contrast test was still failing due to the transparency of the text.
* Added CSS to remove the text transparency.


###JIRA
[SPARK-550132](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-550132)


### Screenshots
Original             	   |  Fixed
:-------------------------:|:-------------------------:
**<img width="421" alt="Screenshot 2024-08-30 at 9 34 40 AM" src="https://github.com/user-attachments/assets/9ccef6e2-108c-4e90-982a-f378b967c6f2">**  |  **<img width="421" alt="Screenshot 2024-08-30 at 9 35 09 AM" src="https://github.com/user-attachments/assets/43cd2e13-3084-4048-8dd4-07fba1dadffe">**