### PR TITLE
fix(widget-files): make download button always visible for a11y

### DIFF
--- a/packages/node_modules/@webex/widget-files/src/components/ShareListingItem.js
+++ b/packages/node_modules/@webex/widget-files/src/components/ShareListingItem.js
@@ -6,7 +6,7 @@ import connectFileDownloader from '@webex/react-container-file-downloader';
 
 function ShareListingItem({fileShare, onDownloadClick, type}) {
   return (
-    <div>
+    <div className="webex-file-share-listing-item">
       <FileShareDisplay
         actor={fileShare.actor}
         file={fileShare.item}

--- a/packages/node_modules/@webex/widget-files/src/styles.css
+++ b/packages/node_modules/@webex/widget-files/src/styles.css
@@ -10,3 +10,7 @@
   overflow-y: auto;
   padding: 10px;
 }
+
+div[class="webex-file-share-listing-item"] div[class="md-content-file__aspect"] {
+  visibility: visible;
+}


### PR DESCRIPTION
Closes [SPARK-564418](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564418)

### This pull request addresses
- file download buttons not being visible by default in the Content tab and not therefore not being accessible by keyboard navigation.

### by making the following changes

- Fixed the issue by making the button permanently visible.

Before:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/131e1cc6-169b-4a6d-b7ac-64f4911bc5f6" />

After:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/3e91343e-16f4-4740-bd13-96d7d4d6237b" />

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Tested with Voiceover locally on Chrome and Firefox.

https://app.vidcast.io/share/d42fbf22-b771-47ae-a1cb-84c0f15b7d23?playerMode=vidcast

## The GAI Coding Policy And Copyright Annotation Best Practices
 - [x] GAI was not used (or, no additional notation is required)
 - [ ] Code was generated entirely by GAI
 - [ ] GAI was used to create a draft that was subsequently customized or modified
 - [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
 - [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
   - [ ] Github Copilot
   - [ ] Other - Please Specify
 - [x] This PR is related to
   - [ ] Feature
   - [x] Defect fix
   - [ ] Tech Debt
   - [ ] Automation
## Checklist before merging
 - [x] I have not skipped any automated checks
 - [x] All existing and new tests passed
 - [x] I have updated the testing document

