### PR TITLE
fix(space-widget): The focus order widget logic for in meeting

### DIFF
--- a/packages/node_modules/@webex/widget-meet/src/components/call-active/index.js
+++ b/packages/node_modules/@webex/widget-meet/src/components/call-active/index.js
@@ -12,6 +12,7 @@ import styles from './styles.css';
 
 const ActiveMeeting = ({setEscapedAuthentication,adapter, meetingId}) => {
   const controls = () => ['mute-audio', 'mute-video', 'share-screen', 'leave-meeting'];
+  const tabIndexes = () => [0, 0, 0, 0];
 
   return (
     <WebexDataProvider adapter={adapter}>
@@ -25,6 +26,7 @@ const ActiveMeeting = ({setEscapedAuthentication,adapter, meetingId}) => {
           className={styles.callControls}
           meetingID={meetingId}
           controls={controls}
+          tabIndexes={tabIndexes}
         />
       </div>
     </WebexDataProvider>


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564425 >

## This pull request addresses

This change updates the tabIndex values for meeting controls to ensure proper keyboard navigation and accessibility.

## by making the following changes

Previously, after focusing on the "Leave Meeting" button, focus did not move correctly to the next element
By explicitly setting all controls to tabIndex={0}, they are now included in the tab order and can be navigated consistently using the keyboard.
This improves accessibility by providing a proper focus order across all meeting controls

## Vidcast Link
https://app.vidcast.io/share/11e734ac-9ab7-4498-9245-74f4090b1193

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document

---