### PR TITLE
fix(tooling): checkout-in-github-actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -84,6 +88,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -114,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -169,6 +177,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
### Fixes Adhoc

### Issue
In GitHub actions we weren't checking out to the respective PR's commits. The pipeline was running on the base branch.
This was happening because we wernt checking out the code correctly

### Fix
Added the 'with' tag in checkout steps in github actions

### Testing
- Create a dummy branch (base node-upgrade) and made the same changes on that branch- 
- Raised a PR against that branch and confirmed the github actions whether we are checking out the correct commit or not.


Dummy branch -https://github.com/webex/react-widgets/tree/test-github-actions
Dummy PR - https://github.com/webex/react-widgets/pull/1447 ( This PR has all the change from yarn workspace PR also)
Github actions for the above PR https://github.com/webex/react-widgets/actions/runs/11551753036
<img width="1096" alt="Screenshot 2024-10-28 at 3 49 07 PM" src="https://github.com/user-attachments/assets/7ad08599-c575-47db-b8c7-ecd0f7a4d46f">
