### PR TITLE
fix(space-widget): links in messages should open in new tab

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-text/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-activity-text/src/__snapshots__/index.test.js.snap
@@ -12,12 +12,48 @@ exports[`ActivityText component renders clean dangerous text properly 1`] = `
 />
 `;
 
+exports[`ActivityText component renders clean email links properly 1`] = `
+<a
+  className="webex-activity-text activityText"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<a href=\\"mailto:someone@example.com\\">someone@example.com</a>",
+    }
+  }
+  tabIndex={0}
+/>
+`;
+
 exports[`ActivityText component renders clean links properly 1`] = `
 <a
   className="webex-activity-text activityText"
   dangerouslySetInnerHTML={
     Object {
       "__html": "<a target=\\"_blank\\" href=\\"https://example.com\\">Test Text</a>",
+    }
+  }
+  tabIndex={0}
+/>
+`;
+
+exports[`ActivityText component renders clean links with target _blank properly 1`] = `
+<a
+  className="webex-activity-text activityText"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<a href=\\"https://example.com\\" target=\\"_blank\\">Test Text</a>",
+    }
+  }
+  tabIndex={0}
+/>
+`;
+
+exports[`ActivityText component renders clean tel links properly 1`] = `
+<a
+  className="webex-activity-text activityText"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<a href=\\"tel://+1234567890\\">Call me</a>",
     }
   }
   tabIndex={0}

--- a/packages/node_modules/@webex/react-component-activity-text/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@webex/react-component-activity-text/src/__snapshots__/index.test.js.snap
@@ -12,6 +12,18 @@ exports[`ActivityText component renders clean dangerous text properly 1`] = `
 />
 `;
 
+exports[`ActivityText component renders clean links properly 1`] = `
+<a
+  className="webex-activity-text activityText"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<a target=\\"_blank\\" href=\\"https://example.com\\">Test Text</a>",
+    }
+  }
+  tabIndex={0}
+/>
+`;
+
 exports[`ActivityText component renders clean text properly 1`] = `
 <a
   className="webex-activity-text activityText"

--- a/packages/node_modules/@webex/react-component-activity-text/src/index.js
+++ b/packages/node_modules/@webex/react-component-activity-text/src/index.js
@@ -28,6 +28,8 @@ function ActivityText({content, displayName, renderedComponent}) {
 
   if (content) {
     const htmlContent = {__html: content || displayName};
+    // regex to add target="_blank" to all anchor tags that don't have target="_blank", href="mailto:", or href="tel:"
+    htmlContent.__html = htmlContent.__html.replace(/<a(?![^>]*target="_blank"|\s*href\s*=\s*["'](?:mailto:|tel:))([^>]*)>/gi, '<a target="_blank"$1>');
 
     return (
       <a

--- a/packages/node_modules/@webex/react-component-activity-text/src/index.test.js
+++ b/packages/node_modules/@webex/react-component-activity-text/src/index.test.js
@@ -6,6 +6,7 @@ import ActivityText from '.';
 describe('ActivityText component', () => {
   const displayName = 'Test Text';
   const cleanContent = '<em>Test Text</em>';
+  const cleanLink = '<a href="https://example.com">Test Text</a>';
   const dirtyContent = '<script>alert(\'dirtyContent\')</script>';
 
   it('renders clean text properly', () => {
@@ -16,6 +17,12 @@ describe('ActivityText component', () => {
 
   it('renders clean dangerous text properly', () => {
     const component = renderer.create(<ActivityText content={cleanContent} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders clean links properly', () => {
+    const component = renderer.create(<ActivityText content={cleanLink} />);
 
     expect(component).toMatchSnapshot();
   });

--- a/packages/node_modules/@webex/react-component-activity-text/src/index.test.js
+++ b/packages/node_modules/@webex/react-component-activity-text/src/index.test.js
@@ -7,6 +7,9 @@ describe('ActivityText component', () => {
   const displayName = 'Test Text';
   const cleanContent = '<em>Test Text</em>';
   const cleanLink = '<a href="https://example.com">Test Text</a>';
+  const cleanLinkWithTargetBlank = '<a href="https://example.com" target="_blank">Test Text</a>';
+  const cleanEmailLink = '<a href="mailto:someone@example.com">someone@example.com</a>';
+  const cleanTelLink = '<a href="tel://+1234567890">Call me</a>';
   const dirtyContent = '<script>alert(\'dirtyContent\')</script>';
 
   it('renders clean text properly', () => {
@@ -23,6 +26,24 @@ describe('ActivityText component', () => {
 
   it('renders clean links properly', () => {
     const component = renderer.create(<ActivityText content={cleanLink} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders clean links with target _blank properly', () => {
+    const component = renderer.create(<ActivityText content={cleanLinkWithTargetBlank} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders clean email links properly', () => {
+    const component = renderer.create(<ActivityText content={cleanEmailLink} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders clean tel links properly', () => {
+    const component = renderer.create(<ActivityText content={cleanTelLink} />);
 
     expect(component).toMatchSnapshot();
   });

--- a/packages/node_modules/@webex/react-container-activity-list/src/formatters/at-mention.js
+++ b/packages/node_modules/@webex/react-container-activity-list/src/formatters/at-mention.js
@@ -53,7 +53,7 @@ function AtMentionComponent({
       className={classNames(styles.atMention)}
       // eslint-disable-reason content is generated from elsewhere in the app
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{__html: content}}
+      dangerouslySetInnerHTML={{__html: content.replace(/<a(?![^>]*target="_blank"|\s*href\s*=\s*["'](?:mailto:|tel:))([^>]*)>/gi, '<a target="_blank"$1>')}}
       onClick={handleClick}
       onKeyUp={handleKeyUp}
       role="presentation"


### PR DESCRIPTION
**Problem:**
When the space widget is loaded inside of an iframe, the links in the messages when clicked are restricted from being loaded.

**Solution:**
Add target="_blank" attribute to open these links in a new tab

JIRA: SPARK-556112
