### PR TITLE
fix(fcc): fix focusing unnecessary elements inside Content tab.

### DIFF
--- a/packages/node_modules/@webex/react-component-activity-share-files/src/styles.css
+++ b/packages/node_modules/@webex/react-component-activity-share-files/src/styles.css
@@ -67,5 +67,5 @@
 }
 
 .shareList div[class="md-content__hover"]{
-  visibility: visible;
+  visibility: inherit;
 }


### PR DESCRIPTION
Problem: In the 'Content' tab, many elements such as the 'Download', 'Remove', and 'Flag' buttons are focusable with the keyboard and screen reader which are not related to the 'Content' tab as they belong to the 'Message' tab.

JIRA: [SPARK-564416](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564416)

Solution: I have fixed this issue by changing the visibility of the class="md-content__hover" to inherit, previously we are using visible value for the visibility CSS property, due to this elements from the Message tab is visible inside the Content and People tab.

Vidcast: https://app.vidcast.io/share/aa1703c9-66ce-407b-84f5-d882605ae3d3
