### PR TITLE
SPARK-843107: Remediate 5 low security findings across widget-demo, token-input, and widget-meet

### DIFF
--- a/packages/node_modules/@webex/private-react-component-token-input/src/index.js
+++ b/packages/node_modules/@webex/private-react-component-token-input/src/index.js
@@ -126,7 +126,7 @@ function TokenInput(props) {
                 placeholder={tokenType === 'JWT' ? 'JWT' : 'Access Token'}
                 value={userAccessToken}
               />
-              <p>You can get an access token from <a href="http://developer.webex.com">developer.webex.com</a></p>
+              <p>You can get an access token from <a href="https://developer.webex.com" target="_blank" rel="noopener noreferrer">developer.webex.com</a></p>
             </div>
           </div>
         }

--- a/packages/node_modules/@webex/private-react-component-token-input/src/index.test.js
+++ b/packages/node_modules/@webex/private-react-component-token-input/src/index.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+import TokenInput from './index';
+
+describe('developer portal link', () => {
+  it('developer link uses https and safe attributes', () => {
+    const testRenderer = TestRenderer.create(<TokenInput onLogin={jest.fn()} />);
+    const anchors = testRenderer.root.findAllByType('a');
+    const developerLink = anchors.find((anchor) => anchor.props.href.includes('developer.webex.com'));
+
+    expect(developerLink.props.href).toBe('https://developer.webex.com');
+    expect(developerLink.props.href).not.toMatch(/^http:\/\//);
+    expect(developerLink.props.rel).toContain('noopener');
+    expect(developerLink.props.rel).toContain('noreferrer');
+  });
+});

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.js
@@ -29,6 +29,38 @@ const {
 const spaceWidgetElementId = 'my-webex-space-widget';
 const recentsWidgetElementId = 'my-webex-recents-widget';
 
+// Comfortably captures a debugging window without unbounded memory growth.
+const MAX_CAPTURED_EVENTS = 50;
+const REDACTED_EVENT_DETAIL_KEYS = ['id', 'personId', 'personEmail', 'displayName', 'email', 'text', 'message', 'content'];
+
+function redactEventDetail(detail) {
+  if (!detail || typeof detail !== 'object') {
+    return detail;
+  }
+
+  const redacted = {...detail};
+
+  REDACTED_EVENT_DETAIL_KEYS.forEach((key) => {
+    delete redacted[key];
+  });
+
+  return redacted;
+}
+
+// Development-only capture; no-op in production so no global buffer exists there.
+function captureDemoEvent(eventName, detail) {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  window.ciscoSparkEvents = window.ciscoSparkEvents || [];
+  window.ciscoSparkEvents.push({eventName, detail: redactEventDetail(detail)});
+
+  if (window.ciscoSparkEvents.length > MAX_CAPTURED_EVENTS) {
+    window.ciscoSparkEvents.splice(0, window.ciscoSparkEvents.length - MAX_CAPTURED_EVENTS);
+  }
+}
+
 class DemoWidget extends Component {
   constructor(props) {
     super(props);
@@ -53,8 +85,8 @@ class DemoWidget extends Component {
         message: isMeetOnly ? false : activities.message,
         people: activities.people
       },
-      accessToken: cookies.get('accessToken') || '',
-      accessTokenType: cookies.get('accessTokenType') || '',
+      accessToken: '',
+      accessTokenType: '',
       composerActions,
       destinationId,
       disableFlags: false,
@@ -98,8 +130,6 @@ class DemoWidget extends Component {
     e.preventDefault();
     const {cookies} = this.props;
 
-    cookies.set('accessToken', this.state.accessToken);
-    cookies.set('accessTokenType', this.state.accessTokenType);
     cookies.set('activities', this.state.activities);
     cookies.set('destinationId', this.state.destinationId);
     cookies.set('destinationMode', this.state.mode);
@@ -124,8 +154,6 @@ class DemoWidget extends Component {
     e.preventDefault();
     const {cookies} = this.props;
 
-    cookies.set('accessToken', this.state.accessToken);
-    cookies.set('accessTokenType', this.state.accessTokenType);
     cookies.set('fedramp', this.state.fedramp);
     cookies.set('enableSpaceListFilter', this.state.enableSpaceListFilter);
     cookies.set('recentsBasicMode', this.state.recentsBasicMode);
@@ -143,7 +171,7 @@ class DemoWidget extends Component {
       fedramp: this.state.fedramp,
       spaceLoadCount: Number(this.state.spaceLoadCount),
       onEvent: (eventName, detail) => {
-        window.ciscoSparkEvents.push({eventName, detail});
+        captureDemoEvent(eventName, detail);
         if (eventName === 'rooms:selected') {
           const spaceId = detail.id;
 
@@ -353,7 +381,7 @@ class DemoWidget extends Component {
       secondaryActivitiesFullWidth: this.state.secondaryActivitiesFullWidth,
       spaceActivities: this.state.activities,
       onEvent: (eventName, detail) => {
-        window.ciscoSparkEvents.push({eventName, detail});
+        captureDemoEvent(eventName, detail);
         if (eventName === spaceEvents.ACTIVITY_CHANGED) {
           this.setState({setCurrentActivity: ''});
         }

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.test.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/index.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+import WrappedDemoWidget from './index';
+
+jest.mock('@webex/widget-space', () => () => null);
+jest.mock('@webex/widget-recents', () => () => null);
+jest.mock('@webex/private-react-component-token-input', () => () => null, {virtual: true});
+jest.mock('@webex/private-react-component-example-code', () => () => null, {virtual: true});
+jest.mock('@webex/private-react-component-space-destination', () => ({
+  __esModule: true,
+  default: () => null,
+  constants: {
+    DESTINATION_PROP_MODE_LEGACY: 'DESTINATION_PROP_MODE_LEGACY',
+    DESTINATION_PROP_MODE_MAIN: 'DESTINATION_PROP_MODE_MAIN',
+    MODE_ONE_ON_ONE: 'email',
+    MODE_ONE_ON_ONE_ID: 'userId',
+    MODE_SPACE: 'spaceId',
+    MODE_SIP: 'sip',
+    MODE_PSTN: 'pstn'
+  }
+}), {virtual: true});
+
+const DemoWidget = WrappedDemoWidget.WrapperComponent;
+
+function createCookiesStub() {
+  const store = {};
+
+  return {
+    get: jest.fn((key) => store[key]),
+    set: jest.fn((key, value) => {
+      store[key] = value;
+    }),
+    store
+  };
+}
+
+function preventDefaultEvent() {
+  return {preventDefault: jest.fn()};
+}
+
+describe('ciscoSparkEvents capture', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete window.ciscoSparkEvents;
+  });
+
+  it('no global buffer capture in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const cookies = createCookiesStub();
+    const testRenderer = TestRenderer.create(<DemoWidget cookies={cookies} />);
+    const instance = testRenderer.getInstance();
+
+    await instance.handleOpenRecentsWidget(preventDefaultEvent());
+    instance.state.recentsWidgetProps.onEvent('rooms:selected', {id: 'space-1'});
+
+    expect(window.ciscoSparkEvents).toBeUndefined();
+  });
+
+  it('development capture is bounded and redacted', async () => {
+    process.env.NODE_ENV = 'test';
+
+    const cookies = createCookiesStub();
+    const testRenderer = TestRenderer.create(<DemoWidget cookies={cookies} />);
+    const instance = testRenderer.getInstance();
+
+    await instance.handleOpenRecentsWidget(preventDefaultEvent());
+    const {onEvent} = instance.state.recentsWidgetProps;
+
+    for (let i = 0; i < 60; i += 1) {
+      onEvent('messages:created', {
+        id: `message-${i}`,
+        personEmail: 'guest@example.com',
+        text: 'sensitive message body'
+      });
+    }
+
+    expect(window.ciscoSparkEvents.length).toBeLessThanOrEqual(50);
+    window.ciscoSparkEvents.forEach((entry) => {
+      expect(entry.detail).not.toHaveProperty('id');
+      expect(entry.detail).not.toHaveProperty('personEmail');
+      expect(entry.detail).not.toHaveProperty('text');
+    });
+  });
+});
+
+describe('token cookie storage', () => {
+  it('no raw token cookie or hardened options', async () => {
+    const cookies = createCookiesStub();
+
+    cookies.store.accessToken = 'raw-access-token-value';
+    cookies.store.accessTokenType = 'Bearer';
+
+    const testRenderer = TestRenderer.create(<DemoWidget cookies={cookies} />);
+    const instance = testRenderer.getInstance();
+
+    expect(instance.state.accessToken).toBe('');
+    expect(instance.state.accessTokenType).toBe('');
+
+    instance.handleOpenSpaceWidget(preventDefaultEvent());
+    await instance.handleOpenRecentsWidget(preventDefaultEvent());
+
+    expect(cookies.set).not.toHaveBeenCalledWith('accessToken', expect.anything());
+    expect(cookies.set).not.toHaveBeenCalledWith('accessTokenType', expect.anything());
+  });
+
+  it('non-token preference cookies preserved', async () => {
+    const cookies = createCookiesStub();
+    const testRenderer = TestRenderer.create(<DemoWidget cookies={cookies} />);
+    const instance = testRenderer.getInstance();
+
+    instance.handleOpenSpaceWidget(preventDefaultEvent());
+    await instance.handleOpenRecentsWidget(preventDefaultEvent());
+
+    expect(cookies.set).toHaveBeenCalledWith('destinationMode', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('activities', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('destinationId', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('fedramp', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('initialActivity', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('enableSpaceListFilter', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('recentsBasicMode', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('recentsEnableAddButton', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('recentsEnableUserProfile', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('recentsEnableUserProfileMenu', expect.anything());
+    expect(cookies.set).toHaveBeenCalledWith('spaceLoadCount', expect.anything());
+  });
+});

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/sdk.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/sdk.js
@@ -113,6 +113,10 @@ export function createSDKInstance(accessToken, options = {}) {
   return Promise.resolve(webexSDKInstance);
 }
 
+// Comfortably exceeds real guest-issuer JWT lengths; bounds client-side input
+// before it reaches the Identity Broker, without parsing or trusting claims.
+const MAX_GUEST_JWT_LENGTH = 8192;
+
 /**
  * Creates a webex instance with the jwt token generated
  * by a guest issuer.
@@ -123,6 +127,12 @@ export function createSDKInstance(accessToken, options = {}) {
  * @returns {Promise<object>}
  */
 export function createSDKGuestInstance(jwt, options = {}) {
+  if (typeof jwt !== 'string' || jwt.length === 0 || jwt.length > MAX_GUEST_JWT_LENGTH) {
+    return Promise.reject(
+      new Error(`createSDKGuestInstance: jwt must be a non-empty string no longer than ${MAX_GUEST_JWT_LENGTH} characters`)
+    );
+  }
+
   const webexSDKInstance = new Webex({
     config: defaultConfig(options)
   });

--- a/packages/node_modules/@webex/widget-demo/src/components/demo-widget/sdk.test.js
+++ b/packages/node_modules/@webex/widget-demo/src/components/demo-widget/sdk.test.js
@@ -1,0 +1,44 @@
+import Webex from '@webex/webex-core';
+
+import {createSDKGuestInstance} from './sdk';
+
+jest.mock('@webex/webex-core', () => {
+  const actual = jest.requireActual('@webex/webex-core');
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      authorization: {
+        requestAccessTokenFromJwt: jest.fn(() => Promise.resolve())
+      }
+    }))
+  };
+});
+
+describe('createSDKGuestInstance', () => {
+  beforeEach(() => {
+    Webex.mockClear();
+  });
+
+  it('accepts valid guest jwt', async () => {
+    const jwt = 'a'.repeat(100);
+    const instance = await createSDKGuestInstance(jwt);
+
+    expect(instance.authorization.requestAccessTokenFromJwt).toHaveBeenCalledWith({jwt});
+  });
+
+  it('rejects oversized jwt', async () => {
+    const jwt = 'a'.repeat(10000);
+
+    await expect(createSDKGuestInstance(jwt)).rejects.toThrow();
+    expect(Webex).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed or empty jwt', async () => {
+    await expect(createSDKGuestInstance('')).rejects.toThrow();
+    await expect(createSDKGuestInstance(null)).rejects.toThrow();
+    await expect(createSDKGuestInstance(undefined)).rejects.toThrow();
+    expect(Webex).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node_modules/@webex/widget-demo/src/index.html
+++ b/packages/node_modules/@webex/widget-demo/src/index.html
@@ -16,8 +16,5 @@
   <body>
     <div id="widget"></div>
     <div id="main"></div>
-    <script>
-      window.ciscoSparkEvents = [];
-    </script>
   </body>
 </html>

--- a/packages/node_modules/@webex/widget-meet/src/enhancers/withCallHandlers.js
+++ b/packages/node_modules/@webex/widget-meet/src/enhancers/withCallHandlers.js
@@ -93,7 +93,7 @@ function handleHangup(props) {
   };
 }
 
-function handleCall(props) {
+export function handleCall(props) {
   const cleanUp = () => props.updateWidgetStatus({hasInitiatedCall: false});
 
   return async () => {
@@ -142,8 +142,6 @@ function handleCall(props) {
             // Use sipAddress (full SIP URI like "26621729979@webex.com")
             const meetingDestination = response.body.sipAddress || response.body.webLink;
 
-            // eslint-disable-next-line no-console
-            console.log('[UnifiedMeeting] Created:', meetingDestination);
             destination = meetingDestination;
           }
           catch (error) {
@@ -168,8 +166,6 @@ function handleCall(props) {
     props.updateWidgetStatus({hasInitiatedCall: true});
     props.placeCall(sdkAdapter, {destination, options: callOptions, cleanUp})
       .then((result) => {
-        // eslint-disable-next-line no-console
-        console.log('[PlaceCall] callId:', result.id);
         props.storeMeetDetails({callId: result.id});
       });
   };

--- a/packages/node_modules/@webex/widget-meet/src/enhancers/withCallHandlers.test.js
+++ b/packages/node_modules/@webex/widget-meet/src/enhancers/withCallHandlers.test.js
@@ -1,0 +1,44 @@
+import {handleCall} from './withCallHandlers';
+
+jest.mock('../', () => ({
+  destinationTypes: {
+    SIP: 'sip',
+    EMAIL: 'email',
+    USERID: 'userId',
+    SPACEID: 'spaceId',
+    PSTN: 'pstn'
+  }
+}));
+
+describe('handlePlaceCall logging', () => {
+  it('no destination or call id logged', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const sipDestination = '26621729979@webex.com';
+    const callId = 'call-id-abc123';
+    const storeMeetDetails = jest.fn();
+
+    const props = {
+      sdkAdapter: {
+        sdk: {
+          meetings: {config: {experimental: {enableUnifiedMeetings: true}}},
+          request: jest.fn(() => Promise.resolve({body: {sipAddress: sipDestination}}))
+        }
+      },
+      widgetMeet: {toType: 'spaceId', toValue: 'room-1'},
+      updateWidgetStatus: jest.fn(),
+      placeCall: jest.fn(() => Promise.resolve({id: callId})),
+      storeMeetDetails
+    };
+
+    await handleCall(props)();
+
+    expect(storeMeetDetails).toHaveBeenCalledWith({callId});
+
+    const loggedText = consoleLogSpy.mock.calls.map((args) => args.join(' ')).join(' ');
+
+    expect(loggedText).not.toContain(sipDestination);
+    expect(loggedText).not.toContain(callId);
+
+    consoleLogSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
# COMPLETES [SPARK-843107](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-843107)

## This pull request addresses

[SecScan][react-widgets][Low] Remediate 5 unique security findings.

Five confirmed Low security findings in this repository's own workspace source
under `packages/node_modules/@webex/*`:

- Unbounded guest JWT input reaching the Identity Broker with no client-side
  size/shape check.
- A dev-only `window.ciscoSparkEvents` buffer that grew without bound and
  captured raw event details (including identity/message fields), initialized
  unconditionally (including in production) via `index.html`.
- The token-input developer portal link used plaintext `http://` with no safe
  `rel`/`target` attributes.
- Raw bearer `accessToken`/`accessTokenType` values persisted to
  weakly-configured browser cookies (no `Secure`/`SameSite`/expiry/cleanup).
- The call-placement path logged the meeting SIP/webLink destination and the
  raw call id via `console.log`.

## by making the following changes

- **`widget-demo/src/components/demo-widget/sdk.js`** — added a
  `MAX_GUEST_JWT_LENGTH` (8192-char) bound plus non-empty/string checks in
  `createSDKGuestInstance`; the accepted-input path is unchanged so the
  Identity Broker remains authoritative for JWT validation.
- **`widget-demo/src/components/demo-widget/index.js`** — added a shared,
  development-only `captureDemoEvent` helper (no-op when
  `process.env.NODE_ENV === 'production'`, capped at 50 entries, strips
  identity/message-shaped keys from `detail`) and routed both `onEvent` push
  sites through it; removed the raw `accessToken`/`accessTokenType`
  `cookies.set` writes and the corresponding constructor `cookies.get` reads
  (all non-token preference cookies are untouched).
- **`widget-demo/src/index.html`** — removed the unconditional
  `window.ciscoSparkEvents = []` init script (the dev-mode helper lazily
  creates the array; no production global buffer exists).
- **`private-react-component-token-input/src/index.js`** — switched the
  developer portal anchor to `https://developer.webex.com` with
  `target="_blank" rel="noopener noreferrer"`.
- **`widget-meet/src/enhancers/withCallHandlers.js`** — removed the two
  `console.log` statements that disclosed the meeting SIP/webLink destination
  and the placed-call id; call placement and `storeMeetDetails({callId})` are
  preserved. Exported `handleCall` (previously module-private) so it is
  directly unit-testable.
- Added four new co-located `*.test.js` suites (9 tests total) covering all
  five findings — see Testing below.

<!-- No screenshots: all changes are non-visual security hardening (bounds checking, buffer redaction, cookie removal, link attributes, log removal) except the developer-link `href`/`rel` swap, which has no visible rendering change. -->

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link

New targeted unit tests were run during implementation (RED → GREEN → targeted
regression per task) with a final combined run of all four new test files: 4
suites, 9 tests, all passing at the time of the Fix step. This delivery step
does not rerun those tests; see `## Testing` below for the recorded evidence
and gate status.

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Claude (Anthropic) via the JiraToPr automation
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document

---

## Testing

- Tests added: 9 (across 4 new co-located `*.test.js` files: `sdk.test.js` 3,
  `demo-widget/index.test.js` 4, `token-input/index.test.js` 1,
  `withCallHandlers.test.js` 1).
- Gate 1 verification: SKIPPED — skipped-missing-command — Gate 1 was not run because no applicable manifest declares commands.compile.
- Gate 2 verification: SKIPPED — skipped-missing-command — Gate 2 was not run because no applicable manifest declares commands.unit-test.
- Gate 3 verification: not run.
- Draft warning: Gate 1 and Gate 2 were both skipped (`skipped-missing-command`); this PR has not been verified by the repository's compile/unit-test gates and must not be merged without independent human verification of the recorded test evidence below.
- Coverage outcome: skipped because role coverage-check is absent.

Recorded evidence from the earlier Fix step (targeted per-task RED/GREEN/regression
runs via `npx jest --config jest.config.json <file>`, not rerun during delivery):

| Task | Test file | Result |
|---|---|---|
| TASK-1 (AC-1) | `sdk.test.js` | 3/3 passing |
| TASK-2 (AC-2) | `index.test.js` (`ciscoSparkEvents capture`) | 2/2 passing |
| TASK-3 (AC-3) | `private-react-component-token-input/src/index.test.js` | 1/1 passing |
| TASK-4 (AC-4) | `index.test.js` (`token cookie storage`) | 2/2 passing |
| TASK-5 (AC-5) | `withCallHandlers.test.js` | 1/1 passing |

## Acceptance Criteria

| ID | Criterion | Source | JiraToPr status | Evidence |
|---|---|---|---|---|
| AC-1 | Guest JWT input is rejected cleanly when it exceeds a documented client-side size bound, while valid input still authenticates through the Identity Broker (server-side validation remains authoritative). | Jira description: Acceptance Criteria | Not validated — Gate 2 skipped | `sdk.test.js` 3/3 passing (recorded Fix-step evidence; Gate 2 not run: `skipped-missing-command`) |
| AC-2 | Production bundles retain no global `window.ciscoSparkEvents` buffer; any event capture is development-only, bounded, and redacted of message/identity metadata. | Jira description: Acceptance Criteria | Not validated — Gate 2 skipped | `index.test.js` (`ciscoSparkEvents capture`) 2/2 passing (recorded Fix-step evidence; Gate 2 not run: `skipped-missing-command`) |
| AC-3 | The token-input developer portal link uses the canonical HTTPS URL with safe external-link attributes and no plaintext developer portal link remains. | Jira description: Acceptance Criteria | Not validated — Gate 2 skipped | `private-react-component-token-input/src/index.test.js` 1/1 passing (recorded Fix-step evidence; Gate 2 not run: `skipped-missing-command`) |
| AC-4 | Raw bearer tokens are not persisted in weakly configured cookies; either token cookies are removed, or approved demo-only storage sets `Secure` and `SameSite`, minimizes lifetime/scope, and cleans up. | Jira description: Acceptance Criteria | Not validated — Gate 2 skipped; external validation required | `index.test.js` (`token cookie storage`) 2/2 passing (recorded Fix-step evidence; Gate 2 not run: `skipped-missing-command`). Demo-storage owner sign-off is still pending — see External Validation Required below. |
| AC-5 | Production logs contain no meeting destination (SIP URI/webLink) or raw call identifier values from the meet call handlers. | Jira description: Acceptance Criteria | Not validated — Gate 2 skipped | `withCallHandlers.test.js` 1/1 passing (recorded Fix-step evidence; Gate 2 not run: `skipped-missing-command`) |

## External Validation Required

- **AC-4 — Raw bearer tokens are not persisted in weakly configured cookies.**
  - Reason: `owner-sign-off`
  - Details: This boundary change (removing the raw `accessToken`/`accessTokenType` cookie writes and reads in `demo-widget/index.js`, at what were lines 101–102 and 127–128 pre-fix) changes how demo user browser storage persists bearer tokens. The code-level removal is implemented and unit-tested (`index.test.js` → `token cookie storage`), but per the implementation plan's boundary-impact-4 note, the demo-storage owner must externally confirm this token-persistence removal is acceptable before delivery. If external validation instead prefers retaining demo-only storage, the equivalent remediation is to set `Secure` + `SameSite`, a minimized expiry, and explicit cleanup on those cookies.
  - Source: Triage boundary requirements (data | user: demo user browser storage)

External validation for AC-4 remains explicitly unrun by JiraToPr; unit evidence
is reported above while the demo-storage owner's sign-off remains pending for
human review.

## Contract Discovery Warnings

- No repository rule documents were discovered.
- No repository contract document was discovered.
- No `.sdd/manifest.json`, `AGENTS.md`, or spec index governs the affected demo/widget files; `target/affected-package-manifests.json` lists no package manifests for these paths. Planning relied on repository-inference from the affected files.

## AI Assistance

- [x] Code was generated entirely by GAI / GAI-assisted / Manual
- Tool: Claude (Anthropic) via the JiraToPr automation

---
Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-843107
